### PR TITLE
feat(clip-browser): add clip import with name and duration display

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+mod state;
+use state::{AppState, ImportedClip};
+
 fn main() -> eframe::Result<()> {
     env_logger::init();
     let options = eframe::NativeOptions {
@@ -14,7 +17,9 @@ fn main() -> eframe::Result<()> {
 }
 
 #[derive(Default)]
-struct AvioEditorApp {}
+struct AvioEditorApp {
+    state: AppState,
+}
 
 impl eframe::App for AvioEditorApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
@@ -40,6 +45,46 @@ impl eframe::App for AvioEditorApp {
             .default_width(240.0)
             .show(ctx, |ui| {
                 ui.heading("Clip Browser");
+                ui.separator();
+
+                if ui.button("Import").clicked()
+                    && let Some(paths) = rfd::FileDialog::new()
+                        .add_filter(
+                            "Video / Audio",
+                            &["mp4", "mov", "mkv", "avi", "mp3", "aac", "wav", "flac"],
+                        )
+                        .pick_files()
+                {
+                    for path in paths {
+                        match avio::open(&path) {
+                            Ok(info) => self.state.clips.push(ImportedClip {
+                                path,
+                                info,
+                                thumbnail: None,
+                                proxy_path: None,
+                            }),
+                            Err(e) => log::warn!("probe failed for {path:?}: {e}"),
+                        }
+                    }
+                }
+
+                ui.separator();
+
+                for clip in &self.state.clips {
+                    ui.horizontal(|ui| {
+                        ui.label("\u{1F3AC}");
+                        ui.label(
+                            clip.path
+                                .file_name()
+                                .unwrap_or_default()
+                                .to_string_lossy()
+                                .as_ref(),
+                        );
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                            ui.label(clip.duration_label());
+                        });
+                    });
+                }
             });
 
         // 4. Center: Source Monitor (must be last)

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,25 @@
+use std::path::PathBuf;
+
+#[derive(Default)]
+pub struct AppState {
+    pub clips: Vec<ImportedClip>,
+}
+
+#[allow(dead_code)]
+pub struct ImportedClip {
+    pub path: PathBuf,
+    pub info: avio::MediaInfo,
+    pub thumbnail: Option<egui::TextureHandle>,
+    pub proxy_path: Option<PathBuf>,
+}
+
+impl ImportedClip {
+    pub fn duration_label(&self) -> String {
+        let d = self.info.duration();
+        let total_secs = d.as_secs();
+        let millis = d.subsec_millis();
+        let mins = total_secs / 60;
+        let secs = total_secs % 60;
+        format!("{mins}:{secs:02}.{millis:03}")
+    }
+}


### PR DESCRIPTION
## Summary

Wires up the Clip Browser panel with a native file import dialog and a clip list. Clicking **Import** opens an OS file picker filtered to common video and audio extensions. Each selected file is probed with `avio::open()`; probe failures are logged via `log::warn!` and skipped. The panel then lists each imported clip with its filename on the left and formatted duration (`M:SS.mmm`) on the right.

This also introduces `AppState` and `ImportedClip` in a new `src/state.rs` module, establishing the central state type that all subsequent issues will extend.

## Changes

- Add `src/state.rs` with `AppState { clips: Vec<ImportedClip> }` and `ImportedClip { path, info, thumbnail, proxy_path }` plus `duration_label()` method
- Add `state: AppState` field to `AvioEditorApp`
- Replace Clip Browser placeholder with Import button, file dialog (`rfd::FileDialog`), `avio::open()` probe call, and clip list rendering

## Related Issues

Closes #3

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes