### PR TITLE
feat(clip-browser): per-clip proxy generation with status indicator

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,14 @@
 mod analysis;
 mod gif;
 mod player;
+mod proxy;
 mod state;
 mod thumbnail;
 mod trim;
 use std::sync::Arc;
 use std::time::Duration;
 
-use state::{AppState, GifStatus, ImportedClip, TrimStatus};
+use state::{AppState, GifStatus, ImportedClip, ProxyStatus, TrimStatus};
 
 fn snap_to_nearest_keyframe(
     target_secs: f64,
@@ -117,6 +118,29 @@ impl eframe::App for AvioEditorApp {
             });
         for path in gif_done {
             log::info!("GIF exported: {}", path.display());
+        }
+
+        // Drain completed proxy jobs each frame.
+        let mut proxy_done: Vec<(usize, std::path::PathBuf)> = Vec::new();
+        self.state.proxy_jobs.retain(|job| {
+            match job
+                .status
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+            {
+                ProxyStatus::Running => true,
+                ProxyStatus::Done(path) => {
+                    proxy_done.push((job.clip_index, path));
+                    false
+                }
+                ProxyStatus::Failed(_) => true, // kept to display error badge
+            }
+        });
+        for (clip_idx, path) in proxy_done {
+            if let Some(clip) = self.state.clips.get_mut(clip_idx) {
+                clip.proxy_path = Some(path);
+            }
         }
 
         // Receive stop handle from a freshly spawned player thread.
@@ -320,6 +344,31 @@ impl eframe::App for AvioEditorApp {
                         }
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             ui.label(clip.duration_label());
+                            if clip.proxy_path.is_some() {
+                                ui.colored_label(egui::Color32::from_rgb(0, 200, 0), "Proxy");
+                            } else {
+                                let job_status = self
+                                    .state
+                                    .proxy_jobs
+                                    .iter()
+                                    .find(|j| j.clip_index == idx)
+                                    .map(|j| {
+                                        j.status
+                                            .lock()
+                                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                            .clone()
+                                    });
+                                match job_status {
+                                    Some(ProxyStatus::Running) => {
+                                        ui.spinner();
+                                    }
+                                    Some(ProxyStatus::Failed(ref msg)) => {
+                                        ui.colored_label(egui::Color32::RED, "Failed")
+                                            .on_hover_text(msg.as_str());
+                                    }
+                                    _ => {}
+                                }
+                            }
                         });
                     });
                 }
@@ -443,6 +492,35 @@ impl eframe::App for AvioEditorApp {
                             ui.end_row();
                         });
                     ui.separator();
+                    let is_proxy_running = self.state.proxy_jobs.iter().any(|j| {
+                        j.clip_index == idx
+                            && matches!(
+                                j.status
+                                    .lock()
+                                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                    .clone(),
+                                ProxyStatus::Running
+                            )
+                    });
+                    if ui
+                        .add_enabled(!is_proxy_running, egui::Button::new("Gen Proxy"))
+                        .clicked()
+                    {
+                        // Remove any stale job for this clip before starting a new one.
+                        self.state.proxy_jobs.retain(|j| j.clip_index != idx);
+                        if let Some(c) = self.state.clips.get(idx) {
+                            let proxy_dir = c
+                                .path
+                                .parent()
+                                .map(|p| p.join("proxies"))
+                                .unwrap_or_default();
+                            if let Err(e) = std::fs::create_dir_all(&proxy_dir) {
+                                log::warn!("failed to create proxy dir {proxy_dir:?}: {e}");
+                            }
+                            let handle = proxy::spawn_proxy_job(idx, c.path.clone(), proxy_dir);
+                            self.state.proxy_jobs.push(handle);
+                        }
+                    }
                     if ui.button("Add to V1").clicked() {
                         let start = self.state.timeline.tracks[0]
                             .clips

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use crate::state::{ProxyJobHandle, ProxyStatus};
+
+/// Spawns a background Quarter-resolution proxy generation job.
+///
+/// Returns a handle to poll the status. The proxy file is written to
+/// `proxy_dir/{stem}_proxy_quarter.mp4`.
+pub fn spawn_proxy_job(
+    clip_index: usize,
+    source_path: PathBuf,
+    proxy_dir: PathBuf,
+) -> ProxyJobHandle {
+    let status = Arc::new(Mutex::new(ProxyStatus::Running));
+    let status_clone = Arc::clone(&status);
+    tokio::task::spawn_blocking(move || {
+        let result = avio::ProxyGenerator::new(&source_path).and_then(|g| {
+            g.resolution(avio::ProxyResolution::Quarter)
+                .output_dir(&proxy_dir)
+                .generate()
+        });
+        *status_clone
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = match result {
+            Ok(p) => ProxyStatus::Done(p),
+            Err(e) => ProxyStatus::Failed(e.to_string()),
+        };
+    });
+    ProxyJobHandle { clip_index, status }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -15,6 +15,7 @@ pub struct AppState {
     pub timeline: TimelineState,
     pub trim_jobs: Vec<TrimJobHandle>,
     pub gif_jobs: Vec<GifJobHandle>,
+    pub proxy_jobs: Vec<ProxyJobHandle>,
     pub frame_handle: Arc<Mutex<Option<avio::RgbaFrame>>>,
     pub preview_texture: Option<egui::TextureHandle>,
     pub player_thread: Option<std::thread::JoinHandle<()>>,
@@ -49,6 +50,7 @@ impl Default for AppState {
             timeline: TimelineState::default(),
             trim_jobs: Vec::new(),
             gif_jobs: Vec::new(),
+            proxy_jobs: Vec::new(),
             frame_handle: Arc::new(Mutex::new(None)),
             preview_texture: None,
             player_thread: None,
@@ -103,6 +105,19 @@ pub enum GifStatus {
 pub struct GifJobHandle {
     pub clip_index: usize,
     pub status: Arc<Mutex<GifStatus>>,
+}
+
+#[derive(Clone)]
+pub enum ProxyStatus {
+    Running,
+    Done(PathBuf),
+    Failed(String),
+}
+
+#[allow(dead_code)]
+pub struct ProxyJobHandle {
+    pub clip_index: usize,
+    pub status: Arc<Mutex<ProxyStatus>>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

Adds a **Gen Proxy** button to the Clip Browser that generates a Quarter-resolution proxy file for the selected clip in a background task. Each clip row shows a status badge reflecting the current state. On success, `ImportedClip::proxy_path` is set so that subsequent Source Monitor playback automatically uses the proxy via `use_proxy_if_available`.

## Changes

- `src/proxy.rs` (new): `spawn_proxy_job()` using `tokio::task::spawn_blocking` + `avio::ProxyGenerator::new().resolution(Quarter).output_dir().generate()`, returning `ProxyJobHandle`
- `src/state.rs`: added `ProxyStatus` enum (`Running` / `Done(PathBuf)` / `Failed(String)`), `ProxyJobHandle` struct, and `proxy_jobs: Vec<ProxyJobHandle>` on `AppState`
- `src/main.rs`: render-loop drain applies `Done` results to `clip.proxy_path` and removes the job; `Failed` jobs are retained to keep the error badge visible
- `src/main.rs`: clip row right-to-left layout shows green `"Proxy"` badge when `proxy_path` is set, spinner while running, red `"Failed"` label (with hover tooltip) on error
- `src/main.rs`: per-clip sidebar shows `"Gen Proxy"` button (disabled while running); creates `proxies/` dir with `create_dir_all`; clears any stale job before spawning

## Related Issues

Closes #8

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes