### PR TITLE
feat(window): implement eframe App with four-panel layout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,50 @@
-fn main() {
-    println!("Hello, world!");
+fn main() -> eframe::Result<()> {
+    env_logger::init();
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default()
+            .with_title("avio-editor-demo")
+            .with_inner_size([1280.0, 720.0]),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "avio-editor-demo",
+        options,
+        Box::new(|_cc| Ok(Box::new(AvioEditorApp::default()))),
+    )
+}
+
+#[derive(Default)]
+struct AvioEditorApp {}
+
+impl eframe::App for AvioEditorApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // 1. Top menu bar (must come before all other panels)
+        egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
+            egui::MenuBar::new().ui(ui, |ui| {
+                ui.menu_button("File", |_ui| {});
+                ui.menu_button("Export", |_ui| {});
+            });
+        });
+
+        // 2. Bottom: Timeline (must come before SidePanel and CentralPanel)
+        egui::TopBottomPanel::bottom("timeline")
+            .resizable(true)
+            .default_height(200.0)
+            .show(ctx, |ui| {
+                ui.heading("Timeline");
+            });
+
+        // 3. Left: Clip Browser
+        egui::SidePanel::left("clip_browser")
+            .resizable(true)
+            .default_width(240.0)
+            .show(ctx, |ui| {
+                ui.heading("Clip Browser");
+            });
+
+        // 4. Center: Source Monitor (must be last)
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.heading("Source Monitor");
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Implements the top-level `AvioEditorApp` struct and the four-panel egui layout that forms the application shell. Each panel renders only a heading placeholder; no logic is wired up. This establishes the window and layout foundation that all subsequent issues build on.

## Changes

- Replace placeholder `main()` with `eframe::run_native` targeting a 1280×720 window titled `"avio-editor-demo"`
- Add `AvioEditorApp` struct deriving `Default` with an empty `eframe::App` implementation
- Render panels in egui's required order: `TopBottomPanel::top` (menu bar) → `TopBottomPanel::bottom` (Timeline) → `SidePanel::left` (Clip Browser) → `CentralPanel` (Source Monitor)
- Use `egui::MenuBar::new().ui(...)` (non-deprecated API in eframe 0.33) for the menu bar stub
- Call `env_logger::init()` at startup so avio's log output is visible in the terminal

## Related Issues

Closes #2

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes