### PR TITLE
feat(export): add Filters panel with scale and color balance controls

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -19,6 +19,7 @@ pub struct ExportSnapshot {
     pub v2_clips: Vec<ExportClip>,
     pub a1_clips: Vec<ExportClip>,
     pub encoder_config: crate::state::EncoderConfigDraft,
+    pub export_filters: crate::state::ExportFilterDraft,
 }
 
 /// Spawns a background task that builds an `avio::Timeline` from the snapshot
@@ -70,6 +71,19 @@ fn build_and_render(snapshot: ExportSnapshot, output: &std::path::Path) -> Resul
     // Progress percentage is therefore unavailable; the UI shows an indeterminate bar.
     let config = snapshot.encoder_config.to_encoder_config();
     let mut builder = avio::Timeline::builder().video_track(v1);
+
+    // Apply output scale via TimelineBuilder::canvas() when enabled.
+    if snapshot.export_filters.scale_enabled {
+        builder = builder.canvas(
+            snapshot.export_filters.output_width,
+            snapshot.export_filters.output_height,
+        );
+    }
+
+    // avio API gap: TimelineBuilder has no video_filter() or post-processing hook.
+    // FilterGraphBuilder::eq(brightness, contrast, saturation) exists in ff-filter
+    // but cannot be attached to Timeline::render() — see docs/issue13.md.
+    // Color balance settings are stored but not applied during render.
 
     // V2: second video_track() call composites over V1 as an overlay layer.
     if !v2.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -353,6 +353,7 @@ impl eframe::App for AvioEditorApp {
                                     .map(make_clip)
                                     .collect(),
                                 encoder_config: self.state.encoder_config.clone(),
+                                export_filters: self.state.export_filters.clone(),
                             };
                             self.state.export = Some(export::spawn_export(snapshot, output_path));
                         }
@@ -430,6 +431,47 @@ impl eframe::App for AvioEditorApp {
                             Ok(pf) => self.state.encoder_config = pf.to_draft(),
                             Err(e) => log::warn!("load preset failed: {e}"),
                         }
+                    }
+                });
+                // Filters section
+                egui::CollapsingHeader::new("Filters").show(ui, |ui| {
+                    ui.checkbox(&mut self.state.export_filters.scale_enabled, "Scale output");
+                    if self.state.export_filters.scale_enabled {
+                        ui.horizontal(|ui| {
+                            ui.add(
+                                egui::DragValue::new(&mut self.state.export_filters.output_width)
+                                    .prefix("W: ")
+                                    .suffix(" px"),
+                            );
+                            ui.add(
+                                egui::DragValue::new(&mut self.state.export_filters.output_height)
+                                    .prefix("H: ")
+                                    .suffix(" px"),
+                            );
+                        });
+                    }
+                    // avio API gap: color balance cannot be applied to Timeline::render().
+                    // See docs/issue13.md. UI is present for gap documentation purposes.
+                    ui.checkbox(
+                        &mut self.state.export_filters.colorbalance_enabled,
+                        "Color adjust (UI only — avio gap, not applied during render)",
+                    );
+                    if self.state.export_filters.colorbalance_enabled {
+                        ui.add(
+                            egui::Slider::new(
+                                &mut self.state.export_filters.brightness,
+                                -1.0..=1.0,
+                            )
+                            .text("Brightness"),
+                        );
+                        ui.add(
+                            egui::Slider::new(&mut self.state.export_filters.contrast, 0.0..=3.0)
+                                .text("Contrast"),
+                        );
+                        ui.add(
+                            egui::Slider::new(&mut self.state.export_filters.saturation, 0.0..=3.0)
+                                .text("Saturation"),
+                        );
                     }
                 });
                 // Export status row (shown while running or after completion)

--- a/src/state.rs
+++ b/src/state.rs
@@ -39,6 +39,7 @@ pub struct AppState {
     pub av_offset_ms: i32,
     pub export: Option<ExportHandle>,
     pub encoder_config: EncoderConfigDraft,
+    pub export_filters: ExportFilterDraft,
 }
 
 impl Default for AppState {
@@ -85,6 +86,7 @@ impl Default for AppState {
             av_offset_ms: 0,
             export: None,
             encoder_config: EncoderConfigDraft::default(),
+            export_filters: ExportFilterDraft::default(),
         }
     }
 }
@@ -177,6 +179,32 @@ pub enum ExportStatus {
 
 pub struct ExportHandle {
     pub status: Arc<Mutex<ExportStatus>>,
+}
+
+/// UI-facing draft of output filter settings.
+#[derive(Clone)]
+pub struct ExportFilterDraft {
+    pub scale_enabled: bool,
+    pub output_width: u32,
+    pub output_height: u32,
+    pub colorbalance_enabled: bool,
+    pub brightness: f32, // −1.0..=1.0, neutral 0.0
+    pub contrast: f32,   //  0.0..=3.0, neutral 1.0
+    pub saturation: f32, //  0.0..=3.0, neutral 1.0
+}
+
+impl Default for ExportFilterDraft {
+    fn default() -> Self {
+        Self {
+            scale_enabled: false,
+            output_width: 1920,
+            output_height: 1080,
+            colorbalance_enabled: false,
+            brightness: 0.0,
+            contrast: 1.0,
+            saturation: 1.0,
+        }
+    }
 }
 
 /// UI-facing draft of encoder settings, editable in the Export panel.


### PR DESCRIPTION
## Summary

Adds a collapsible **Filters** section to the Export panel, exposing scale and color balance controls. Scale output is wired through `TimelineBuilder::canvas()` and takes effect during render. Color balance (brightness, contrast, saturation) is present as UI but cannot be applied during `Timeline::render()` due to an avio API gap — `TimelineBuilder` has no video filter attachment point.

## Changes

- `src/state.rs`: Added `ExportFilterDraft` struct (scale enabled/width/height, color balance enabled/brightness/contrast/saturation) with `Default` impl; added `export_filters` field to `AppState`
- `src/export.rs`: Added `export_filters` to `ExportSnapshot`; calls `builder.canvas(w, h)` when `scale_enabled`; added avio gap comment for color balance referencing `docs/issue13.md`
- `src/main.rs`: Added `CollapsingHeader("Filters")` with Scale checkbox + W/H `DragValue`, Color adjust checkbox + Brightness/Contrast/Saturation `Slider`s; passes `export_filters` clone in snapshot construction

## Related Issues

Closes #31

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes