### PR TITLE
feat(clip-browser): add Export GIF action via GifPreview

### DIFF
--- a/src/gif.rs
+++ b/src/gif.rs
@@ -1,0 +1,40 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::state::{GifJobHandle, GifStatus};
+
+/// Spawns a background GIF generation and returns a handle to track its status.
+///
+/// Uses IN/OUT points as the clip range when present; falls back to the full
+/// clip duration otherwise.
+pub fn spawn_gif(
+    clip_index: usize,
+    source_path: PathBuf,
+    output_path: PathBuf,
+    in_point: Option<Duration>,
+    out_point: Option<Duration>,
+    clip_duration: Duration,
+) -> GifJobHandle {
+    let status = Arc::new(Mutex::new(GifStatus::Running));
+    let status_clone = Arc::clone(&status);
+    tokio::task::spawn_blocking(move || {
+        let start = in_point.unwrap_or(Duration::ZERO);
+        let duration = match out_point {
+            Some(out) => out.saturating_sub(start),
+            None => clip_duration.saturating_sub(start),
+        };
+        let result = avio::GifPreview::new(&source_path)
+            .start(start)
+            .duration(duration)
+            .fps(10.0)
+            .width(480)
+            .output(&output_path)
+            .run();
+        *status_clone.lock().unwrap() = match result {
+            Ok(()) => GifStatus::Done(output_path),
+            Err(e) => GifStatus::Failed(e.to_string()),
+        };
+    });
+    GifJobHandle { clip_index, status }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 mod analysis;
+mod gif;
 mod state;
 mod thumbnail;
 mod trim;
-use state::{AppState, ImportedClip, TrimStatus};
+use state::{AppState, GifStatus, ImportedClip, TrimStatus};
 
 fn main() -> eframe::Result<()> {
     env_logger::init();
@@ -76,6 +77,25 @@ impl eframe::App for AvioEditorApp {
                 }
                 Err(e) => log::warn!("probe failed for trimmed clip {path:?}: {e}"),
             }
+        }
+
+        // Drain completed GIF jobs each frame.
+        let mut gif_done: Vec<std::path::PathBuf> = Vec::new();
+        self.state
+            .gif_jobs
+            .retain(|job| match job.status.lock().unwrap().clone() {
+                GifStatus::Running => true,
+                GifStatus::Done(path) => {
+                    gif_done.push(path);
+                    false
+                }
+                GifStatus::Failed(msg) => {
+                    log::warn!("GIF export failed: {msg}");
+                    false
+                }
+            });
+        for path in gif_done {
+            log::info!("GIF exported: {}", path.display());
         }
 
         // Drain completed thumbnail results each frame.
@@ -332,6 +352,22 @@ impl eframe::App for AvioEditorApp {
                             clip.out_point.unwrap(),
                         );
                         self.state.trim_jobs.push(handle);
+                    }
+                    if ui.button("Export GIF").clicked()
+                        && let Some(output_path) = rfd::FileDialog::new()
+                            .add_filter("GIF", &["gif"])
+                            .set_file_name("preview.gif")
+                            .save_file()
+                    {
+                        let handle = gif::spawn_gif(
+                            idx,
+                            clip.path.clone(),
+                            output_path,
+                            clip.in_point,
+                            clip.out_point,
+                            clip.info.duration(),
+                        );
+                        self.state.gif_jobs.push(handle);
                     }
                 }
             });

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,6 +11,7 @@ pub struct AppState {
     pub scene_rx: mpsc::Receiver<(usize, Vec<Duration>)>,
     pub timeline: TimelineState,
     pub trim_jobs: Vec<TrimJobHandle>,
+    pub gif_jobs: Vec<GifJobHandle>,
 }
 
 impl Default for AppState {
@@ -26,6 +27,7 @@ impl Default for AppState {
             scene_rx,
             timeline: TimelineState::default(),
             trim_jobs: Vec::new(),
+            gif_jobs: Vec::new(),
         }
     }
 }
@@ -52,6 +54,19 @@ pub enum TrimStatus {
 pub struct TrimJobHandle {
     pub clip_index: usize,
     pub status: Arc<Mutex<TrimStatus>>,
+}
+
+#[derive(Clone)]
+pub enum GifStatus {
+    Running,
+    Done(PathBuf),
+    Failed(String),
+}
+
+#[allow(dead_code)]
+pub struct GifJobHandle {
+    pub clip_index: usize,
+    pub status: Arc<Mutex<GifStatus>>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

Adds an **Export GIF** button to the Clip Browser that generates an animated GIF preview using `GifPreview`. The GIF is saved via a native save dialog. When IN/OUT points are set the GIF covers only that range; otherwise the full clip is used. Output is 480 px wide at 10 fps.

## Changes

- `src/gif.rs` (new): `spawn_gif()` converts IN/OUT points to `start`/`duration`, then runs `GifPreview::new(path).start(s).duration(d).fps(10.0).width(480).output(out).run()` on `spawn_blocking`
- `src/state.rs`: added `GifStatus` enum, `GifJobHandle` struct, and `gif_jobs: Vec<GifJobHandle>` to `AppState`
- `src/main.rs`: GIF drain loop retains running jobs, logs completed paths, and warns on failure; "Export GIF" button added after "Trim & Save" in the metadata panel — always enabled, opens a save dialog before spawning

## Related Issues

Closes #24

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes