### PR TITLE
feat(monitor): real-time video playback via PreviewPlayer + TimedRgbaSink

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
 mod analysis;
 mod gif;
+mod player;
 mod state;
 mod thumbnail;
 mod trim;
+use std::sync::Arc;
+
 use state::{AppState, GifStatus, ImportedClip, TrimStatus};
 
 fn main() -> eframe::Result<()> {
@@ -96,6 +99,35 @@ impl eframe::App for AvioEditorApp {
             });
         for path in gif_done {
             log::info!("GIF exported: {}", path.display());
+        }
+
+        // Receive stop handle from a freshly spawned player thread.
+        if let Some(rx) = &self.state.pending_stop_rx
+            && let Ok(stop) = rx.try_recv()
+        {
+            self.state.player_stop = Some(stop);
+            self.state.pending_stop_rx = None;
+        }
+
+        // Poll for the latest decoded frame from the player sink.
+        if let Ok(mut guard) = self.state.frame_handle.try_lock()
+            && let Some(frame) = guard.take()
+        {
+            let image = egui::ColorImage::from_rgba_unmultiplied(
+                [frame.width as usize, frame.height as usize],
+                &frame.data,
+            );
+            match &mut self.state.preview_texture {
+                Some(tex) => tex.set(image, egui::TextureOptions::LINEAR),
+                None => {
+                    self.state.preview_texture = Some(ctx.load_texture(
+                        "source_monitor",
+                        image,
+                        egui::TextureOptions::LINEAR,
+                    ));
+                }
+            }
+            ctx.request_repaint();
         }
 
         // Drain completed thumbnail results each frame.
@@ -229,6 +261,7 @@ impl eframe::App for AvioEditorApp {
                 ui.separator();
 
                 let mut clicked_idx: Option<usize> = None;
+                let mut dbl_clicked_idx: Option<usize> = None;
                 for (idx, clip) in self.state.clips.iter().enumerate() {
                     let selected = self.state.selected_clip_index == Some(idx);
                     ui.horizontal(|ui| {
@@ -244,8 +277,12 @@ impl eframe::App for AvioEditorApp {
                             }
                         }
                         let name = clip.path.file_name().unwrap_or_default().to_string_lossy();
-                        if ui.selectable_label(selected, name.as_ref()).clicked() {
+                        let resp = ui.selectable_label(selected, name.as_ref());
+                        if resp.clicked() {
                             clicked_idx = Some(idx);
+                        }
+                        if resp.double_clicked() {
+                            dbl_clicked_idx = Some(idx);
                         }
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             ui.label(clip.duration_label());
@@ -254,6 +291,39 @@ impl eframe::App for AvioEditorApp {
                 }
                 if let Some(idx) = clicked_idx {
                     self.state.selected_clip_index = Some(idx);
+                }
+                if let Some(idx) = dbl_clicked_idx {
+                    self.state.selected_clip_index = Some(idx);
+                    // Stop any current player.
+                    if let Some(stop) = self.state.player_stop.take() {
+                        stop.store(true, std::sync::atomic::Ordering::Release);
+                    }
+                    self.state.player_thread = None;
+                    self.state.pending_stop_rx = None;
+                    self.state.monitor_clip_index = Some(idx);
+
+                    // Only launch a player if the clip has a video stream.
+                    // PreviewPlayer::open() fails for audio-only files because
+                    // DecodeBuffer requires a video stream — avio API gap: a
+                    // dedicated AudioPlayer (or an audio-only path in
+                    // PreviewPlayer) would be needed.
+                    let has_video = self
+                        .state
+                        .clips
+                        .get(idx)
+                        .map(|c| c.info.primary_video().is_some())
+                        .unwrap_or(false);
+                    if has_video
+                        && let Some(path) = self.state.clips.get(idx).map(|c| c.path.clone())
+                    {
+                        let (thread, stop_rx) = player::spawn_player(
+                            path,
+                            Arc::clone(&self.state.frame_handle),
+                            ctx.clone(),
+                        );
+                        self.state.player_thread = Some(thread);
+                        self.state.pending_stop_rx = Some(stop_rx);
+                    }
                 }
 
                 if let Some(idx) = self.state.selected_clip_index
@@ -375,6 +445,67 @@ impl eframe::App for AvioEditorApp {
         // 4. Center: Source Monitor (must be last)
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("Source Monitor");
+            ui.separator();
+
+            let is_playing = self
+                .state
+                .player_thread
+                .as_ref()
+                .map(|h| !h.is_finished())
+                .unwrap_or(false);
+
+            let ctrl_height = 36.0;
+            let available = ui.available_size();
+            let video_size = egui::vec2(available.x, (available.y - ctrl_height).max(0.0));
+
+            if let Some(tex) = &self.state.preview_texture {
+                ui.image(egui::load::SizedTexture::new(tex.id(), video_size));
+            } else {
+                ui.allocate_ui(video_size, |ui| {
+                    ui.centered_and_justified(|ui| {
+                        ui.label("Double-click a clip to load it");
+                    });
+                });
+            }
+
+            ui.separator();
+            ui.horizontal(|ui| {
+                if is_playing {
+                    // avio API gap: pause() takes &mut self so it cannot be called
+                    // while run() blocks the player thread. Pause stops playback.
+                    if ui.button("⏸ Pause").clicked()
+                        && let Some(stop) = self.state.player_stop.take()
+                    {
+                        stop.store(true, std::sync::atomic::Ordering::Release);
+                    }
+                    if ui.button("⏹ Stop").clicked()
+                        && let Some(stop) = self.state.player_stop.take()
+                    {
+                        stop.store(true, std::sync::atomic::Ordering::Release);
+                    }
+                } else if let Some(idx) = self.state.monitor_clip_index {
+                    let has_video = self
+                        .state
+                        .clips
+                        .get(idx)
+                        .map(|c| c.info.primary_video().is_some())
+                        .unwrap_or(false);
+                    if has_video
+                        && ui.button("▶ Play").clicked()
+                        && let Some(path) = self.state.clips.get(idx).map(|c| c.path.clone())
+                    {
+                        let (thread, stop_rx) = player::spawn_player(
+                            path,
+                            Arc::clone(&self.state.frame_handle),
+                            ctx.clone(),
+                        );
+                        self.state.player_thread = Some(thread);
+                        self.state.pending_stop_rx = Some(stop_rx);
+                    } else if !has_video {
+                        ui.label("No video stream");
+                    }
+                }
+            });
         });
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,0 +1,123 @@
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex, mpsc};
+use std::time::{Duration, Instant};
+
+use avio::RgbaFrame;
+
+// ── TimedRgbaSink ──────────────────────────────────────────────────────────────
+
+/// `FrameSink` implementation that stores the latest RGBA frame and applies
+/// wall-clock pacing.
+///
+/// `PreviewPlayer::run()` paces video against `MasterClock::Audio`, which only
+/// advances when `pop_audio_samples()` is called. Since we have no audio
+/// output wired up, the audio clock never starts and `should_sync()` returns
+/// `false`, causing frames to be delivered as fast as the decoder can produce
+/// them (far above real-time).
+///
+/// # avio API gap
+/// `pop_audio_samples(&mut self)` takes `&mut self`, making it unreachable
+/// while `run()` holds the same `&mut self` on the player thread. A future
+/// avio issue should change the receiver to `&self` (all internal state it
+/// touches — `AtomicBool`, `AtomicU64`, `Arc<Mutex<…>>` — is already
+/// thread-safe) so that callers can drive audio output from a `cpal` callback
+/// without conflicting with `run()`.
+///
+/// # Workaround
+/// We implement our own A/V sync inside `push_frame`: on the first frame we
+/// record the wall-clock start time and the base PTS. For every subsequent
+/// frame we sleep until `(pts − base_pts)` has elapsed on the wall clock.
+/// This is equivalent to the `MasterClock::System` path that `run()` uses
+/// for video-only files.
+struct TimedRgbaSink {
+    frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
+    /// `(wall_clock_start, base_pts)` set on the first received frame.
+    start: Option<(Instant, Duration)>,
+}
+
+impl TimedRgbaSink {
+    fn new(frame_handle: Arc<Mutex<Option<RgbaFrame>>>) -> Self {
+        Self {
+            frame_handle,
+            start: None,
+        }
+    }
+}
+
+impl avio::FrameSink for TimedRgbaSink {
+    fn push_frame(&mut self, rgba: &[u8], width: u32, height: u32, pts: Duration) {
+        let (wall_start, pts_base) = self.start.get_or_insert_with(|| (Instant::now(), pts));
+
+        // How far into the clip is this frame?
+        let video_relative = pts.saturating_sub(*pts_base);
+        // How much wall time has elapsed since the first frame?
+        let wall_elapsed = wall_start.elapsed();
+
+        // Sleep until the wall clock catches up with the video PTS.
+        if let Some(ahead) = video_relative.checked_sub(wall_elapsed)
+            && ahead > Duration::from_millis(1)
+        {
+            std::thread::sleep(ahead);
+        }
+
+        let mut guard = self
+            .frame_handle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *guard = Some(RgbaFrame {
+            data: rgba.to_vec(),
+            width,
+            height,
+            pts,
+        });
+    }
+}
+
+// ── spawn_player ───────────────────────────────────────────────────────────────
+
+/// Spawns a background thread running `PreviewPlayer::run()`.
+///
+/// Returns (thread handle, receiver for the player's stop handle).
+/// The stop handle is sent from the player thread immediately after
+/// `PreviewPlayer::open()` succeeds and before `run()` blocks, so the UI
+/// thread can receive it via `try_recv` within one or two render frames.
+///
+/// Video pacing is handled by [`TimedRgbaSink`] (wall-clock sync).
+///
+/// # avio API gap — pause
+/// `PreviewPlayer::pause()` takes `&mut self`, making it unreachable while
+/// `run()` blocks the player thread. A future avio issue should add
+/// `pause_handle() -> Arc<AtomicBool>` analogous to `stop_handle()`.
+///
+/// # avio API gap — audio output
+/// Audio samples accumulate in the player's internal ring buffer but we have
+/// no way to drain them from a `cpal` callback while `run()` holds `&mut self`.
+/// See the doc-comment on [`TimedRgbaSink`] for details.
+pub fn spawn_player(
+    path: PathBuf,
+    frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
+    ctx: egui::Context,
+) -> (std::thread::JoinHandle<()>, mpsc::Receiver<Arc<AtomicBool>>) {
+    let (stop_tx, stop_rx) = mpsc::sync_channel::<Arc<AtomicBool>>(1);
+    let handle = std::thread::spawn(move || {
+        let mut player = match avio::PreviewPlayer::open(&path) {
+            Ok(p) => p,
+            Err(e) => {
+                log::warn!("PreviewPlayer::open failed path={path:?}: {e}");
+                return;
+            }
+        };
+        // Send the stop handle back before blocking in run().
+        let _ = stop_tx.send(player.stop_handle());
+
+        player.set_sink(Box::new(TimedRgbaSink::new(frame_handle)));
+        player.play();
+        if let Err(e) = player.run() {
+            log::warn!("PreviewPlayer::run failed: {e}");
+        }
+        // Wake the render loop so the UI can update after playback ends.
+        ctx.request_repaint();
+    });
+    (handle, stop_rx)
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
 
@@ -12,6 +13,12 @@ pub struct AppState {
     pub timeline: TimelineState,
     pub trim_jobs: Vec<TrimJobHandle>,
     pub gif_jobs: Vec<GifJobHandle>,
+    pub frame_handle: Arc<Mutex<Option<avio::RgbaFrame>>>,
+    pub preview_texture: Option<egui::TextureHandle>,
+    pub player_thread: Option<std::thread::JoinHandle<()>>,
+    pub player_stop: Option<Arc<AtomicBool>>,
+    pub pending_stop_rx: Option<mpsc::Receiver<Arc<AtomicBool>>>,
+    pub monitor_clip_index: Option<usize>,
 }
 
 impl Default for AppState {
@@ -28,6 +35,12 @@ impl Default for AppState {
             timeline: TimelineState::default(),
             trim_jobs: Vec::new(),
             gif_jobs: Vec::new(),
+            frame_handle: Arc::new(Mutex::new(None)),
+            preview_texture: None,
+            player_thread: None,
+            player_stop: None,
+            pending_stop_rx: None,
+            monitor_clip_index: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements Source Monitor real-time playback (issue #5). Double-clicking a clip in the
Clip Browser loads it into a `PreviewPlayer` on a background thread. Each render frame
polls the shared `RgbaSink` for the latest decoded frame and uploads it to an
`egui::TextureHandle`. Play and Stop controls are shown in the Source Monitor panel.

## Changes

- **`src/player.rs`** (new): `spawn_player()` opens `PreviewPlayer` on a `std::thread`,
  sends its `stop_handle()` back via a one-shot channel before `run()` blocks, and wires
  a `TimedRgbaSink` for RGBA frame delivery.
- **`TimedRgbaSink`**: custom `FrameSink` that applies wall-clock pacing inside
  `push_frame()`, fixing frame-rate when the audio master clock is not driven
  (`MasterClock::Audio::should_sync()` returns false without audio output).
- **`src/state.rs`**: adds `frame_handle`, `preview_texture`, `player_thread`,
  `player_stop`, `pending_stop_rx`, and `monitor_clip_index` to `AppState`.
- **`src/main.rs`**: drains the stop-handle channel and polls the frame handle each
  frame; double-click on a clip row starts playback; Source Monitor renders the texture
  or a placeholder with ⏸ Pause / ⏹ Stop while playing and ▶ Play when stopped.
- Audio-only clips are guarded with `primary_video().is_some()` — clicking them shows
  "No video stream" instead of silently failing.
- Two avio API gaps documented in code comments: `pause()` taking `&mut self` (no
  cross-thread pause), and `pop_audio_samples(&mut self)` conflicting with `run()`.

## Related Issues

Closes #5

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes