### PR TITLE
feat(clip-browser): add Trim & Save action via StreamCopyTrim

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 mod analysis;
 mod state;
 mod thumbnail;
-use state::{AppState, ImportedClip};
+mod trim;
+use state::{AppState, ImportedClip, TrimStatus};
 
 fn main() -> eframe::Result<()> {
     env_logger::init();
@@ -28,6 +29,55 @@ struct AvioEditorApp {
 
 impl eframe::App for AvioEditorApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Drain completed trim jobs each frame.
+        // Collect outcomes first to avoid borrowing trim_jobs and clips simultaneously.
+        let mut trim_done: Vec<std::path::PathBuf> = Vec::new();
+        self.state
+            .trim_jobs
+            .retain(|job| match job.status.lock().unwrap().clone() {
+                TrimStatus::Running => true,
+                TrimStatus::Done(path) => {
+                    trim_done.push(path);
+                    false
+                }
+                TrimStatus::Failed(msg) => {
+                    log::warn!("trim failed: {msg}");
+                    false
+                }
+            });
+        for path in trim_done {
+            match avio::open(&path) {
+                Ok(info) => {
+                    let has_video = info.primary_video().is_some();
+                    let clip_idx = self.state.clips.len();
+                    self.state.clips.push(ImportedClip {
+                        path: path.clone(),
+                        info,
+                        thumbnail: None,
+                        proxy_path: None,
+                        scenes: Vec::new(),
+                        in_point: None,
+                        out_point: None,
+                    });
+                    if has_video {
+                        let tx = self.state.thumbnail_tx.clone();
+                        let p = path.clone();
+                        tokio::task::spawn_blocking(move || {
+                            if let Some((w, h, rgb)) = thumbnail::select_best_thumbnail(&p) {
+                                let _ = tx.send((p, w, h, rgb));
+                            }
+                        });
+                        let scene_tx = self.state.scene_tx.clone();
+                        tokio::task::spawn_blocking(move || {
+                            let scenes = analysis::detect_scenes(&path);
+                            let _ = scene_tx.send((clip_idx, scenes));
+                        });
+                    }
+                }
+                Err(e) => log::warn!("probe failed for trimmed clip {path:?}: {e}"),
+            }
+        }
+
         // Drain completed thumbnail results each frame.
         while let Ok((idx, scenes)) = self.state.scene_rx.try_recv() {
             if let Some(clip) = self.state.clips.get_mut(idx) {
@@ -129,6 +179,8 @@ impl eframe::App for AvioEditorApp {
                                     thumbnail: None,
                                     proxy_path: None,
                                     scenes: Vec::new(),
+                                    in_point: None,
+                                    out_point: None,
                                 });
                                 let clip_idx = self.state.clips.len() - 1;
                                 if has_video {
@@ -262,6 +314,24 @@ impl eframe::App for AvioEditorApp {
                                 source_index: idx,
                                 start_on_track: start,
                             });
+                    }
+                    let can_trim = clip.in_point.is_some() && clip.out_point.is_some();
+                    if ui
+                        .add_enabled(can_trim, egui::Button::new("Trim & Save"))
+                        .clicked()
+                        && let Some(output_path) = rfd::FileDialog::new()
+                            .add_filter("MP4", &["mp4"])
+                            .set_file_name("trimmed.mp4")
+                            .save_file()
+                    {
+                        let handle = trim::spawn_trim(
+                            idx,
+                            clip.path.clone(),
+                            output_path,
+                            clip.in_point.unwrap(),
+                            clip.out_point.unwrap(),
+                        );
+                        self.state.trim_jobs.push(handle);
                     }
                 }
             });

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::mpsc;
+use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
 
 pub struct AppState {
@@ -10,6 +10,7 @@ pub struct AppState {
     pub scene_tx: mpsc::SyncSender<(usize, Vec<Duration>)>,
     pub scene_rx: mpsc::Receiver<(usize, Vec<Duration>)>,
     pub timeline: TimelineState,
+    pub trim_jobs: Vec<TrimJobHandle>,
 }
 
 impl Default for AppState {
@@ -24,6 +25,7 @@ impl Default for AppState {
             scene_tx,
             scene_rx,
             timeline: TimelineState::default(),
+            trim_jobs: Vec::new(),
         }
     }
 }
@@ -35,6 +37,21 @@ pub struct ImportedClip {
     pub thumbnail: Option<egui::TextureHandle>,
     pub proxy_path: Option<PathBuf>,
     pub scenes: Vec<Duration>,
+    pub in_point: Option<Duration>,
+    pub out_point: Option<Duration>,
+}
+
+#[derive(Clone)]
+pub enum TrimStatus {
+    Running,
+    Done(PathBuf),
+    Failed(String),
+}
+
+#[allow(dead_code)]
+pub struct TrimJobHandle {
+    pub clip_index: usize,
+    pub status: Arc<Mutex<TrimStatus>>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/src/trim.rs
+++ b/src/trim.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::state::{TrimJobHandle, TrimStatus};
+
+/// Spawns a background stream-copy trim and returns a handle to track its status.
+pub fn spawn_trim(
+    clip_index: usize,
+    source_path: PathBuf,
+    output_path: PathBuf,
+    in_point: Duration,
+    out_point: Duration,
+) -> TrimJobHandle {
+    let status = Arc::new(Mutex::new(TrimStatus::Running));
+    let status_clone = Arc::clone(&status);
+    tokio::task::spawn_blocking(move || {
+        let result =
+            avio::StreamCopyTrim::new(&source_path, in_point, out_point, &output_path).run();
+        *status_clone.lock().unwrap() = match result {
+            Ok(()) => TrimStatus::Done(output_path),
+            Err(e) => TrimStatus::Failed(e.to_string()),
+        };
+    });
+    TrimJobHandle { clip_index, status }
+}


### PR DESCRIPTION
## Summary

Implements the Trim & Save action in the Clip Browser using `StreamCopyTrim` for lossless stream-copy trimming. The button is shown for every selected clip but remains disabled until both an IN point and an OUT point are set (those are added by issue #19). After a successful trim the output file is automatically probed and added to the Clip Browser as a new clip, with thumbnail extraction and scene detection spawned in the background.

## Changes

- `src/trim.rs` (new): `spawn_trim()` runs `StreamCopyTrim::new(input, start, end, output).run()` on `spawn_blocking` and tracks progress via `Arc<Mutex<TrimStatus>>`
- `src/state.rs`: added `TrimStatus` enum, `TrimJobHandle` struct, `trim_jobs: Vec<TrimJobHandle>` to `AppState`, and `in_point`/`out_point: Option<Duration>` fields to `ImportedClip`
- `src/main.rs`: drain loop collects completed trim jobs into a local vec to avoid borrow conflicts, then probes each output and adds it to the clip list; "Trim & Save" button added to the metadata panel, disabled when IN/OUT are not both set

## Related Issues

Closes #23

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes