### PR TITLE
feat(clip-browser): add single-click selection and metadata panel

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,9 @@ impl eframe::App for AvioEditorApp {
 
                 ui.separator();
 
-                for clip in &self.state.clips {
+                let mut clicked_idx: Option<usize> = None;
+                for (idx, clip) in self.state.clips.iter().enumerate() {
+                    let selected = self.state.selected_clip_index == Some(idx);
                     ui.horizontal(|ui| {
                         match &clip.thumbnail {
                             Some(tex) => {
@@ -111,17 +113,81 @@ impl eframe::App for AvioEditorApp {
                                 ui.label("\u{1F3AC}");
                             }
                         }
-                        ui.label(
-                            clip.path
-                                .file_name()
-                                .unwrap_or_default()
-                                .to_string_lossy()
-                                .as_ref(),
-                        );
+                        let name = clip.path.file_name().unwrap_or_default().to_string_lossy();
+                        if ui.selectable_label(selected, name.as_ref()).clicked() {
+                            clicked_idx = Some(idx);
+                        }
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             ui.label(clip.duration_label());
                         });
                     });
+                }
+                if let Some(idx) = clicked_idx {
+                    self.state.selected_clip_index = Some(idx);
+                }
+
+                if let Some(idx) = self.state.selected_clip_index
+                    && let Some(clip) = self.state.clips.get(idx)
+                {
+                    ui.separator();
+                    egui::Grid::new("meta_grid")
+                        .num_columns(2)
+                        .striped(true)
+                        .show(ui, |ui| {
+                            let info = &clip.info;
+
+                            ui.label("Container");
+                            ui.label(info.format());
+                            ui.end_row();
+
+                            if let Some(v) = info.primary_video() {
+                                ui.label("Video");
+                                ui.label(v.codec().display_name());
+                                ui.end_row();
+
+                                ui.label("Size");
+                                ui.label(format!("{}×{}", v.width(), v.height()));
+                                ui.end_row();
+
+                                ui.label("FPS");
+                                ui.label(format!("{:.3}", v.fps()));
+                                ui.end_row();
+
+                                if let Some(br) = v.bitrate() {
+                                    ui.label("V-bitrate");
+                                    ui.label(format!("{} kb/s", br / 1000));
+                                    ui.end_row();
+                                }
+
+                                ui.label("Color");
+                                ui.label(v.color_space().name());
+                                ui.end_row();
+                            }
+
+                            if let Some(a) = info.primary_audio() {
+                                ui.label("Audio");
+                                ui.label(a.codec().display_name());
+                                ui.end_row();
+
+                                ui.label("Rate");
+                                ui.label(format!("{} Hz", a.sample_rate()));
+                                ui.end_row();
+
+                                ui.label("Ch");
+                                ui.label(format!("{}", a.channels()));
+                                ui.end_row();
+
+                                if let Some(br) = a.bitrate() {
+                                    ui.label("A-bitrate");
+                                    ui.label(format!("{} kb/s", br / 1000));
+                                    ui.end_row();
+                                }
+                            }
+
+                            ui.label("Duration");
+                            ui.label(clip.duration_label());
+                            ui.end_row();
+                        });
                 }
             });
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,6 +3,7 @@ use std::sync::mpsc;
 
 pub struct AppState {
     pub clips: Vec<ImportedClip>,
+    pub selected_clip_index: Option<usize>,
     pub thumbnail_tx: mpsc::SyncSender<(PathBuf, u32, u32, Vec<u8>)>,
     pub thumbnail_rx: mpsc::Receiver<(PathBuf, u32, u32, Vec<u8>)>,
 }
@@ -12,6 +13,7 @@ impl Default for AppState {
         let (thumbnail_tx, thumbnail_rx) = mpsc::sync_channel(32);
         Self {
             clips: Vec::new(),
+            selected_clip_index: None,
             thumbnail_tx,
             thumbnail_rx,
         }


### PR DESCRIPTION
## Summary

Implements clip selection in the Clip Browser and shows a detailed metadata panel for the selected clip. Clicking a clip row highlights it and displays its container format, video/audio codec, resolution, frame rate, sample rate, channel count, optional bitrate fields, and duration in a two-column grid below the list.

## Changes

- `src/state.rs`: added `selected_clip_index: Option<usize>` to `AppState` and initialized it to `None` in `Default`
- `src/main.rs`: clip list rows now use `selectable_label` for click handling; clicked index is collected outside the immutable borrow to avoid borrow-checker issues; metadata `egui::Grid` panel is rendered below the separator when a clip is selected

## Related Issues

Closes #20

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes