### PR TITLE
feat(timeline): audio waveform visualization via WaveformAnalyzer

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -14,6 +14,57 @@ pub fn enumerate_keyframes(path: &Path) -> Vec<Duration> {
     }
 }
 
+/// Extracts a downsampled waveform normalised to [0.0, 1.0].
+///
+/// `columns` is the desired number of output samples (typically 512).
+/// Returns an empty vec if the file has no audio stream or extraction fails.
+pub fn extract_waveform(path: &Path, columns: usize) -> Vec<f32> {
+    let samples = match avio::WaveformAnalyzer::new(path).run() {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("waveform extraction failed for {path:?}: {e}");
+            return Vec::new();
+        }
+    };
+
+    if samples.is_empty() {
+        return Vec::new();
+    }
+
+    // Convert peak_db (dBFS) to linear amplitude.
+    // peak_db = 0.0 → 1.0 full scale; f32::NEG_INFINITY → 0.0 silence.
+    let linear: Vec<f32> = samples
+        .iter()
+        .map(|s| {
+            if s.peak_db.is_finite() {
+                10_f32.powf(s.peak_db / 20.0)
+            } else {
+                0.0
+            }
+        })
+        .collect();
+
+    // Normalise to the loudest sample so quiet clips still show a visible waveform.
+    let max = linear.iter().copied().fold(0.0_f32, f32::max);
+    let normalised: Vec<f32> = if max > 0.0 {
+        linear.iter().map(|&v| v / max).collect()
+    } else {
+        vec![0.0; linear.len()]
+    };
+
+    // Downsample/resample to `columns` output values.
+    let n = normalised.len();
+    if n == columns {
+        return normalised;
+    }
+    (0..columns)
+        .map(|i| {
+            let src = ((i as f32 / columns as f32) * n as f32) as usize;
+            normalised[src.min(n - 1)]
+        })
+        .collect()
+}
+
 /// Returns (start, end) silence regions for the audio in the given file.
 ///
 /// Returns an empty vec if the file has no audio stream or detection fails.

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ impl eframe::App for AvioEditorApp {
                         proxy_path: None,
                         scenes: Vec::new(),
                         silence_regions: Vec::new(),
+                        waveform: Vec::new(),
                         in_point: None,
                         out_point: None,
                     });
@@ -103,6 +104,12 @@ impl eframe::App for AvioEditorApp {
                     tokio::task::spawn_blocking(move || {
                         let regions = analysis::detect_silence(&path_for_silence);
                         let _ = silence_tx.send((clip_idx, regions));
+                    });
+                    let waveform_tx = self.state.waveform_tx.clone();
+                    let path_for_waveform = path.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let waveform = analysis::extract_waveform(&path_for_waveform, 512);
+                        let _ = waveform_tx.send((clip_idx, waveform));
                     });
                 }
                 Err(e) => log::warn!("probe failed for trimmed clip {path:?}: {e}"),
@@ -200,6 +207,11 @@ impl eframe::App for AvioEditorApp {
         while let Ok((idx, regions)) = self.state.silence_rx.try_recv() {
             if let Some(clip) = self.state.clips.get_mut(idx) {
                 clip.silence_regions = regions;
+            }
+        }
+        while let Ok((idx, waveform)) = self.state.waveform_rx.try_recv() {
+            if let Some(clip) = self.state.clips.get_mut(idx) {
+                clip.waveform = waveform;
             }
         }
         while let Ok((path, w, h, rgb)) = self.state.thumbnail_rx.try_recv() {
@@ -369,6 +381,34 @@ impl eframe::App for AvioEditorApp {
                                             && cr.min.x <= lane_rect.right()
                                         {
                                             ui.painter().rect_filled(cr, 4.0, clip_color);
+                                            // Waveform — A1 track only
+                                            if track.kind == state::TrackKind::Audio1
+                                                && !source.waveform.is_empty()
+                                            {
+                                                let n = source.waveform.len();
+                                                let mid_y = cr.center().y;
+                                                let half_h = cr.height() * 0.4;
+                                                for (i, &amp) in source.waveform.iter().enumerate()
+                                                {
+                                                    let x = cr.left()
+                                                        + (i as f32 / n as f32) * cr.width();
+                                                    if x >= lane_rect.left()
+                                                        && x <= lane_rect.right()
+                                                    {
+                                                        ui.painter().vline(
+                                                            x,
+                                                            (mid_y - amp * half_h)
+                                                                ..=(mid_y + amp * half_h),
+                                                            egui::Stroke::new(
+                                                                1.0,
+                                                                egui::Color32::from_rgb(
+                                                                    100, 200, 100,
+                                                                ),
+                                                            ),
+                                                        );
+                                                    }
+                                                }
+                                            }
                                             let name = source
                                                 .path
                                                 .file_name()
@@ -472,6 +512,7 @@ impl eframe::App for AvioEditorApp {
                                     proxy_path: None,
                                     scenes: Vec::new(),
                                     silence_regions: Vec::new(),
+                                    waveform: Vec::new(),
                                     in_point: None,
                                     out_point: None,
                                 });
@@ -498,6 +539,13 @@ impl eframe::App for AvioEditorApp {
                                 tokio::task::spawn_blocking(move || {
                                     let regions = analysis::detect_silence(&path_for_silence);
                                     let _ = silence_tx.send((clip_idx, regions));
+                                });
+                                let waveform_tx = self.state.waveform_tx.clone();
+                                let path_for_waveform = path.clone();
+                                tokio::task::spawn_blocking(move || {
+                                    let waveform =
+                                        analysis::extract_waveform(&path_for_waveform, 512);
+                                    let _ = waveform_tx.send((clip_idx, waveform));
                                 });
                             }
                             Err(e) => log::warn!("probe failed for {path:?}: {e}"),

--- a/src/state.rs
+++ b/src/state.rs
@@ -14,6 +14,8 @@ pub struct AppState {
     pub keyframe_rx: mpsc::Receiver<Vec<Duration>>,
     pub silence_tx: mpsc::SyncSender<(usize, Vec<(Duration, Duration)>)>,
     pub silence_rx: mpsc::Receiver<(usize, Vec<(Duration, Duration)>)>,
+    pub waveform_tx: mpsc::SyncSender<(usize, Vec<f32>)>,
+    pub waveform_rx: mpsc::Receiver<(usize, Vec<f32>)>,
     pub timeline: TimelineState,
     pub trim_jobs: Vec<TrimJobHandle>,
     pub gif_jobs: Vec<GifJobHandle>,
@@ -41,6 +43,7 @@ impl Default for AppState {
         let (scene_tx, scene_rx) = mpsc::sync_channel(32);
         let (keyframe_tx, keyframe_rx) = mpsc::sync_channel(4);
         let (silence_tx, silence_rx) = mpsc::sync_channel(32);
+        let (waveform_tx, waveform_rx) = mpsc::sync_channel(32);
         Self {
             clips: Vec::new(),
             selected_clip_index: None,
@@ -52,6 +55,8 @@ impl Default for AppState {
             keyframe_rx,
             silence_tx,
             silence_rx,
+            waveform_tx,
+            waveform_rx,
             timeline: TimelineState::default(),
             trim_jobs: Vec::new(),
             gif_jobs: Vec::new(),
@@ -83,6 +88,7 @@ pub struct ImportedClip {
     pub proxy_path: Option<PathBuf>,
     pub scenes: Vec<Duration>,
     pub silence_regions: Vec<(Duration, Duration)>,
+    pub waveform: Vec<f32>,
     pub in_point: Option<Duration>,
     pub out_point: Option<Duration>,
 }


### PR DESCRIPTION
## Summary

Draws a centred green waveform inside each clip rectangle on the A1 audio track lane. Waveform data is extracted in a background task using `avio::WaveformAnalyzer` immediately after a clip is imported, stored as `Vec<f32>` on `ImportedClip`, and rendered as vertical lines scaled to the clip rect height.

## Changes

- `src/analysis.rs`: added `extract_waveform(path, columns) -> Vec<f32>` — runs `WaveformAnalyzer`, converts `peak_db` (dBFS) to linear amplitude, normalises to peak, and resamples to the requested column count
- `src/state.rs`: added `waveform: Vec<f32>` field to `ImportedClip`; added `waveform_tx`/`waveform_rx` channels to `AppState`
- `src/main.rs`: spawn waveform extraction on both import paths (regular and trim-done re-import); drain `waveform_rx` each frame; draw waveform as green vlines in A1 clip rects (after background fill, before filename label and silence overlays)

## Related Issues

Closes #26

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes