### PR TITLE
feat(timeline): silence region detection and A1 overlay visualization

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -14,6 +14,19 @@ pub fn enumerate_keyframes(path: &Path) -> Vec<Duration> {
     }
 }
 
+/// Returns (start, end) silence regions for the audio in the given file.
+///
+/// Returns an empty vec if the file has no audio stream or detection fails.
+pub fn detect_silence(path: &Path) -> Vec<(std::time::Duration, std::time::Duration)> {
+    match avio::SilenceDetector::new(path).run() {
+        Ok(regions) => regions.into_iter().map(|r| (r.start, r.end)).collect(),
+        Err(e) => {
+            log::warn!("silence detection failed for {path:?}: {e}");
+            Vec::new()
+        }
+    }
+}
+
 /// Detects scene changes and returns their timestamps.
 ///
 /// Returns an empty vec if the file has no video stream or detection fails.

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ impl eframe::App for AvioEditorApp {
                         thumbnail: None,
                         proxy_path: None,
                         scenes: Vec::new(),
+                        silence_regions: Vec::new(),
                         in_point: None,
                         out_point: None,
                     });
@@ -91,11 +92,18 @@ impl eframe::App for AvioEditorApp {
                             }
                         });
                         let scene_tx = self.state.scene_tx.clone();
+                        let path_for_scene = path.clone();
                         tokio::task::spawn_blocking(move || {
-                            let scenes = analysis::detect_scenes(&path);
+                            let scenes = analysis::detect_scenes(&path_for_scene);
                             let _ = scene_tx.send((clip_idx, scenes));
                         });
                     }
+                    let silence_tx = self.state.silence_tx.clone();
+                    let path_for_silence = path.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let regions = analysis::detect_silence(&path_for_silence);
+                        let _ = silence_tx.send((clip_idx, regions));
+                    });
                 }
                 Err(e) => log::warn!("probe failed for trimmed clip {path:?}: {e}"),
             }
@@ -187,6 +195,11 @@ impl eframe::App for AvioEditorApp {
         while let Ok((idx, scenes)) = self.state.scene_rx.try_recv() {
             if let Some(clip) = self.state.clips.get_mut(idx) {
                 clip.scenes = scenes;
+            }
+        }
+        while let Ok((idx, regions)) = self.state.silence_rx.try_recv() {
+            if let Some(clip) = self.state.clips.get_mut(idx) {
+                clip.silence_regions = regions;
             }
         }
         while let Ok((path, w, h, rgb)) = self.state.thumbnail_rx.try_recv() {
@@ -368,6 +381,31 @@ impl eframe::App for AvioEditorApp {
                                                 egui::FontId::proportional(11.0),
                                                 egui::Color32::WHITE,
                                             );
+                                            // Silence region overlays — A1 track only
+                                            if track.kind == state::TrackKind::Audio1 {
+                                                for &(start, end) in &source.silence_regions {
+                                                    let sx0 = lane_rect.left()
+                                                        + (tc.start_on_track + start).as_secs_f32()
+                                                            * pps;
+                                                    let sx1 = lane_rect.left()
+                                                        + (tc.start_on_track + end).as_secs_f32()
+                                                            * pps;
+                                                    let sr = egui::Rect::from_x_y_ranges(
+                                                        sx0..=sx1,
+                                                        lane_rect.y_range(),
+                                                    )
+                                                    .intersect(cr);
+                                                    if sr.is_positive() {
+                                                        ui.painter().rect_filled(
+                                                            sr,
+                                                            0.0,
+                                                            egui::Color32::from_rgba_premultiplied(
+                                                                0, 0, 0, 100,
+                                                            ),
+                                                        );
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -433,6 +471,7 @@ impl eframe::App for AvioEditorApp {
                                     thumbnail: None,
                                     proxy_path: None,
                                     scenes: Vec::new(),
+                                    silence_regions: Vec::new(),
                                     in_point: None,
                                     out_point: None,
                                 });
@@ -454,6 +493,12 @@ impl eframe::App for AvioEditorApp {
                                         let _ = scene_tx.send((clip_idx, scenes));
                                     });
                                 }
+                                let silence_tx = self.state.silence_tx.clone();
+                                let path_for_silence = path.clone();
+                                tokio::task::spawn_blocking(move || {
+                                    let regions = analysis::detect_silence(&path_for_silence);
+                                    let _ = silence_tx.send((clip_idx, regions));
+                                });
                             }
                             Err(e) => log::warn!("probe failed for {path:?}: {e}"),
                         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -12,6 +12,8 @@ pub struct AppState {
     pub scene_rx: mpsc::Receiver<(usize, Vec<Duration>)>,
     pub keyframe_tx: mpsc::SyncSender<Vec<Duration>>,
     pub keyframe_rx: mpsc::Receiver<Vec<Duration>>,
+    pub silence_tx: mpsc::SyncSender<(usize, Vec<(Duration, Duration)>)>,
+    pub silence_rx: mpsc::Receiver<(usize, Vec<(Duration, Duration)>)>,
     pub timeline: TimelineState,
     pub trim_jobs: Vec<TrimJobHandle>,
     pub gif_jobs: Vec<GifJobHandle>,
@@ -38,6 +40,7 @@ impl Default for AppState {
         let (thumbnail_tx, thumbnail_rx) = mpsc::sync_channel(32);
         let (scene_tx, scene_rx) = mpsc::sync_channel(32);
         let (keyframe_tx, keyframe_rx) = mpsc::sync_channel(4);
+        let (silence_tx, silence_rx) = mpsc::sync_channel(32);
         Self {
             clips: Vec::new(),
             selected_clip_index: None,
@@ -47,6 +50,8 @@ impl Default for AppState {
             scene_rx,
             keyframe_tx,
             keyframe_rx,
+            silence_tx,
+            silence_rx,
             timeline: TimelineState::default(),
             trim_jobs: Vec::new(),
             gif_jobs: Vec::new(),
@@ -77,6 +82,7 @@ pub struct ImportedClip {
     pub thumbnail: Option<egui::TextureHandle>,
     pub proxy_path: Option<PathBuf>,
     pub scenes: Vec<Duration>,
+    pub silence_regions: Vec<(Duration, Duration)>,
     pub in_point: Option<Duration>,
     pub out_point: Option<Duration>,
 }


### PR DESCRIPTION
## Summary

Implements issue #22: runs `avio::SilenceDetector` on every imported clip in a background task and renders detected silence regions as semi-transparent dark overlays on the A1 track lane. This validates the `SilenceDetector` API and gives editors an immediate visual cue for silent gaps.

## Changes

- **`src/analysis.rs`**: added `detect_silence(path) -> Vec<(Duration, Duration)>` using `SilenceDetector::new(path).run()`; maps `SilenceRange` public fields `r.start`/`r.end` to tuples; returns empty vec on error (video-only clips)
- **`src/state.rs`**: added `silence_regions: Vec<(Duration, Duration)>` to `ImportedClip`; added `silence_tx`/`silence_rx` sync channel pair to `AppState`
- **`src/main.rs`**: spawns silence detection on `spawn_blocking` after every clip import (both the regular import path and the trim-done re-import path); drains `silence_rx` each frame to update `clip.silence_regions`; renders semi-transparent black overlays (`rgba(0,0,0,100)`) on A1 track clips, clipped to the visible clip rect via `intersect(cr)`

## Related Issues

Closes #22

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes