### PR TITLE
feat(source-monitor): add playback rate control (0.25×/0.5×/1×/2×)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -340,6 +340,7 @@ impl eframe::App for AvioEditorApp {
                             ctx.clone(),
                             None,
                             proxy_dir,
+                            Arc::clone(&self.state.rate_handle),
                         );
                         self.state.player_thread = Some(thread);
                         self.state.pending_stop_rx = Some(stop_rx);
@@ -572,6 +573,7 @@ impl eframe::App for AvioEditorApp {
                                 ctx.clone(),
                                 Some(target),
                                 proxy_dir,
+                                Arc::clone(&self.state.rate_handle),
                             );
                             self.state.player_thread = Some(thread);
                             self.state.pending_stop_rx = Some(stop_rx);
@@ -621,6 +623,7 @@ impl eframe::App for AvioEditorApp {
                             ctx.clone(),
                             None,
                             proxy_dir,
+                            Arc::clone(&self.state.rate_handle),
                         );
                         self.state.player_thread = Some(thread);
                         self.state.pending_stop_rx = Some(stop_rx);
@@ -628,6 +631,25 @@ impl eframe::App for AvioEditorApp {
                         self.state.proxy_active = false;
                     } else if !has_video {
                         ui.label("No video stream");
+                    }
+                }
+                // Rate selector — visible whenever a clip is loaded.
+                // avio API gap: PreviewPlayer has no set_rate() — rate is applied
+                // inside TimedRgbaSink::push_frame by scaling the sleep duration.
+                if self.state.monitor_clip_index.is_some() {
+                    ui.separator();
+                    for (rate, label) in
+                        [(0.25_f64, "0.25×"), (0.5, "0.5×"), (1.0, "1×"), (2.0, "2×")]
+                    {
+                        if ui
+                            .selectable_label(self.state.playback_rate == rate, label)
+                            .clicked()
+                        {
+                            self.state.playback_rate = rate;
+                            self.state
+                                .rate_handle
+                                .store(rate.to_bits(), std::sync::atomic::Ordering::Relaxed);
+                        }
                     }
                 }
             });

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
@@ -32,30 +32,60 @@ use avio::RgbaFrame;
 /// for video-only files.
 struct TimedRgbaSink {
     frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
-    /// `(wall_clock_start, base_pts)` set on the first received frame.
+    ctx: egui::Context,
+    /// `(wall_clock_start, base_pts)` set on the first frame (and reset on rate change).
     start: Option<(Instant, Duration)>,
+    /// Playback rate as `f64` bits stored atomically. Read each frame.
+    rate: Arc<AtomicU64>,
+    /// Last observed rate. When the rate changes, `start` is reset so the new
+    /// rate is applied from the current position rather than the clip origin.
+    last_rate: f64,
 }
 
 impl TimedRgbaSink {
-    fn new(frame_handle: Arc<Mutex<Option<RgbaFrame>>>) -> Self {
+    fn new(
+        frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
+        ctx: egui::Context,
+        rate: Arc<AtomicU64>,
+    ) -> Self {
         Self {
             frame_handle,
+            ctx,
             start: None,
+            rate,
+            last_rate: 1.0,
         }
     }
 }
 
 impl avio::FrameSink for TimedRgbaSink {
     fn push_frame(&mut self, rgba: &[u8], width: u32, height: u32, pts: Duration) {
+        let rate = f64::from_bits(self.rate.load(Ordering::Relaxed));
+
+        // Reset the clock reference whenever the rate changes mid-playback.
+        // Without this, `target_wall = video_relative / new_rate` would place
+        // the target in the past for frames after a rate increase, causing
+        // all remaining frames to be delivered at decoder speed (no pacing).
+        if (rate - self.last_rate).abs() > f64::EPSILON {
+            self.start = None;
+            self.last_rate = rate;
+        }
+
         let (wall_start, pts_base) = self.start.get_or_insert_with(|| (Instant::now(), pts));
 
-        // How far into the clip is this frame?
+        // How far into the clip (from the current reference point) is this frame?
         let video_relative = pts.saturating_sub(*pts_base);
-        // How much wall time has elapsed since the first frame?
+        // How much wall time has elapsed since the reference point?
         let wall_elapsed = wall_start.elapsed();
 
-        // Sleep until the wall clock catches up with the video PTS.
-        if let Some(ahead) = video_relative.checked_sub(wall_elapsed)
+        // Target wall time for this frame at the requested rate.
+        // At 2×: target = video_relative / 2  → shorter sleep → faster.
+        // At 0.5×: target = video_relative * 2 → longer sleep  → slower.
+        // Note: dividing `video_relative` (not `ahead`) by rate is required.
+        // Dividing `ahead = video_relative − wall_elapsed` by rate yields
+        // a formula that converges to 1× regardless of the rate setting.
+        let target_wall = video_relative.div_f64(rate);
+        if let Some(ahead) = target_wall.checked_sub(wall_elapsed)
             && ahead > Duration::from_millis(1)
         {
             std::thread::sleep(ahead);
@@ -71,6 +101,10 @@ impl avio::FrameSink for TimedRgbaSink {
             height,
             pts,
         });
+        // Wake the render loop so egui picks up this frame without waiting for
+        // the next input event. Required at slow rates (0.5×, 0.25×) where the
+        // inter-frame sleep is long enough for eframe to go fully idle.
+        self.ctx.request_repaint();
     }
 }
 
@@ -100,6 +134,7 @@ pub fn spawn_player(
     ctx: egui::Context,
     start_pos: Option<Duration>,
     proxy_dir: Option<PathBuf>,
+    rate: Arc<AtomicU64>,
 ) -> (
     std::thread::JoinHandle<()>,
     mpsc::Receiver<Arc<AtomicBool>>,
@@ -143,7 +178,11 @@ pub fn spawn_player(
         // Send the stop handle back before blocking in run().
         let _ = stop_tx.send(player.stop_handle());
 
-        player.set_sink(Box::new(TimedRgbaSink::new(frame_handle)));
+        player.set_sink(Box::new(TimedRgbaSink::new(
+            frame_handle,
+            ctx.clone(),
+            rate,
+        )));
         player.play();
         if let Err(e) = player.run() {
             log::warn!("PreviewPlayer::run failed: {e}");

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
 
@@ -24,6 +24,8 @@ pub struct AppState {
     pub current_pts: Option<Duration>,
     pub proxy_active: bool,
     pub pending_proxy_rx: Option<mpsc::Receiver<bool>>,
+    pub playback_rate: f64,
+    pub rate_handle: Arc<AtomicU64>,
 }
 
 impl Default for AppState {
@@ -51,6 +53,8 @@ impl Default for AppState {
             current_pts: None,
             proxy_active: false,
             pending_proxy_rx: None,
+            playback_rate: 1.0,
+            rate_handle: Arc::new(AtomicU64::new(1.0_f64.to_bits())),
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds rate-selector buttons (0.25×, 0.5×, 1×, 2×) to the Source Monitor controls row. Clicking a button changes playback speed immediately without restarting the player. `PreviewPlayer::set_rate()` does not exist in avio, so rate control is implemented by scaling the wall-clock sleep duration inside `TimedRgbaSink::push_frame`.

## Changes

- `src/state.rs`: add `playback_rate: f64` (default `1.0`) and `rate_handle: Arc<AtomicU64>` to `AppState`
- `src/player.rs`:
  - Add `rate: Arc<AtomicU64>` and `ctx: egui::Context` fields to `TimedRgbaSink`
  - Fix sleep formula from `(video_relative − wall_elapsed) / rate` to `video_relative / rate − wall_elapsed`; the original formula converged to 1× regardless of rate setting
  - Reset clock reference (`start = None`) when rate changes mid-playback to prevent frames from being delivered at decoder speed after a rate increase
  - Call `ctx.request_repaint()` after each frame so eframe wakes up at slow rates (0.5×, 0.25×) where inter-frame sleep exceeds eframe's idle threshold
  - Add `rate: Arc<AtomicU64>` parameter to `spawn_player`
- `src/main.rs`: add rate buttons in the controls row; pass `rate_handle` to all three `spawn_player` call sites

## Related Issues

Closes #16

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes