### PR TITLE
feat(source-monitor): add A/V offset correction (±500 ms)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -341,6 +341,7 @@ impl eframe::App for AvioEditorApp {
                             None,
                             proxy_dir,
                             Arc::clone(&self.state.rate_handle),
+                            self.state.av_offset_ms as i64,
                         );
                         self.state.player_thread = Some(thread);
                         self.state.pending_stop_rx = Some(stop_rx);
@@ -485,7 +486,7 @@ impl eframe::App for AvioEditorApp {
 
             // Two control rows when a clip is loaded: seek bar + timecode, then buttons.
             let ctrl_height = if self.state.monitor_clip_index.is_some() {
-                72.0
+                100.0
             } else {
                 36.0
             };
@@ -574,6 +575,7 @@ impl eframe::App for AvioEditorApp {
                                 Some(target),
                                 proxy_dir,
                                 Arc::clone(&self.state.rate_handle),
+                                self.state.av_offset_ms as i64,
                             );
                             self.state.player_thread = Some(thread);
                             self.state.pending_stop_rx = Some(stop_rx);
@@ -624,6 +626,7 @@ impl eframe::App for AvioEditorApp {
                             None,
                             proxy_dir,
                             Arc::clone(&self.state.rate_handle),
+                            self.state.av_offset_ms as i64,
                         );
                         self.state.player_thread = Some(thread);
                         self.state.pending_stop_rx = Some(stop_rx);
@@ -653,6 +656,89 @@ impl eframe::App for AvioEditorApp {
                     }
                 }
             });
+
+            // A/V offset row — visible whenever a clip is loaded.
+            // avio API gap: set_av_offset(&self) uses AtomicI64 (thread-safe)
+            // but there is no av_offset_handle() method analogous to
+            // stop_handle(). Without a handle the UI thread cannot write to
+            // the player while run() holds &mut self on the player thread.
+            // Workaround: stop + respawn at current position on drag release.
+            if let Some(idx) = self.state.monitor_clip_index {
+                ui.horizontal(|ui| {
+                    ui.label("A/V:");
+                    let av_resp = ui.add(
+                        egui::DragValue::new(&mut self.state.av_offset_ms)
+                            .range(-500..=500)
+                            .speed(1.0)
+                            .suffix(" ms"),
+                    );
+                    let should_apply =
+                        av_resp.drag_stopped() || (!av_resp.dragged() && av_resp.changed());
+                    if should_apply && is_playing {
+                        if let Some(stop) = self.state.player_stop.take() {
+                            stop.store(true, std::sync::atomic::Ordering::Release);
+                        }
+                        self.state.player_thread = None;
+                        self.state.pending_stop_rx = None;
+                        self.state.pending_proxy_rx = None;
+                        let target = Duration::from_secs_f64(self.state.seek_pos_secs);
+                        if let Some(path) = self.state.clips.get(idx).map(|c| c.path.clone()) {
+                            let proxy_dir = self
+                                .state
+                                .clips
+                                .get(idx)
+                                .and_then(|c| c.path.parent())
+                                .map(|p| p.join("proxies"));
+                            let (thread, stop_rx, proxy_rx) = player::spawn_player(
+                                path,
+                                Arc::clone(&self.state.frame_handle),
+                                ctx.clone(),
+                                Some(target),
+                                proxy_dir,
+                                Arc::clone(&self.state.rate_handle),
+                                self.state.av_offset_ms as i64,
+                            );
+                            self.state.player_thread = Some(thread);
+                            self.state.pending_stop_rx = Some(stop_rx);
+                            self.state.pending_proxy_rx = Some(proxy_rx);
+                            self.state.proxy_active = false;
+                        }
+                    }
+                    if ui.small_button("Reset").clicked() {
+                        self.state.av_offset_ms = 0;
+                        if is_playing {
+                            if let Some(stop) = self.state.player_stop.take() {
+                                stop.store(true, std::sync::atomic::Ordering::Release);
+                            }
+                            self.state.player_thread = None;
+                            self.state.pending_stop_rx = None;
+                            self.state.pending_proxy_rx = None;
+                            let target = Duration::from_secs_f64(self.state.seek_pos_secs);
+                            if let Some(path) = self.state.clips.get(idx).map(|c| c.path.clone()) {
+                                let proxy_dir = self
+                                    .state
+                                    .clips
+                                    .get(idx)
+                                    .and_then(|c| c.path.parent())
+                                    .map(|p| p.join("proxies"));
+                                let (thread, stop_rx, proxy_rx) = player::spawn_player(
+                                    path,
+                                    Arc::clone(&self.state.frame_handle),
+                                    ctx.clone(),
+                                    Some(target),
+                                    proxy_dir,
+                                    Arc::clone(&self.state.rate_handle),
+                                    0_i64,
+                                );
+                                self.state.player_thread = Some(thread);
+                                self.state.pending_stop_rx = Some(stop_rx);
+                                self.state.pending_proxy_rx = Some(proxy_rx);
+                                self.state.proxy_active = false;
+                            }
+                        }
+                    }
+                });
+            }
         });
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -135,6 +135,7 @@ pub fn spawn_player(
     start_pos: Option<Duration>,
     proxy_dir: Option<PathBuf>,
     rate: Arc<AtomicU64>,
+    av_offset_ms: i64,
 ) -> (
     std::thread::JoinHandle<()>,
     mpsc::Receiver<Arc<AtomicBool>>,
@@ -158,6 +159,13 @@ pub fn spawn_player(
         {
             log::warn!("initial seek to {pos:?} failed: {e}");
         }
+        // Apply A/V offset before play().
+        // avio API gap: set_av_offset(&self) uses AtomicI64 so concurrent
+        // writes are safe, but there is no av_offset_handle() method.
+        // Without a handle the UI thread cannot reach the player while
+        // run() holds &mut self. Workaround: apply the offset on every spawn.
+        player.set_av_offset(av_offset_ms);
+
         // Activate proxy transparently before play().
         // use_proxy_if_available() scans proxy_dir for <stem>_half/quarter/eighth.mp4.
         // Must be called after open() and before play(); calling after play() is a no-op.

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,6 +26,7 @@ pub struct AppState {
     pub pending_proxy_rx: Option<mpsc::Receiver<bool>>,
     pub playback_rate: f64,
     pub rate_handle: Arc<AtomicU64>,
+    pub av_offset_ms: i32,
 }
 
 impl Default for AppState {
@@ -55,6 +56,7 @@ impl Default for AppState {
             pending_proxy_rx: None,
             playback_rate: 1.0,
             rate_handle: Arc::new(AtomicU64::new(1.0_f64.to_bits())),
+            av_offset_ms: 0,
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds an A/V offset `DragValue` (±500 ms, 1 ms/px) and a **Reset** button to the Source Monitor controls. The offset is applied via `PreviewPlayer::set_av_offset()` on every player spawn. Validates the `set_av_offset` API and documents the cross-thread access limitation.

## Changes

- `src/state.rs`: add `av_offset_ms: i32` (default `0`) to `AppState`
- `src/player.rs`: add `av_offset_ms: i64` parameter to `spawn_player`; call `player.set_av_offset(av_offset_ms)` before `play()`
- `src/main.rs`:
  - Bump `ctrl_height` from `72.0` to `100.0` to accommodate the new row
  - Add A/V offset row (label + `DragValue` + Reset button) below the rate buttons; hidden when no clip is loaded
  - On `drag_stopped` or Reset while playing: stop + respawn at current position with new offset (same pattern as seek)
  - Pass `av_offset_ms` to all three `spawn_player` call sites
- `docs/issue7.md`: document avio gap — no `av_offset_handle() -> Arc<AtomicI64>` method; `set_av_offset(&self)` is designed for concurrent use but callers cannot reach the player while `run()` holds `&mut self`
- `docs/issue8.md`: document avio gap — `PreviewPlayer` exposes no `set_rate()`; `PlaybackClock::set_rate()` exists but is unreachable via `PreviewPlayer`

## Related Issues

Closes #17

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes