### PR TITLE
feat(timeline): clip hover frame preview via SpriteSheet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,7 @@ dependencies = [
  "eframe",
  "egui",
  "env_logger",
+ "image",
  "log",
  "rfd",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ rfd        = "0.17.2"
 tokio      = { version = "1.51.1", features = ["full"] }
 log        = "0.4.29"
 env_logger = "0.11.10"
+image     = { version = "0.25.10", default-features = false, features = ["png"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod analysis;
 mod gif;
 mod player;
 mod proxy;
+mod sprite;
 mod state;
 mod thumbnail;
 mod trim;
@@ -81,6 +82,7 @@ impl eframe::App for AvioEditorApp {
                         scenes: Vec::new(),
                         silence_regions: Vec::new(),
                         waveform: Vec::new(),
+                        sprite_sheet: None,
                         in_point: None,
                         out_point: None,
                     });
@@ -97,6 +99,15 @@ impl eframe::App for AvioEditorApp {
                         tokio::task::spawn_blocking(move || {
                             let scenes = analysis::detect_scenes(&path_for_scene);
                             let _ = scene_tx.send((clip_idx, scenes));
+                        });
+                        let sprite_tx = self.state.sprite_tx.clone();
+                        let path_for_sprite = path.clone();
+                        tokio::task::spawn_blocking(move || {
+                            if let Some((w, h, rgba)) =
+                                sprite::generate_sprite_sheet(&path_for_sprite, 10, 5)
+                            {
+                                let _ = sprite_tx.send((clip_idx, w, h, rgba));
+                            }
                         });
                     }
                     let silence_tx = self.state.silence_tx.clone();
@@ -212,6 +223,21 @@ impl eframe::App for AvioEditorApp {
         while let Ok((idx, waveform)) = self.state.waveform_rx.try_recv() {
             if let Some(clip) = self.state.clips.get_mut(idx) {
                 clip.waveform = waveform;
+            }
+        }
+        while let Ok((idx, w, h, rgba)) = self.state.sprite_rx.try_recv() {
+            let image = egui::ColorImage::from_rgba_unmultiplied([w as usize, h as usize], &rgba);
+            let texture =
+                ctx.load_texture(format!("sprite_{idx}"), image, egui::TextureOptions::LINEAR);
+            if let Some(clip) = self.state.clips.get_mut(idx) {
+                let dur = clip.info.duration();
+                clip.sprite_sheet = Some(state::SpriteSheetData {
+                    texture,
+                    columns: 10,
+                    rows: 5,
+                    frame_count: 50,
+                    clip_duration: dur,
+                });
             }
         }
         while let Ok((path, w, h, rgb)) = self.state.thumbnail_rx.try_recv() {
@@ -446,6 +472,37 @@ impl eframe::App for AvioEditorApp {
                                                     }
                                                 }
                                             }
+                                            // Sprite frame tooltip on hover
+                                            let clip_resp =
+                                                ui.allocate_rect(cr, egui::Sense::hover());
+                                            if clip_resp.hovered()
+                                                && let Some(ss) = &source.sprite_sheet
+                                                && let Some(ptr) =
+                                                    ui.input(|i| i.pointer.latest_pos())
+                                            {
+                                                let offset_secs =
+                                                    ((ptr.x - cr.left()) / pps).max(0.0) as f64;
+                                                let hover_ts = Duration::from_secs_f64(offset_secs);
+                                                let uv = ss.sprite_uv(hover_ts);
+                                                egui::Tooltip::always_open(
+                                                    ui.ctx().clone(),
+                                                    ui.layer_id(),
+                                                    egui::Id::new("sprite_tip"),
+                                                    egui::PopupAnchor::Pointer,
+                                                )
+                                                .gap(12.0)
+                                                .show(|ui| {
+                                                    ui.add(
+                                                        egui::Image::new(
+                                                            egui::load::SizedTexture::new(
+                                                                ss.texture.id(),
+                                                                egui::vec2(160.0, 90.0),
+                                                            ),
+                                                        )
+                                                        .uv(uv),
+                                                    );
+                                                });
+                                            }
                                         }
                                     }
                                 }
@@ -513,6 +570,7 @@ impl eframe::App for AvioEditorApp {
                                     scenes: Vec::new(),
                                     silence_regions: Vec::new(),
                                     waveform: Vec::new(),
+                                    sprite_sheet: None,
                                     in_point: None,
                                     out_point: None,
                                 });
@@ -532,6 +590,15 @@ impl eframe::App for AvioEditorApp {
                                     tokio::task::spawn_blocking(move || {
                                         let scenes = analysis::detect_scenes(&path_for_scene);
                                         let _ = scene_tx.send((clip_idx, scenes));
+                                    });
+                                    let sprite_tx = self.state.sprite_tx.clone();
+                                    let path_for_sprite = path.clone();
+                                    tokio::task::spawn_blocking(move || {
+                                        if let Some((w, h, rgba)) =
+                                            sprite::generate_sprite_sheet(&path_for_sprite, 10, 5)
+                                        {
+                                            let _ = sprite_tx.send((clip_idx, w, h, rgba));
+                                        }
                                     });
                                 }
                                 let silence_tx = self.state.silence_tx.clone();

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -1,0 +1,28 @@
+use std::path::Path;
+
+/// Generates a sprite sheet PNG for the given video file.
+///
+/// Writes `{stem}_sprite.png` to the system temp directory, then loads it
+/// back as RGBA bytes ready for egui texture upload.
+///
+/// Returns `None` if generation fails or the PNG cannot be loaded.
+pub fn generate_sprite_sheet(path: &Path, cols: u32, rows: u32) -> Option<(u32, u32, Vec<u8>)> {
+    let stem = path.file_stem()?.to_string_lossy().into_owned();
+    let out_path = std::env::temp_dir().join(format!("{stem}_sprite.png"));
+
+    avio::SpriteSheet::new(path)
+        .cols(cols)
+        .rows(rows)
+        .output(&out_path)
+        .run()
+        .map_err(|e| log::warn!("sprite sheet generation failed for {path:?}: {e}"))
+        .ok()?;
+
+    let img = image::open(&out_path)
+        .map_err(|e| log::warn!("sprite sheet PNG load failed for {out_path:?}: {e}"))
+        .ok()?;
+
+    let rgba = img.to_rgba8();
+    let (w, h) = rgba.dimensions();
+    Some((w, h, rgba.into_raw()))
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -16,6 +16,8 @@ pub struct AppState {
     pub silence_rx: mpsc::Receiver<(usize, Vec<(Duration, Duration)>)>,
     pub waveform_tx: mpsc::SyncSender<(usize, Vec<f32>)>,
     pub waveform_rx: mpsc::Receiver<(usize, Vec<f32>)>,
+    pub sprite_tx: mpsc::SyncSender<(usize, u32, u32, Vec<u8>)>,
+    pub sprite_rx: mpsc::Receiver<(usize, u32, u32, Vec<u8>)>,
     pub timeline: TimelineState,
     pub trim_jobs: Vec<TrimJobHandle>,
     pub gif_jobs: Vec<GifJobHandle>,
@@ -44,6 +46,7 @@ impl Default for AppState {
         let (keyframe_tx, keyframe_rx) = mpsc::sync_channel(4);
         let (silence_tx, silence_rx) = mpsc::sync_channel(32);
         let (waveform_tx, waveform_rx) = mpsc::sync_channel(32);
+        let (sprite_tx, sprite_rx) = mpsc::sync_channel(4);
         Self {
             clips: Vec::new(),
             selected_clip_index: None,
@@ -57,6 +60,8 @@ impl Default for AppState {
             silence_rx,
             waveform_tx,
             waveform_rx,
+            sprite_tx,
+            sprite_rx,
             timeline: TimelineState::default(),
             trim_jobs: Vec::new(),
             gif_jobs: Vec::new(),
@@ -80,6 +85,32 @@ impl Default for AppState {
     }
 }
 
+pub struct SpriteSheetData {
+    pub texture: egui::TextureHandle,
+    pub columns: usize,
+    pub rows: usize,
+    pub frame_count: usize,
+    pub clip_duration: std::time::Duration,
+}
+
+impl SpriteSheetData {
+    /// Returns the UV rect selecting the sprite frame at the given timestamp.
+    pub fn sprite_uv(&self, at: std::time::Duration) -> egui::Rect {
+        let dur = self.clip_duration.as_secs_f64();
+        let frame_idx = if dur > 0.0 {
+            ((at.as_secs_f64() / dur) * self.frame_count as f64) as usize
+        } else {
+            0
+        };
+        let frame_idx = frame_idx.min(self.frame_count - 1);
+        let col = frame_idx % self.columns;
+        let row = frame_idx / self.columns;
+        let w = 1.0 / self.columns as f32;
+        let h = 1.0 / self.rows as f32;
+        egui::Rect::from_min_size(egui::pos2(col as f32 * w, row as f32 * h), egui::vec2(w, h))
+    }
+}
+
 #[allow(dead_code)]
 pub struct ImportedClip {
     pub path: PathBuf,
@@ -89,6 +120,7 @@ pub struct ImportedClip {
     pub scenes: Vec<Duration>,
     pub silence_regions: Vec<(Duration, Duration)>,
     pub waveform: Vec<f32>,
+    pub sprite_sheet: Option<SpriteSheetData>,
     pub in_point: Option<Duration>,
     pub out_point: Option<Duration>,
 }


### PR DESCRIPTION
## Summary

Generates a 10×5 sprite sheet (50 frames) for each imported video clip using `avio::SpriteSheet` and displays the frame at the cursor position as a tooltip when the user hovers over a clip rectangle on the timeline. This validates the `SpriteSheet` API and provides frame-accurate scrub previews without requiring a running `PreviewPlayer`.

## Changes

- `Cargo.toml`: added `image = { version = "0.25", … features = ["png"] }` to load the sprite sheet PNG written to disk by `avio::SpriteSheet`
- `src/sprite.rs`: new module — `generate_sprite_sheet()` runs `avio::SpriteSheet::new().cols().rows().output().run()`, then loads the PNG via the `image` crate and returns raw RGBA bytes
- `src/state.rs`: added `SpriteSheetData` struct with `sprite_uv()` UV-rect helper; added `sprite_sheet: Option<SpriteSheetData>` field to `ImportedClip`; added `sprite_tx/rx` channel to `AppState`
- `src/main.rs`: spawn sprite generation on import (video clips only, both regular and trim-done paths); drain `sprite_rx` per frame to upload the texture; show `egui::Tooltip` with the correct UV sub-image on clip hover

## Related Issues

Closes #28

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes