### PR TITLE
feat(export): full multi-track render (V1 + V2 overlay + A1 audio)

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -4,25 +4,32 @@ use std::time::Duration;
 
 use crate::state::{ExportHandle, ExportStatus};
 
-/// Send-safe snapshot of a single V1 clip, constructed on the main thread
-/// before handing off to `spawn_blocking`.
-pub struct ClipSnapshot {
+/// Send-safe snapshot of a single clip on any track.
+pub struct ExportClip {
     pub path: PathBuf,
     pub start_on_track: Duration,
     pub in_point: Option<Duration>,
     pub out_point: Option<Duration>,
 }
 
-/// Spawns a background task that builds an `avio::Timeline` from the given V1
-/// clips and calls `Timeline::render()`. Returns an `ExportHandle` whose
-/// `status` field can be polled from the render loop.
-pub fn spawn_export(clips: Vec<ClipSnapshot>, output_path: PathBuf) -> ExportHandle {
+/// Send-safe snapshot of all timeline tracks, constructed on the main thread
+/// before handing off to `spawn_blocking`.
+pub struct ExportSnapshot {
+    pub v1_clips: Vec<ExportClip>,
+    pub v2_clips: Vec<ExportClip>,
+    pub a1_clips: Vec<ExportClip>,
+}
+
+/// Spawns a background task that builds an `avio::Timeline` from the snapshot
+/// and calls `Timeline::render()`. Returns an `ExportHandle` whose `status`
+/// field can be polled from the render loop.
+pub fn spawn_export(snapshot: ExportSnapshot, output_path: PathBuf) -> ExportHandle {
     let status = Arc::new(Mutex::new(ExportStatus::Running));
     let status_clone = Arc::clone(&status);
     let output_clone = output_path.clone();
 
     tokio::task::spawn_blocking(move || {
-        let result = build_and_render(clips, &output_clone);
+        let result = build_and_render(snapshot, &output_clone);
         if let Ok(mut guard) = status_clone.lock() {
             *guard = match result {
                 Ok(()) => ExportStatus::Done(output_clone),
@@ -34,8 +41,8 @@ pub fn spawn_export(clips: Vec<ClipSnapshot>, output_path: PathBuf) -> ExportHan
     ExportHandle { status }
 }
 
-fn build_and_render(clips: Vec<ClipSnapshot>, output: &std::path::Path) -> Result<(), String> {
-    let video_clips: Vec<avio::Clip> = clips
+fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
+    clips
         .into_iter()
         .map(|c| {
             let clip = avio::Clip::new(&c.path).offset(c.start_on_track);
@@ -44,9 +51,15 @@ fn build_and_render(clips: Vec<ClipSnapshot>, output: &std::path::Path) -> Resul
                 _ => clip,
             }
         })
-        .collect();
+        .collect()
+}
 
-    if video_clips.is_empty() {
+fn build_and_render(snapshot: ExportSnapshot, output: &std::path::Path) -> Result<(), String> {
+    let v1 = clips_to_avio(snapshot.v1_clips);
+    let v2 = clips_to_avio(snapshot.v2_clips);
+    let a1 = clips_to_avio(snapshot.a1_clips);
+
+    if v1.is_empty() {
         return Err("V1 track has no clips to export".to_string());
     }
 
@@ -55,10 +68,19 @@ fn build_and_render(clips: Vec<ClipSnapshot>, output: &std::path::Path) -> Resul
     // wired only into Pipeline (single-file transcode), not Timeline.
     // Progress percentage is therefore unavailable; the UI shows an indeterminate bar.
     let config = avio::EncoderConfig::builder().build();
-    let timeline = avio::Timeline::builder()
-        .video_track(video_clips)
-        .build()
-        .map_err(|e| e.to_string())?;
+    let mut builder = avio::Timeline::builder().video_track(v1);
+
+    // V2: second video_track() call composites over V1 as an overlay layer.
+    if !v2.is_empty() {
+        builder = builder.video_track(v2);
+    }
+
+    // A1: audio mix track.
+    if !a1.is_empty() {
+        builder = builder.audio_track(a1);
+    }
+
+    let timeline = builder.build().map_err(|e| e.to_string())?;
     timeline.render(output, config).map_err(|e| e.to_string())?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,17 +285,30 @@ impl eframe::App for AvioEditorApp {
                                 .set_file_name("export.mp4")
                                 .save_file()
                         {
-                            let clips: Vec<export::ClipSnapshot> = self.state.timeline.tracks[0]
-                                .clips
-                                .iter()
-                                .map(|tc| export::ClipSnapshot {
-                                    path: self.state.clips[tc.source_index].path.clone(),
-                                    start_on_track: tc.start_on_track,
-                                    in_point: tc.in_point,
-                                    out_point: tc.out_point,
-                                })
-                                .collect();
-                            self.state.export = Some(export::spawn_export(clips, output_path));
+                            let make_clip = |tc: &state::TimelineClip| export::ExportClip {
+                                path: self.state.clips[tc.source_index].path.clone(),
+                                start_on_track: tc.start_on_track,
+                                in_point: tc.in_point,
+                                out_point: tc.out_point,
+                            };
+                            let snapshot = export::ExportSnapshot {
+                                v1_clips: self.state.timeline.tracks[0]
+                                    .clips
+                                    .iter()
+                                    .map(make_clip)
+                                    .collect(),
+                                v2_clips: self.state.timeline.tracks[1]
+                                    .clips
+                                    .iter()
+                                    .map(make_clip)
+                                    .collect(),
+                                a1_clips: self.state.timeline.tracks[2]
+                                    .clips
+                                    .iter()
+                                    .map(make_clip)
+                                    .collect(),
+                            };
+                            self.state.export = Some(export::spawn_export(snapshot, output_path));
                         }
                     });
                 });


### PR DESCRIPTION
## Summary

Extends the V1-only export from issue #9 to a full multi-track render. V2 clips are
composited as an overlay layer over V1, and A1 clips are mixed as an audio track.
Empty V2 and A1 tracks are silently skipped, so existing V1-only exports are unaffected.

## Changes

- `src/export.rs`: renamed `ClipSnapshot` → `ExportClip`; added `ExportSnapshot { v1_clips, v2_clips, a1_clips }`; updated `spawn_export` to accept `ExportSnapshot`; `build_and_render` now calls `.video_track(v2)` and `.audio_track(a1)` when those tracks are non-empty — second `.video_track()` call composites V2 as an overlay layer over V1 per the `ff-pipeline::Timeline` API
- `src/main.rs`: Export button handler now collects all three tracks into `ExportSnapshot` before calling `spawn_export`

## Related Issues

Closes #25

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes