### PR TITLE
refactor(thumbnail): rename extract_thumbnail to select_best_thumbnail

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ impl eframe::App for AvioEditorApp {
                                     let path_for_task = path.clone();
                                     tokio::task::spawn_blocking(move || {
                                         if let Some((w, h, rgb)) =
-                                            thumbnail::extract_thumbnail(&path_for_task)
+                                            thumbnail::select_best_thumbnail(&path_for_task)
                                         {
                                             let _ = tx.send((path_for_task, w, h, rgb));
                                         }

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -1,13 +1,13 @@
 use std::path::Path;
 
-/// Extracts the best-quality thumbnail frame from a video file.
+/// Selects the best representative thumbnail frame from a video file.
 ///
 /// Uses [`avio::ThumbnailSelector`] which skips near-black, near-white, and
 /// blurry frames, returning the first candidate that passes all quality gates.
 ///
 /// Returns `(width, height, rgb24_bytes)`, or `None` if the file has no video
-/// stream or decoding fails.
-pub fn extract_thumbnail(path: &Path) -> Option<(u32, u32, Vec<u8>)> {
+/// stream or selection fails.
+pub fn select_best_thumbnail(path: &Path) -> Option<(u32, u32, Vec<u8>)> {
     let frame = avio::ThumbnailSelector::new(path).run().ok()?;
 
     let w = frame.width() as usize;


### PR DESCRIPTION
## Summary

Issue #18 asked for `select_best_thumbnail` as the function name to reflect that `ThumbnailSelector` (not a fixed-timestamp extractor) is used. The smart selection logic itself was already implemented when closing issue #4 — this PR just aligns the function name with the spec.

## Changes

- Rename `extract_thumbnail` → `select_best_thumbnail` in `src/thumbnail.rs`
- Update the call site in `src/main.rs` accordingly

## Related Issues

Closes #18

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes