### PR TITLE
feat(clip-browser): extract and display per-clip thumbnails

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,12 @@
 mod state;
+mod thumbnail;
 use state::{AppState, ImportedClip};
 
 fn main() -> eframe::Result<()> {
     env_logger::init();
+    let rt = tokio::runtime::Runtime::new().map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
+    let _rt_guard = rt.enter();
+
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_title("avio-editor-demo")
@@ -23,6 +27,16 @@ struct AvioEditorApp {
 
 impl eframe::App for AvioEditorApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Drain completed thumbnail results each frame.
+        while let Ok((path, w, h, rgb)) = self.state.thumbnail_rx.try_recv() {
+            let image = egui::ColorImage::from_rgb([w as usize, h as usize], &rgb);
+            let texture =
+                ctx.load_texture(path.to_string_lossy(), image, egui::TextureOptions::LINEAR);
+            if let Some(clip) = self.state.clips.iter_mut().find(|c| c.path == path) {
+                clip.thumbnail = Some(texture);
+            }
+        }
+
         // 1. Top menu bar (must come before all other panels)
         egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
             egui::MenuBar::new().ui(ui, |ui| {
@@ -57,12 +71,26 @@ impl eframe::App for AvioEditorApp {
                 {
                     for path in paths {
                         match avio::open(&path) {
-                            Ok(info) => self.state.clips.push(ImportedClip {
-                                path,
-                                info,
-                                thumbnail: None,
-                                proxy_path: None,
-                            }),
+                            Ok(info) => {
+                                let has_video = info.primary_video().is_some();
+                                self.state.clips.push(ImportedClip {
+                                    path: path.clone(),
+                                    info,
+                                    thumbnail: None,
+                                    proxy_path: None,
+                                });
+                                if has_video {
+                                    let tx = self.state.thumbnail_tx.clone();
+                                    let path_for_task = path.clone();
+                                    tokio::task::spawn_blocking(move || {
+                                        if let Some((w, h, rgb)) =
+                                            thumbnail::extract_thumbnail(&path_for_task)
+                                        {
+                                            let _ = tx.send((path_for_task, w, h, rgb));
+                                        }
+                                    });
+                                }
+                            }
                             Err(e) => log::warn!("probe failed for {path:?}: {e}"),
                         }
                     }
@@ -72,7 +100,17 @@ impl eframe::App for AvioEditorApp {
 
                 for clip in &self.state.clips {
                     ui.horizontal(|ui| {
-                        ui.label("\u{1F3AC}");
+                        match &clip.thumbnail {
+                            Some(tex) => {
+                                ui.image(egui::load::SizedTexture::new(
+                                    tex.id(),
+                                    egui::vec2(48.0, 27.0),
+                                ));
+                            }
+                            None => {
+                                ui.label("\u{1F3AC}");
+                            }
+                        }
                         ui.label(
                             clip.path
                                 .file_name()

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,8 +1,21 @@
 use std::path::PathBuf;
+use std::sync::mpsc;
 
-#[derive(Default)]
 pub struct AppState {
     pub clips: Vec<ImportedClip>,
+    pub thumbnail_tx: mpsc::SyncSender<(PathBuf, u32, u32, Vec<u8>)>,
+    pub thumbnail_rx: mpsc::Receiver<(PathBuf, u32, u32, Vec<u8>)>,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        let (thumbnail_tx, thumbnail_rx) = mpsc::sync_channel(32);
+        Self {
+            clips: Vec::new(),
+            thumbnail_tx,
+            thumbnail_rx,
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -1,0 +1,27 @@
+use std::path::Path;
+
+/// Extracts the best-quality thumbnail frame from a video file.
+///
+/// Uses [`avio::ThumbnailSelector`] which skips near-black, near-white, and
+/// blurry frames, returning the first candidate that passes all quality gates.
+///
+/// Returns `(width, height, rgb24_bytes)`, or `None` if the file has no video
+/// stream or decoding fails.
+pub fn extract_thumbnail(path: &Path) -> Option<(u32, u32, Vec<u8>)> {
+    let frame = avio::ThumbnailSelector::new(path).run().ok()?;
+
+    let w = frame.width() as usize;
+    let h = frame.height() as usize;
+    let stride = frame.stride(0)?;
+    let plane = frame.plane(0)?;
+    let row_bytes = w * 3; // RGB24: 3 bytes per pixel
+
+    // Strip stride padding — egui expects tightly-packed rows.
+    let mut rgb = Vec::with_capacity(row_bytes * h);
+    for row in 0..h {
+        let start = row * stride;
+        rgb.extend_from_slice(&plane[start..start + row_bytes]);
+    }
+
+    Some((frame.width(), frame.height(), rgb))
+}


### PR DESCRIPTION
## Summary

Adds background thumbnail extraction for imported video clips. After each successful import, a `tokio::task::spawn_blocking` task runs `ThumbnailSelector` to pick the best-quality frame (skipping near-black, near-white, and blurry candidates). Results are delivered back to the render loop via an `mpsc::sync_channel` and uploaded to an egui texture. Video clips show their thumbnail at 48×27 px (16:9); audio-only clips keep the 🎬 icon permanently.

The issue proposed `ImageDecoder` (a still-image decoder), but the spec and actual avio API both point to `ThumbnailSelector`, which already outputs `RGB24` frames suitable for `egui::ColorImage::from_rgb`.

## Changes

- Add `src/thumbnail.rs` with `extract_thumbnail(path)` using `avio::ThumbnailSelector`; strips stride padding before returning tightly-packed RGB24 bytes
- Add `thumbnail_tx / thumbnail_rx: mpsc::sync_channel(32)` to `AppState`; replace `#[derive(Default)]` with a manual `Default` impl that creates the channel
- Create a tokio `Runtime` in `main()` and call `rt.enter()` so `spawn_blocking` works throughout the eframe event loop
- After each successful video-clip import, spawn a blocking task to extract the thumbnail
- Drain the thumbnail channel at the top of every `update()` frame and upload textures via `ctx.load_texture`
- Clip rows now show the texture (48×27 px) once available, falling back to 🎬 until the task completes

## Related Issues

Closes #4

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes