### PR TITLE
feat(source-monitor): activate proxy automatically via use_proxy_if_available

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,14 @@ impl eframe::App for AvioEditorApp {
             self.state.pending_stop_rx = None;
         }
 
+        // Drain proxy-active status from a freshly spawned player thread.
+        if let Some(rx) = &self.state.pending_proxy_rx
+            && let Ok(active) = rx.try_recv()
+        {
+            self.state.proxy_active = active;
+            self.state.pending_proxy_rx = None;
+        }
+
         // Poll for the latest decoded frame from the player sink.
         if let Ok(mut guard) = self.state.frame_handle.try_lock()
             && let Some(frame) = guard.take()
@@ -320,14 +328,23 @@ impl eframe::App for AvioEditorApp {
                     if has_video
                         && let Some(path) = self.state.clips.get(idx).map(|c| c.path.clone())
                     {
-                        let (thread, stop_rx) = player::spawn_player(
+                        let proxy_dir = self
+                            .state
+                            .clips
+                            .get(idx)
+                            .and_then(|c| c.path.parent())
+                            .map(|p| p.join("proxies"));
+                        let (thread, stop_rx, proxy_rx) = player::spawn_player(
                             path,
                             Arc::clone(&self.state.frame_handle),
                             ctx.clone(),
                             None,
+                            proxy_dir,
                         );
                         self.state.player_thread = Some(thread);
                         self.state.pending_stop_rx = Some(stop_rx);
+                        self.state.pending_proxy_rx = Some(proxy_rx);
+                        self.state.proxy_active = false;
                     }
                 }
 
@@ -449,7 +466,13 @@ impl eframe::App for AvioEditorApp {
 
         // 4. Center: Source Monitor (must be last)
         egui::CentralPanel::default().show(ctx, |ui| {
-            ui.heading("Source Monitor");
+            ui.horizontal(|ui| {
+                ui.heading("Source Monitor");
+                if self.state.proxy_active {
+                    ui.colored_label(egui::Color32::from_rgb(255, 200, 0), "PROXY")
+                        .on_hover_text("Playing proxy — reload clip to hot-swap");
+                }
+            });
             ui.separator();
 
             let is_playing = self
@@ -522,16 +545,26 @@ impl eframe::App for AvioEditorApp {
                         }
                         self.state.player_thread = None;
                         self.state.pending_stop_rx = None;
+                        self.state.pending_proxy_rx = None;
                         let target = Duration::from_secs_f64(self.state.seek_pos_secs);
                         if let Some(path) = self.state.clips.get(idx).map(|c| c.path.clone()) {
-                            let (thread, stop_rx) = player::spawn_player(
+                            let proxy_dir = self
+                                .state
+                                .clips
+                                .get(idx)
+                                .and_then(|c| c.path.parent())
+                                .map(|p| p.join("proxies"));
+                            let (thread, stop_rx, proxy_rx) = player::spawn_player(
                                 path,
                                 Arc::clone(&self.state.frame_handle),
                                 ctx.clone(),
                                 Some(target),
+                                proxy_dir,
                             );
                             self.state.player_thread = Some(thread);
                             self.state.pending_stop_rx = Some(stop_rx);
+                            self.state.pending_proxy_rx = Some(proxy_rx);
+                            self.state.proxy_active = false;
                         }
                     }
                 });
@@ -545,11 +578,13 @@ impl eframe::App for AvioEditorApp {
                         && let Some(stop) = self.state.player_stop.take()
                     {
                         stop.store(true, std::sync::atomic::Ordering::Release);
+                        self.state.proxy_active = false;
                     }
                     if ui.button("⏹ Stop").clicked()
                         && let Some(stop) = self.state.player_stop.take()
                     {
                         stop.store(true, std::sync::atomic::Ordering::Release);
+                        self.state.proxy_active = false;
                     }
                 } else if let Some(idx) = self.state.monitor_clip_index {
                     let has_video = self
@@ -562,14 +597,23 @@ impl eframe::App for AvioEditorApp {
                         && ui.button("▶ Play").clicked()
                         && let Some(path) = self.state.clips.get(idx).map(|c| c.path.clone())
                     {
-                        let (thread, stop_rx) = player::spawn_player(
+                        let proxy_dir = self
+                            .state
+                            .clips
+                            .get(idx)
+                            .and_then(|c| c.path.parent())
+                            .map(|p| p.join("proxies"));
+                        let (thread, stop_rx, proxy_rx) = player::spawn_player(
                             path,
                             Arc::clone(&self.state.frame_handle),
                             ctx.clone(),
                             None,
+                            proxy_dir,
                         );
                         self.state.player_thread = Some(thread);
                         self.state.pending_stop_rx = Some(stop_rx);
+                        self.state.pending_proxy_rx = Some(proxy_rx);
+                        self.state.proxy_active = false;
                     } else if !has_video {
                         ui.label("No video stream");
                     }

--- a/src/player.rs
+++ b/src/player.rs
@@ -99,8 +99,14 @@ pub fn spawn_player(
     frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
     ctx: egui::Context,
     start_pos: Option<Duration>,
-) -> (std::thread::JoinHandle<()>, mpsc::Receiver<Arc<AtomicBool>>) {
+    proxy_dir: Option<PathBuf>,
+) -> (
+    std::thread::JoinHandle<()>,
+    mpsc::Receiver<Arc<AtomicBool>>,
+    mpsc::Receiver<bool>,
+) {
     let (stop_tx, stop_rx) = mpsc::sync_channel::<Arc<AtomicBool>>(1);
+    let (proxy_tx, proxy_rx) = mpsc::sync_channel::<bool>(1);
     let handle = std::thread::spawn(move || {
         let mut player = match avio::PreviewPlayer::open(&path) {
             Ok(p) => p,
@@ -117,6 +123,23 @@ pub fn spawn_player(
         {
             log::warn!("initial seek to {pos:?} failed: {e}");
         }
+        // Activate proxy transparently before play().
+        // use_proxy_if_available() scans proxy_dir for <stem>_half/quarter/eighth.mp4.
+        // Must be called after open() and before play(); calling after play() is a no-op.
+        let proxy_active = if let Some(ref dir) = proxy_dir {
+            let active = player.use_proxy_if_available(dir);
+            if active {
+                log::info!(
+                    "source monitor: proxy active — {}",
+                    player.active_source().display()
+                );
+            }
+            active
+        } else {
+            false
+        };
+        let _ = proxy_tx.send(proxy_active);
+
         // Send the stop handle back before blocking in run().
         let _ = stop_tx.send(player.stop_handle());
 
@@ -128,5 +151,5 @@ pub fn spawn_player(
         // Wake the render loop so the UI can update after playback ends.
         ctx.request_repaint();
     });
-    (handle, stop_rx)
+    (handle, stop_rx, proxy_rx)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -21,6 +21,8 @@ pub struct AppState {
     pub monitor_clip_index: Option<usize>,
     pub seek_pos_secs: f64,
     pub current_pts: Option<Duration>,
+    pub proxy_active: bool,
+    pub pending_proxy_rx: Option<mpsc::Receiver<bool>>,
 }
 
 impl Default for AppState {
@@ -45,6 +47,8 @@ impl Default for AppState {
             monitor_clip_index: None,
             seek_pos_secs: 0.0,
             current_pts: None,
+            proxy_active: false,
+            pending_proxy_rx: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Wires `PreviewPlayer::use_proxy_if_available()` into the player spawn path so that if a proxy file exists at `<clip-dir>/proxies/<stem>_quarter.mp4` (or `_half`, `_eighth`), it is transparently used during Source Monitor playback. A yellow `PROXY` badge is shown in the Source Monitor header while a proxy is active, with a tooltip noting that the clip must be reloaded to hot-swap. Proxy status is communicated back to the UI thread via a one-shot channel mirroring the existing stop-handle pattern.

## Changes

- `src/player.rs`: added `proxy_dir: Option<PathBuf>` parameter to `spawn_player()`; calls `use_proxy_if_available()` after `seek()` and before `play()`; logs the active source path when a proxy is activated; adds a second one-shot `mpsc` channel returning `bool` proxy status; return type extended to a 3-tuple
- `src/state.rs`: added `proxy_active: bool` and `pending_proxy_rx: Option<Receiver<bool>>` to `AppState`
- `src/main.rs`: drains `pending_proxy_rx` each frame to update `proxy_active`; all three `spawn_player` call sites updated to derive `proxy_dir` from the clip path and capture `proxy_rx`; `proxy_active` reset to `false` on Pause/Stop; Source Monitor heading replaced with a horizontal row showing the yellow `PROXY` badge with tooltip when active

## Related Issues

Closes #14

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes