### PR TITLE
feat(source-monitor): keyframe-snapping seek bar via KeyframeEnumerator

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,6 +1,19 @@
 use std::path::Path;
 use std::time::Duration;
 
+/// Returns all keyframe (I-frame) timestamps for the given file.
+///
+/// Returns an empty vec if the file has no video stream or enumeration fails.
+pub fn enumerate_keyframes(path: &Path) -> Vec<Duration> {
+    match avio::KeyframeEnumerator::new(path).run() {
+        Ok(kfs) => kfs,
+        Err(e) => {
+            log::warn!("keyframe enumeration failed for {path:?}: {e}");
+            Vec::new()
+        }
+    }
+}
+
 /// Detects scene changes and returns their timestamps.
 ///
 /// Returns an empty vec if the file has no video stream or detection fails.

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,23 @@ use std::time::Duration;
 
 use state::{AppState, GifStatus, ImportedClip, TrimStatus};
 
+fn snap_to_nearest_keyframe(
+    target_secs: f64,
+    keyframes: &[std::time::Duration],
+    snap_radius_secs: f64,
+) -> f64 {
+    keyframes
+        .iter()
+        .map(|kf| kf.as_secs_f64())
+        .min_by(|a, b| {
+            let da = (a - target_secs).abs();
+            let db = (b - target_secs).abs();
+            da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .filter(|&nearest| (nearest - target_secs).abs() <= snap_radius_secs)
+        .unwrap_or(target_secs)
+}
+
 fn main() -> eframe::Result<()> {
     env_logger::init();
     let rt = tokio::runtime::Runtime::new().map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
@@ -155,6 +172,11 @@ impl eframe::App for AvioEditorApp {
             if let Some(clip) = self.state.clips.iter_mut().find(|c| c.path == path) {
                 clip.thumbnail = Some(texture);
             }
+        }
+
+        // Drain keyframe enumeration results for the currently loaded clip.
+        if let Ok(kfs) = self.state.keyframe_rx.try_recv() {
+            self.state.keyframes = kfs;
         }
 
         // 1. Top menu bar (must come before all other panels)
@@ -328,6 +350,14 @@ impl eframe::App for AvioEditorApp {
                     if has_video
                         && let Some(path) = self.state.clips.get(idx).map(|c| c.path.clone())
                     {
+                        // Clear stale keyframes and enumerate new ones for this clip.
+                        self.state.keyframes.clear();
+                        let kf_tx = self.state.keyframe_tx.clone();
+                        let kf_path = path.clone();
+                        tokio::task::spawn_blocking(move || {
+                            let kfs = analysis::enumerate_keyframes(&kf_path);
+                            let _ = kf_tx.send(kfs);
+                        });
                         let proxy_dir = self
                             .state
                             .clips
@@ -563,6 +593,20 @@ impl eframe::App for AvioEditorApp {
                         }
                     }
 
+                    // Draw keyframe tick marks (blue, 4 px tall) above the seek bar.
+                    {
+                        let r = slider_resp.rect;
+                        for kf in &self.state.keyframes {
+                            let x =
+                                r.left() + (kf.as_secs_f64() / duration_secs) as f32 * r.width();
+                            ui.painter().vline(
+                                x,
+                                r.top()..=(r.top() + 4.0),
+                                egui::Stroke::new(1.0, egui::Color32::from_rgb(150, 150, 255)),
+                            );
+                        }
+                    }
+
                     // Timecode: HH:MM:SS.mmm
                     let t = self.state.seek_pos_secs;
                     let h = (t / 3600.0) as u64;
@@ -588,6 +632,14 @@ impl eframe::App for AvioEditorApp {
                     // avio API gap: seek() takes &mut self — cannot call during
                     // run(). Workaround: stop + respawn from the target position.
                     if slider_resp.drag_stopped() {
+                        // Snap to nearest keyframe in Coarse mode.
+                        if !self.state.seek_exact {
+                            self.state.seek_pos_secs = snap_to_nearest_keyframe(
+                                self.state.seek_pos_secs,
+                                &self.state.keyframes,
+                                0.5,
+                            );
+                        }
                         if let Some(stop) = self.state.player_stop.take() {
                             stop.store(true, std::sync::atomic::Ordering::Release);
                         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,6 +10,8 @@ pub struct AppState {
     pub thumbnail_rx: mpsc::Receiver<(PathBuf, u32, u32, Vec<u8>)>,
     pub scene_tx: mpsc::SyncSender<(usize, Vec<Duration>)>,
     pub scene_rx: mpsc::Receiver<(usize, Vec<Duration>)>,
+    pub keyframe_tx: mpsc::SyncSender<Vec<Duration>>,
+    pub keyframe_rx: mpsc::Receiver<Vec<Duration>>,
     pub timeline: TimelineState,
     pub trim_jobs: Vec<TrimJobHandle>,
     pub gif_jobs: Vec<GifJobHandle>,
@@ -22,6 +24,7 @@ pub struct AppState {
     pub seek_pos_secs: f64,
     pub seek_exact: bool,
     pub current_pts: Option<Duration>,
+    pub keyframes: Vec<Duration>,
     pub proxy_active: bool,
     pub pending_proxy_rx: Option<mpsc::Receiver<bool>>,
     pub playback_rate: f64,
@@ -33,6 +36,7 @@ impl Default for AppState {
     fn default() -> Self {
         let (thumbnail_tx, thumbnail_rx) = mpsc::sync_channel(32);
         let (scene_tx, scene_rx) = mpsc::sync_channel(32);
+        let (keyframe_tx, keyframe_rx) = mpsc::sync_channel(4);
         Self {
             clips: Vec::new(),
             selected_clip_index: None,
@@ -40,6 +44,8 @@ impl Default for AppState {
             thumbnail_rx,
             scene_tx,
             scene_rx,
+            keyframe_tx,
+            keyframe_rx,
             timeline: TimelineState::default(),
             trim_jobs: Vec::new(),
             gif_jobs: Vec::new(),
@@ -52,6 +58,7 @@ impl Default for AppState {
             seek_pos_secs: 0.0,
             seek_exact: false,
             current_pts: None,
+            keyframes: Vec::new(),
             proxy_active: false,
             pending_proxy_rx: None,
             playback_rate: 1.0,


### PR DESCRIPTION
## Summary

Adds keyframe-snapping to the seek bar in the Source Monitor. When the user releases the seek bar in **Coarse** mode, the target position is snapped to the nearest I-frame within a 0.5 s radius. Blue 4 px tick marks on the seek bar visualise all I-frame positions. Snapping is suppressed in **Exact** mode. This validates `avio::KeyframeEnumerator` and makes scrubbing more responsive by only seeking to positions that require no forward decode.

## Changes

- `src/analysis.rs`: added `enumerate_keyframes(path) -> Vec<Duration>` using `avio::KeyframeEnumerator::new(path).run()`
- `src/state.rs`: added `keyframes: Vec<Duration>`, `keyframe_tx`, and `keyframe_rx` channel fields
- `src/main.rs`: added `snap_to_nearest_keyframe()` free function (0.5 s snap radius)
- `src/main.rs`: double-click handler clears `keyframes` and spawns `enumerate_keyframes` on `spawn_blocking`
- `src/main.rs`: render loop drains `keyframe_rx` into `state.keyframes`
- `src/main.rs`: seek bar draws blue 4 px tick marks at all keyframe positions
- `src/main.rs`: `drag_stopped` handler applies snapping before seeking when `seek_exact == false`

## Related Issues

Closes #27

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes