### PR TITLE
feat(export): render timeline to MP4 with animated progress bar

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,65 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::state::{ExportHandle, ExportStatus};
+
+/// Send-safe snapshot of a single V1 clip, constructed on the main thread
+/// before handing off to `spawn_blocking`.
+pub struct ClipSnapshot {
+    pub path: PathBuf,
+    pub start_on_track: Duration,
+    pub in_point: Option<Duration>,
+    pub out_point: Option<Duration>,
+}
+
+/// Spawns a background task that builds an `avio::Timeline` from the given V1
+/// clips and calls `Timeline::render()`. Returns an `ExportHandle` whose
+/// `status` field can be polled from the render loop.
+pub fn spawn_export(clips: Vec<ClipSnapshot>, output_path: PathBuf) -> ExportHandle {
+    let status = Arc::new(Mutex::new(ExportStatus::Running));
+    let status_clone = Arc::clone(&status);
+    let output_clone = output_path.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let result = build_and_render(clips, &output_clone);
+        if let Ok(mut guard) = status_clone.lock() {
+            *guard = match result {
+                Ok(()) => ExportStatus::Done(output_clone),
+                Err(e) => ExportStatus::Failed(e),
+            };
+        }
+    });
+
+    ExportHandle { status }
+}
+
+fn build_and_render(clips: Vec<ClipSnapshot>, output: &std::path::Path) -> Result<(), String> {
+    let video_clips: Vec<avio::Clip> = clips
+        .into_iter()
+        .map(|c| {
+            let clip = avio::Clip::new(&c.path).offset(c.start_on_track);
+            match (c.in_point, c.out_point) {
+                (Some(in_pt), Some(out_pt)) => clip.trim(in_pt, out_pt),
+                _ => clip,
+            }
+        })
+        .collect();
+
+    if video_clips.is_empty() {
+        return Err("V1 track has no clips to export".to_string());
+    }
+
+    // avio API gap: Timeline::render() has no progress callback.
+    // The real Progress/ProgressCallback types exist in ff-pipeline but are
+    // wired only into Pipeline (single-file transcode), not Timeline.
+    // Progress percentage is therefore unavailable; the UI shows an indeterminate bar.
+    let config = avio::EncoderConfig::builder().build();
+    let timeline = avio::Timeline::builder()
+        .video_track(video_clips)
+        .build()
+        .map_err(|e| e.to_string())?;
+    timeline.render(output, config).map_err(|e| e.to_string())?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod analysis;
+mod export;
 mod gif;
 mod player;
 mod proxy;
@@ -267,7 +268,71 @@ impl eframe::App for AvioEditorApp {
             .resizable(true)
             .default_height(200.0)
             .show(ctx, |ui| {
-                ui.heading("Timeline");
+                // Header: "Timeline" heading + Export button aligned right
+                let mut clear_export = false;
+                ui.horizontal(|ui| {
+                    ui.heading("Timeline");
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        let v1_empty = self.state.timeline.tracks[0].clips.is_empty();
+                        let is_running = self.state.export.as_ref().is_some_and(|h| {
+                            matches!(*h.status.lock().unwrap(), state::ExportStatus::Running)
+                        });
+                        if ui
+                            .add_enabled(!v1_empty && !is_running, egui::Button::new("Export"))
+                            .clicked()
+                            && let Some(output_path) = rfd::FileDialog::new()
+                                .add_filter("MP4", &["mp4"])
+                                .set_file_name("export.mp4")
+                                .save_file()
+                        {
+                            let clips: Vec<export::ClipSnapshot> = self.state.timeline.tracks[0]
+                                .clips
+                                .iter()
+                                .map(|tc| export::ClipSnapshot {
+                                    path: self.state.clips[tc.source_index].path.clone(),
+                                    start_on_track: tc.start_on_track,
+                                    in_point: tc.in_point,
+                                    out_point: tc.out_point,
+                                })
+                                .collect();
+                            self.state.export = Some(export::spawn_export(clips, output_path));
+                        }
+                    });
+                });
+                // Export status row (shown while running or after completion)
+                if let Some(handle) = &self.state.export {
+                    let status = handle.status.lock().unwrap().clone();
+                    match status {
+                        state::ExportStatus::Running => {
+                            ui.add(egui::ProgressBar::new(0.0).animate(true).text("Exporting…"));
+                        }
+                        state::ExportStatus::Done(path) => {
+                            ui.horizontal(|ui| {
+                                ui.colored_label(
+                                    egui::Color32::GREEN,
+                                    format!("Exported: {}", path.display()),
+                                );
+                                if ui.button("Clear").clicked() {
+                                    clear_export = true;
+                                }
+                            });
+                        }
+                        state::ExportStatus::Failed(msg) => {
+                            ui.horizontal(|ui| {
+                                ui.colored_label(
+                                    egui::Color32::RED,
+                                    format!("Export failed: {msg}"),
+                                );
+                                if ui.button("Dismiss").clicked() {
+                                    clear_export = true;
+                                }
+                            });
+                        }
+                    }
+                }
+                if clear_export {
+                    self.state.export = None;
+                }
                 ui.separator();
 
                 const TRACK_HEIGHT: f32 = 40.0;

--- a/src/state.rs
+++ b/src/state.rs
@@ -37,6 +37,7 @@ pub struct AppState {
     pub playback_rate: f64,
     pub rate_handle: Arc<AtomicU64>,
     pub av_offset_ms: i32,
+    pub export: Option<ExportHandle>,
 }
 
 impl Default for AppState {
@@ -81,6 +82,7 @@ impl Default for AppState {
             playback_rate: 1.0,
             rate_handle: Arc::new(AtomicU64::new(1.0_f64.to_bits())),
             av_offset_ms: 0,
+            export: None,
         }
     }
 }
@@ -162,6 +164,17 @@ pub enum ProxyStatus {
 pub struct ProxyJobHandle {
     pub clip_index: usize,
     pub status: Arc<Mutex<ProxyStatus>>,
+}
+
+#[derive(Clone, PartialEq)]
+pub enum ExportStatus {
+    Running,
+    Done(PathBuf),
+    Failed(String),
+}
+
+pub struct ExportHandle {
+    pub status: Arc<Mutex<ExportStatus>>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

Adds an Export button to the Timeline panel header that builds an `avio::Timeline` from
all V1 clips and calls `Timeline::render()` in a `spawn_blocking` background task.
An animated indeterminate progress bar is shown while the render runs; on completion
the output path is shown in green with a Clear button, or an error message in red with
a Dismiss button.

## Changes

- `src/export.rs` (new): `ClipSnapshot` struct, `spawn_export()` that drives the background task, `build_and_render()` that constructs the `avio::Timeline` and calls `render()`
- `src/state.rs`: added `ExportStatus` enum, `ExportHandle` struct, and `export: Option<ExportHandle>` field on `AppState`
- `src/main.rs`: replaced the plain `ui.heading("Timeline")` line with a horizontal header row containing the Export button (disabled when V1 is empty or a render is already running) plus an export-status row below it

Note: `Timeline::render()` has no progress callback in the current avio API, so the
progress bar is indeterminate. This gap is tracked in `docs/issue10.md`.

## Images
### Exported
<img width="1153" height="875" alt="asis" src="https://github.com/user-attachments/assets/ec9bac2a-ffdb-4507-a12c-ea55c978c571" />

### Original
<img width="1152" height="877" alt="tobe" src="https://github.com/user-attachments/assets/c75d92f3-f86c-45dc-9f39-83458eb1f7e2" />
Some bugs in Format conversion.

## Related Issues

Closes #9

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes