### PR TITLE
feat(export): encoder settings UI and Save/Load preset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,8 @@ dependencies = [
  "image",
  "log",
  "rfd",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,6 @@ rfd        = "0.17.2"
 tokio      = { version = "1.51.1", features = ["full"] }
 log        = "0.4.29"
 env_logger = "0.11.10"
-image     = { version = "0.25.10", default-features = false, features = ["png"] }
+image      = { version = "0.25.10", default-features = false, features = ["png"] }
+serde      = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"

--- a/src/export.rs
+++ b/src/export.rs
@@ -18,6 +18,7 @@ pub struct ExportSnapshot {
     pub v1_clips: Vec<ExportClip>,
     pub v2_clips: Vec<ExportClip>,
     pub a1_clips: Vec<ExportClip>,
+    pub encoder_config: crate::state::EncoderConfigDraft,
 }
 
 /// Spawns a background task that builds an `avio::Timeline` from the snapshot
@@ -67,7 +68,7 @@ fn build_and_render(snapshot: ExportSnapshot, output: &std::path::Path) -> Resul
     // The real Progress/ProgressCallback types exist in ff-pipeline but are
     // wired only into Pipeline (single-file transcode), not Timeline.
     // Progress percentage is therefore unavailable; the UI shows an indeterminate bar.
-    let config = avio::EncoderConfig::builder().build();
+    let config = snapshot.encoder_config.to_encoder_config();
     let mut builder = avio::Timeline::builder().video_track(v1);
 
     // V2: second video_track() call composites over V1 as an overlay layer.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,51 @@ use std::time::Duration;
 
 use state::{AppState, GifStatus, ImportedClip, ProxyStatus, TrimStatus};
 
+// avio API gap: ExportPreset / EncoderConfig have no serde support, and
+// VideoCodec / AudioCodec have no serde derives. We serialize our own
+// EncoderConfigDraft as a plain JSON file. See docs/issue13.md.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PresetFile {
+    video_codec: String,
+    audio_codec: String,
+    crf: u32,
+}
+
+impl PresetFile {
+    fn from_draft(d: &state::EncoderConfigDraft) -> Self {
+        Self {
+            video_codec: d.video_codec.name().to_owned(),
+            audio_codec: d.audio_codec.name().to_owned(),
+            crf: d.crf,
+        }
+    }
+
+    fn to_draft(&self) -> state::EncoderConfigDraft {
+        state::EncoderConfigDraft {
+            video_codec: match self.video_codec.as_str() {
+                "h264" => avio::VideoCodec::H264,
+                "hevc" => avio::VideoCodec::H265,
+                "vp9" => avio::VideoCodec::Vp9,
+                "vp8" => avio::VideoCodec::Vp8,
+                "av1" => avio::VideoCodec::Av1,
+                "prores" => avio::VideoCodec::ProRes,
+                "dnxhd" => avio::VideoCodec::DnxHd,
+                _ => avio::VideoCodec::H264,
+            },
+            audio_codec: match self.audio_codec.as_str() {
+                "aac" => avio::AudioCodec::Aac,
+                "mp3" => avio::AudioCodec::Mp3,
+                "opus" => avio::AudioCodec::Opus,
+                "flac" => avio::AudioCodec::Flac,
+                "vorbis" => avio::AudioCodec::Vorbis,
+                "ac3" => avio::AudioCodec::Ac3,
+                _ => avio::AudioCodec::Aac,
+            },
+            crf: self.crf,
+        }
+    }
+}
+
 fn snap_to_nearest_keyframe(
     target_secs: f64,
     keyframes: &[std::time::Duration],
@@ -307,10 +352,85 @@ impl eframe::App for AvioEditorApp {
                                     .iter()
                                     .map(make_clip)
                                     .collect(),
+                                encoder_config: self.state.encoder_config.clone(),
                             };
                             self.state.export = Some(export::spawn_export(snapshot, output_path));
                         }
                     });
+                });
+                // Encoder settings row: codec selectors, CRF, Save/Load preset
+                ui.horizontal(|ui| {
+                    ui.label("Video:");
+                    egui::ComboBox::from_id_salt("vcod")
+                        .selected_text(self.state.encoder_config.video_codec.display_name())
+                        .show_ui(ui, |ui| {
+                            for codec in [
+                                avio::VideoCodec::H264,
+                                avio::VideoCodec::H265,
+                                avio::VideoCodec::Vp9,
+                                avio::VideoCodec::Av1,
+                                avio::VideoCodec::ProRes,
+                            ] {
+                                ui.selectable_value(
+                                    &mut self.state.encoder_config.video_codec,
+                                    codec,
+                                    codec.display_name(),
+                                );
+                            }
+                        });
+                    ui.label("Audio:");
+                    egui::ComboBox::from_id_salt("acod")
+                        .selected_text(self.state.encoder_config.audio_codec.display_name())
+                        .show_ui(ui, |ui| {
+                            for codec in [
+                                avio::AudioCodec::Aac,
+                                avio::AudioCodec::Mp3,
+                                avio::AudioCodec::Opus,
+                                avio::AudioCodec::Flac,
+                            ] {
+                                ui.selectable_value(
+                                    &mut self.state.encoder_config.audio_codec,
+                                    codec,
+                                    codec.display_name(),
+                                );
+                            }
+                        });
+                    ui.label("CRF:");
+                    ui.add(egui::Slider::new(
+                        &mut self.state.encoder_config.crf,
+                        0..=51,
+                    ));
+                    if ui.button("Save Preset…").clicked()
+                        && let Some(path) = rfd::FileDialog::new()
+                            .add_filter("Export Preset", &["json"])
+                            .set_file_name("preset.json")
+                            .save_file()
+                    {
+                        let pf = PresetFile::from_draft(&self.state.encoder_config);
+                        match std::fs::File::create(&path)
+                            .map_err(|e| e.to_string())
+                            .and_then(|f| {
+                                serde_json::to_writer_pretty(f, &pf).map_err(|e| e.to_string())
+                            }) {
+                            Ok(()) => {}
+                            Err(e) => log::warn!("save preset failed: {e}"),
+                        }
+                    }
+                    if ui.button("Load Preset…").clicked()
+                        && let Some(path) = rfd::FileDialog::new()
+                            .add_filter("Export Preset", &["json"])
+                            .pick_file()
+                    {
+                        match std::fs::File::open(&path)
+                            .map_err(|e| e.to_string())
+                            .and_then(|f| {
+                                serde_json::from_reader::<_, PresetFile>(f)
+                                    .map_err(|e| e.to_string())
+                            }) {
+                            Ok(pf) => self.state.encoder_config = pf.to_draft(),
+                            Err(e) => log::warn!("load preset failed: {e}"),
+                        }
+                    }
                 });
                 // Export status row (shown while running or after completion)
                 if let Some(handle) = &self.state.export {

--- a/src/state.rs
+++ b/src/state.rs
@@ -38,6 +38,7 @@ pub struct AppState {
     pub rate_handle: Arc<AtomicU64>,
     pub av_offset_ms: i32,
     pub export: Option<ExportHandle>,
+    pub encoder_config: EncoderConfigDraft,
 }
 
 impl Default for AppState {
@@ -83,6 +84,7 @@ impl Default for AppState {
             rate_handle: Arc::new(AtomicU64::new(1.0_f64.to_bits())),
             av_offset_ms: 0,
             export: None,
+            encoder_config: EncoderConfigDraft::default(),
         }
     }
 }
@@ -175,6 +177,35 @@ pub enum ExportStatus {
 
 pub struct ExportHandle {
     pub status: Arc<Mutex<ExportStatus>>,
+}
+
+/// UI-facing draft of encoder settings, editable in the Export panel.
+#[derive(Clone)]
+pub struct EncoderConfigDraft {
+    pub video_codec: avio::VideoCodec,
+    pub audio_codec: avio::AudioCodec,
+    pub crf: u32,
+}
+
+impl Default for EncoderConfigDraft {
+    fn default() -> Self {
+        Self {
+            video_codec: avio::VideoCodec::H264,
+            audio_codec: avio::AudioCodec::Aac,
+            crf: 23,
+        }
+    }
+}
+
+impl EncoderConfigDraft {
+    /// Converts the draft into an `avio::EncoderConfig` for use in `Timeline::render()`.
+    pub fn to_encoder_config(&self) -> avio::EncoderConfig {
+        avio::EncoderConfig::builder()
+            .video_codec(self.video_codec)
+            .audio_codec(self.audio_codec)
+            .crf(self.crf)
+            .build()
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

Adds an `EncoderConfigDraft` struct (video codec, audio codec, CRF) to `AppState` so
the user can configure encode settings before exporting. The export task now uses these
settings instead of hard-coded defaults. **Save Preset…** and **Load Preset…** buttons
persist and restore the settings as a plain JSON file.

Note: `avio::ExportPreset` has no `save()`/`load()` API and `VideoCodec`/`AudioCodec`
have no serde derives, so the demo implements its own JSON format (`PresetFile`).
This gap is tracked in `docs/issue13.md`.

## Changes

- `Cargo.toml`: added `serde` + `serde_json` dependencies
- `src/state.rs`: added `EncoderConfigDraft` (H264/AAC/CRF 23 defaults) with `to_encoder_config()`; added `encoder_config` field to `AppState`
- `src/export.rs`: added `encoder_config: EncoderConfigDraft` to `ExportSnapshot`; `build_and_render` now uses `snapshot.encoder_config.to_encoder_config()` instead of hard-coded `EncoderConfig::builder().build()`
- `src/main.rs`: added `PresetFile` (serde JSON struct mapping codec names to/from `EncoderConfigDraft`); added encoder settings row in the timeline panel with Video ComboBox, Audio ComboBox, CRF slider, Save Preset…, and Load Preset… buttons

## Related Issues

Closes #30

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes