### PR TITLE
feat(export): add EBU R128 loudness measurement and normalize toggle

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -20,6 +20,11 @@ pub struct ExportSnapshot {
     pub a1_clips: Vec<ExportClip>,
     pub encoder_config: crate::state::EncoderConfigDraft,
     pub export_filters: crate::state::ExportFilterDraft,
+    #[allow(dead_code)]
+    // stored for UI state; not applied (avio API gap — no audio_filter on TimelineBuilder)
+    pub loudness_normalize: bool,
+    #[allow(dead_code)]
+    pub loudness_target: f64,
 }
 
 /// Spawns a background task that builds an `avio::Timeline` from the snapshot
@@ -84,6 +89,11 @@ fn build_and_render(snapshot: ExportSnapshot, output: &std::path::Path) -> Resul
     // FilterGraphBuilder::eq(brightness, contrast, saturation) exists in ff-filter
     // but cannot be attached to Timeline::render() — see docs/issue13.md.
     // Color balance settings are stored but not applied during render.
+
+    // avio API gap: TimelineBuilder has no audio_filter() method.
+    // FilterGraphBuilder::loudness_normalize() exists in ff-filter but
+    // cannot be attached to Timeline — same gap as color balance (docs/issue13.md).
+    // loudness_normalize is stored but not applied during render.
 
     // V2: second video_track() call composites over V1 as an overlay layer.
     if !v2.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,6 +300,11 @@ impl eframe::App for AvioEditorApp {
             self.state.keyframes = kfs;
         }
 
+        // Drain loudness measurement results.
+        while let Ok(result) = self.state.loudness_rx.try_recv() {
+            self.state.loudness_result = result;
+        }
+
         // 1. Top menu bar (must come before all other panels)
         egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
             egui::MenuBar::new().ui(ui, |ui| {
@@ -354,6 +359,8 @@ impl eframe::App for AvioEditorApp {
                                     .collect(),
                                 encoder_config: self.state.encoder_config.clone(),
                                 export_filters: self.state.export_filters.clone(),
+                                loudness_normalize: self.state.loudness_normalize,
+                                loudness_target: self.state.loudness_target,
                             };
                             self.state.export = Some(export::spawn_export(snapshot, output_path));
                         }
@@ -473,6 +480,47 @@ impl eframe::App for AvioEditorApp {
                                 .text("Saturation"),
                         );
                     }
+                });
+                // Loudness measurement
+                ui.horizontal(|ui| {
+                    let can_measure = !self.state.timeline.tracks[2].clips.is_empty();
+                    if ui
+                        .add_enabled(can_measure, egui::Button::new("Measure Loudness"))
+                        .clicked()
+                        && let Some(tc) = self.state.timeline.tracks[2].clips.first()
+                    {
+                        let path = self.state.clips[tc.source_index].path.clone();
+                        let tx = self.state.loudness_tx.clone();
+                        tokio::task::spawn_blocking(move || {
+                            let result = avio::LoudnessMeter::new(&path).measure().ok().map(|r| {
+                                state::LoudnessResult {
+                                    integrated_lufs: r.integrated_lufs,
+                                    true_peak_dbtp: r.true_peak_dbtp,
+                                    lra: r.lra,
+                                }
+                            });
+                            let _ = tx.send(result);
+                        });
+                    }
+                    if let Some(ref r) = self.state.loudness_result {
+                        ui.label(format!(
+                            "I: {:.1} LUFS  TP: {:.1} dBTP  LRA: {:.1} LU",
+                            r.integrated_lufs, r.true_peak_dbtp, r.lra,
+                        ));
+                    }
+                });
+                // avio API gap: audio_filter() not available on TimelineBuilder (docs/issue13.md).
+                ui.horizontal(|ui| {
+                    ui.checkbox(
+                        &mut self.state.loudness_normalize,
+                        "Normalize to (UI only — avio gap, not applied during render)",
+                    );
+                    ui.add(
+                        egui::DragValue::new(&mut self.state.loudness_target)
+                            .range(-40.0..=-5.0)
+                            .speed(0.5)
+                            .suffix(" LUFS"),
+                    );
                 });
                 // Export status row (shown while running or after completion)
                 if let Some(handle) = &self.state.export {

--- a/src/state.rs
+++ b/src/state.rs
@@ -40,6 +40,11 @@ pub struct AppState {
     pub export: Option<ExportHandle>,
     pub encoder_config: EncoderConfigDraft,
     pub export_filters: ExportFilterDraft,
+    pub loudness_result: Option<LoudnessResult>,
+    pub loudness_normalize: bool,
+    pub loudness_target: f64,
+    pub loudness_tx: mpsc::SyncSender<Option<LoudnessResult>>,
+    pub loudness_rx: mpsc::Receiver<Option<LoudnessResult>>,
 }
 
 impl Default for AppState {
@@ -50,6 +55,7 @@ impl Default for AppState {
         let (silence_tx, silence_rx) = mpsc::sync_channel(32);
         let (waveform_tx, waveform_rx) = mpsc::sync_channel(32);
         let (sprite_tx, sprite_rx) = mpsc::sync_channel(4);
+        let (loudness_tx, loudness_rx) = mpsc::sync_channel(4);
         Self {
             clips: Vec::new(),
             selected_clip_index: None,
@@ -87,6 +93,11 @@ impl Default for AppState {
             export: None,
             encoder_config: EncoderConfigDraft::default(),
             export_filters: ExportFilterDraft::default(),
+            loudness_result: None,
+            loudness_normalize: false,
+            loudness_target: -23.0,
+            loudness_tx,
+            loudness_rx,
         }
     }
 }
@@ -179,6 +190,14 @@ pub enum ExportStatus {
 
 pub struct ExportHandle {
     pub status: Arc<Mutex<ExportStatus>>,
+}
+
+/// EBU R128 loudness measurement result.
+#[derive(Clone)]
+pub struct LoudnessResult {
+    pub integrated_lufs: f32,
+    pub true_peak_dbtp: f32,
+    pub lra: f32,
 }
 
 /// UI-facing draft of output filter settings.


### PR DESCRIPTION
## Summary

Adds a **Measure Loudness** button to the Export panel that runs `avio::LoudnessMeter` on the first A1 clip and displays the result as `I: X LUFS  TP: X dBTP  LRA: X LU`. Also adds a Normalize toggle and target LUFS `DragValue`, which are UI-only due to an avio API gap: `TimelineBuilder` has no `audio_filter()` hook so `FilterGraphBuilder::loudness_normalize()` cannot be applied during `Timeline::render()`.

## Changes

- `src/state.rs`: Added `LoudnessResult` struct (`integrated_lufs`, `true_peak_dbtp`, `lra` as `f32`, matching the actual avio API); added `loudness_result`, `loudness_normalize`, `loudness_target`, and `loudness_tx/rx` channel to `AppState`
- `src/export.rs`: Added `loudness_normalize` and `loudness_target` to `ExportSnapshot` (marked `#[allow(dead_code)]` with gap comment — cannot be wired into render); added avio gap comment for `audio_filter()` absence
- `src/main.rs`: Drain loop for `loudness_rx`; Measure Loudness button (disabled when A1 empty); result label; Normalize checkbox + DragValue (−40..=−5 LUFS)

**avio API gap discovered:** `TimelineBuilder` has no `audio_filter()` method, so `FilterGraphBuilder::loudness_normalize()` cannot be applied to the rendered output — same structural gap as the color balance filter (issue #31).

## Related Issues

Closes #32

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes