### PR TITLE
chore(avio): migrate to 0.13.1 APIs and remove workarounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,9 +468,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avio"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68061573665096492dd8d01b94cbb686861082d0ea5757071184f5d7cf8962d"
+checksum = "25728b9cf0b7db79d867d06d5bdb42ad779a0cb279e7502e8b992b12ed1d0185"
 dependencies = [
  "ff-common",
  "ff-decode",
@@ -1207,18 +1207,18 @@ dependencies = [
 
 [[package]]
 name = "ff-common"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b71c76514cf413521a8c4f227689014dca9cdf48112380f2cdcbaa8d94dfb0"
+checksum = "05168bf7aa0bd5f18bc9a560052c23935bf10dfdcde98db7ba08327a5597687c"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "ff-decode"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f509901a4d29b5063429e47e0eb859c49b6ec50eba65468f30071ed8cfd24fd6"
+checksum = "208c31b978c652e51633e5062040d6e3ee02e0004aa547beb0816bcde2b6d4c0"
 dependencies = [
  "ff-common",
  "ff-format",
@@ -1231,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "ff-encode"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4390ebe663622abd5790974e3df6d27d9a3ea72a92e32e80fb572148eb336114"
+checksum = "a0417ce610fa32671b9b977f2c35880f17540a4c3e5fc4087f73d505e854eb2c"
 dependencies = [
  "ff-format",
  "ff-sys",
@@ -1244,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "ff-filter"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4772ebbda494b42445e2b5f892d55a4adc6b853a81aecd99fa709d23ee282a0e"
+checksum = "96168a7289598ba9ed2125986ceb2a1d188cdc88f04b548fdb9bd1673aceb318"
 dependencies = [
  "ff-common",
  "ff-format",
@@ -1258,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "ff-format"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132298b6f9772b6139c707bb0030c23a687fba6f6f337a75cb3351812a4e95cb"
+checksum = "b906e213d928015762650cb69f1948f69df988d8118b293de66f9a4f2ad24bea"
 dependencies = [
  "ff-common",
  "log",
@@ -1269,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "ff-pipeline"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7981da1a05b37db54e8efb40a775e3043594a9b9c26954f9d389918d57828b0c"
+checksum = "8f3ca41a104437f525c0cbd0480e59ad3ea51f7b94f5277c9ad7311fb7995785"
 dependencies = [
  "ff-common",
  "ff-decode",
@@ -1284,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "ff-preview"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2f08c17faf3402826e55ef2858bd1eaad949ffd9d842a221b6bca8db5a0f6d"
+checksum = "b2899b596b4cde8f98368234eed5aa3ddfe3e5725ddc6899b1214b6696439649"
 dependencies = [
  "ff-decode",
  "ff-encode",
@@ -1302,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "ff-probe"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b144a6464ea23715afa30d355956fb235d8988301c4fdbee0584457e05990248"
+checksum = "c1f648d9aa3579035c18c7be0325538c717e21967db088bf3496bdad5a5cf41e"
 dependencies = [
  "ff-format",
  "ff-sys",
@@ -1314,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "ff-sys"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b447319117ffd0a05cc753d7a53124e9b5d298c7fc08d21c8c8de27a8a54526e"
+checksum = "5ab4398e887edc782ee6bc9f245f21cebbfc58dcb051bd149903b02119888876"
 dependencies = [
  "bindgen",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-avio = { version = "0.13.0", features = [
+avio = { version = "0.13.1", features = [
     "decode",
     "encode",
     "filter",

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -10,6 +11,8 @@ pub struct ExportClip {
     pub start_on_track: Duration,
     pub in_point: Option<Duration>,
     pub out_point: Option<Duration>,
+    pub transition: Option<avio::XfadeTransition>,
+    pub transition_duration: Duration,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -28,15 +31,17 @@ pub struct ExportSnapshot {
 }
 
 /// Spawns a background task that builds an `avio::Timeline` from the snapshot
-/// and calls `Timeline::render()`. Returns an `ExportHandle` whose `status`
-/// field can be polled from the render loop.
+/// and calls `Timeline::render_with_progress()`. Returns an `ExportHandle`
+/// whose `status` and `progress` fields can be polled from the render loop.
 pub fn spawn_export(snapshot: ExportSnapshot, output_path: PathBuf) -> ExportHandle {
     let status = Arc::new(Mutex::new(ExportStatus::Running));
+    let progress = Arc::new(AtomicU32::new(0));
     let status_clone = Arc::clone(&status);
+    let progress_clone = Arc::clone(&progress);
     let output_clone = output_path.clone();
 
     tokio::task::spawn_blocking(move || {
-        let result = build_and_render(snapshot, &output_clone);
+        let result = build_and_render(snapshot, &output_clone, &progress_clone);
         if let Ok(mut guard) = status_clone.lock() {
             *guard = match result {
                 Ok(()) => ExportStatus::Done(output_clone),
@@ -45,7 +50,7 @@ pub fn spawn_export(snapshot: ExportSnapshot, output_path: PathBuf) -> ExportHan
         }
     });
 
-    ExportHandle { status }
+    ExportHandle { status, progress }
 }
 
 fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
@@ -53,15 +58,23 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
         .into_iter()
         .map(|c| {
             let clip = avio::Clip::new(&c.path).offset(c.start_on_track);
-            match (c.in_point, c.out_point) {
+            let clip = match (c.in_point, c.out_point) {
                 (Some(in_pt), Some(out_pt)) => clip.trim(in_pt, out_pt),
                 _ => clip,
+            };
+            match c.transition {
+                Some(kind) => clip.with_transition(kind, c.transition_duration),
+                None => clip,
             }
         })
         .collect()
 }
 
-fn build_and_render(snapshot: ExportSnapshot, output: &std::path::Path) -> Result<(), String> {
+fn build_and_render(
+    snapshot: ExportSnapshot,
+    output: &std::path::Path,
+    progress: &Arc<AtomicU32>,
+) -> Result<(), String> {
     let v1 = clips_to_avio(snapshot.v1_clips);
     let v2 = clips_to_avio(snapshot.v2_clips);
     let a1 = clips_to_avio(snapshot.a1_clips);
@@ -70,14 +83,9 @@ fn build_and_render(snapshot: ExportSnapshot, output: &std::path::Path) -> Resul
         return Err("V1 track has no clips to export".to_string());
     }
 
-    // avio API gap: Timeline::render() has no progress callback.
-    // The real Progress/ProgressCallback types exist in ff-pipeline but are
-    // wired only into Pipeline (single-file transcode), not Timeline.
-    // Progress percentage is therefore unavailable; the UI shows an indeterminate bar.
     let config = snapshot.encoder_config.to_encoder_config();
     let mut builder = avio::Timeline::builder().video_track(v1);
 
-    // Apply output scale via TimelineBuilder::canvas() when enabled.
     if snapshot.export_filters.scale_enabled {
         builder = builder.canvas(
             snapshot.export_filters.output_width,
@@ -95,18 +103,24 @@ fn build_and_render(snapshot: ExportSnapshot, output: &std::path::Path) -> Resul
     // cannot be attached to Timeline — same gap as color balance (docs/issue13.md).
     // loudness_normalize is stored but not applied during render.
 
-    // V2: second video_track() call composites over V1 as an overlay layer.
     if !v2.is_empty() {
         builder = builder.video_track(v2);
     }
-
-    // A1: audio mix track.
     if !a1.is_empty() {
         builder = builder.audio_track(a1);
     }
 
     let timeline = builder.build().map_err(|e| e.to_string())?;
-    timeline.render(output, config).map_err(|e| e.to_string())?;
+
+    let progress_ref = Arc::clone(progress);
+    timeline
+        .render_with_progress(output, config, move |p| {
+            if let Some(pct) = p.percent() {
+                progress_ref.store((pct as f32).to_bits(), Ordering::Relaxed);
+            }
+            true
+        })
+        .map_err(|e| e.to_string())?;
 
     Ok(())
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
@@ -8,28 +8,18 @@ use avio::RgbaFrame;
 // ── TimedRgbaSink ──────────────────────────────────────────────────────────────
 
 /// `FrameSink` implementation that stores the latest RGBA frame and applies
-/// wall-clock pacing.
+/// wall-clock pacing for audio files.
 ///
-/// `PreviewPlayer::run()` paces video against `MasterClock::Audio`, which only
-/// advances when `pop_audio_samples()` is called. Since we have no audio
-/// output wired up, the audio clock never starts and `should_sync()` returns
-/// `false`, causing frames to be delivered as fast as the decoder can produce
-/// them (far above real-time).
+/// `PreviewPlayer::run()` uses `MasterClock::Audio` when the file has an audio
+/// stream, advancing only when `pop_audio_samples()` is called. Since we have
+/// no audio output (cpal not wired), the audio clock never starts and frames
+/// arrive at decoder speed. We compensate with wall-clock pacing here.
 ///
-/// # avio API gap
-/// `pop_audio_samples(&mut self)` takes `&mut self`, making it unreachable
-/// while `run()` holds the same `&mut self` on the player thread. A future
-/// avio issue should change the receiver to `&self` (all internal state it
-/// touches — `AtomicBool`, `AtomicU64`, `Arc<Mutex<…>>` — is already
-/// thread-safe) so that callers can drive audio output from a `cpal` callback
-/// without conflicting with `run()`.
-///
-/// # Workaround
-/// We implement our own A/V sync inside `push_frame`: on the first frame we
-/// record the wall-clock start time and the base PTS. For every subsequent
-/// frame we sleep until `(pts − base_pts)` has elapsed on the wall clock.
-/// This is equivalent to the `MasterClock::System` path that `run()` uses
-/// for video-only files.
+/// For video-only files (`MasterClock::System`) the player already paces via
+/// `Instant`. `TimedRgbaSink` adds the residual delay between the player's 1×
+/// pacing and the target rate, which is zero at 1× and correct at ≤1× rates.
+/// At >1× rates the player's 1× pacing is the bottleneck; callers should also
+/// call `player.set_rate()` to make `MasterClock::System` aware of the rate.
 struct TimedRgbaSink {
     frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
     ctx: egui::Context,
@@ -62,10 +52,9 @@ impl avio::FrameSink for TimedRgbaSink {
     fn push_frame(&mut self, rgba: &[u8], width: u32, height: u32, pts: Duration) {
         let rate = f64::from_bits(self.rate.load(Ordering::Relaxed));
 
-        // Reset the clock reference whenever the rate changes mid-playback.
-        // Without this, `target_wall = video_relative / new_rate` would place
-        // the target in the past for frames after a rate increase, causing
-        // all remaining frames to be delivered at decoder speed (no pacing).
+        // Reset the clock reference whenever the rate changes mid-playback so
+        // that `target_wall = video_relative / new_rate` doesn't over- or
+        // under-sleep relative to the new reference point.
         if (rate - self.last_rate).abs() > f64::EPSILON {
             self.start = None;
             self.last_rate = rate;
@@ -73,17 +62,9 @@ impl avio::FrameSink for TimedRgbaSink {
 
         let (wall_start, pts_base) = self.start.get_or_insert_with(|| (Instant::now(), pts));
 
-        // How far into the clip (from the current reference point) is this frame?
         let video_relative = pts.saturating_sub(*pts_base);
-        // How much wall time has elapsed since the reference point?
         let wall_elapsed = wall_start.elapsed();
 
-        // Target wall time for this frame at the requested rate.
-        // At 2×: target = video_relative / 2  → shorter sleep → faster.
-        // At 0.5×: target = video_relative * 2 → longer sleep  → slower.
-        // Note: dividing `video_relative` (not `ahead`) by rate is required.
-        // Dividing `ahead = video_relative − wall_elapsed` by rate yields
-        // a formula that converges to 1× regardless of the rate setting.
         let target_wall = video_relative.div_f64(rate);
         if let Some(ahead) = target_wall.checked_sub(wall_elapsed)
             && ahead > Duration::from_millis(1)
@@ -101,9 +82,6 @@ impl avio::FrameSink for TimedRgbaSink {
             height,
             pts,
         });
-        // Wake the render loop so egui picks up this frame without waiting for
-        // the next input event. Required at slow rates (0.5×, 0.25×) where the
-        // inter-frame sleep is long enough for eframe to go fully idle.
         self.ctx.request_repaint();
     }
 }
@@ -112,22 +90,11 @@ impl avio::FrameSink for TimedRgbaSink {
 
 /// Spawns a background thread running `PreviewPlayer::run()`.
 ///
-/// Returns (thread handle, receiver for the player's stop handle).
-/// The stop handle is sent from the player thread immediately after
-/// `PreviewPlayer::open()` succeeds and before `run()` blocks, so the UI
-/// thread can receive it via `try_recv` within one or two render frames.
-///
-/// Video pacing is handled by [`TimedRgbaSink`] (wall-clock sync).
-///
-/// # avio API gap — pause
-/// `PreviewPlayer::pause()` takes `&mut self`, making it unreachable while
-/// `run()` blocks the player thread. A future avio issue should add
-/// `pause_handle() -> Arc<AtomicBool>` analogous to `stop_handle()`.
-///
-/// # avio API gap — audio output
-/// Audio samples accumulate in the player's internal ring buffer but we have
-/// no way to drain them from a `cpal` callback while `run()` holds `&mut self`.
-/// See the doc-comment on [`TimedRgbaSink`] for details.
+/// Returns `(thread, stop_rx, proxy_rx, pause_rx, av_offset_rx)`. The last four
+/// are one-shot channels that deliver the player's own atomic handles, sent from
+/// the player thread before `run()` blocks. The UI thread can then toggle pause
+/// or update the A/V offset live without stopping the player.
+#[allow(clippy::type_complexity)]
 pub fn spawn_player(
     path: PathBuf,
     frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
@@ -140,9 +107,14 @@ pub fn spawn_player(
     std::thread::JoinHandle<()>,
     mpsc::Receiver<Arc<AtomicBool>>,
     mpsc::Receiver<bool>,
+    mpsc::Receiver<Arc<AtomicBool>>,
+    mpsc::Receiver<Arc<AtomicI64>>,
 ) {
     let (stop_tx, stop_rx) = mpsc::sync_channel::<Arc<AtomicBool>>(1);
     let (proxy_tx, proxy_rx) = mpsc::sync_channel::<bool>(1);
+    let (pause_tx, pause_rx) = mpsc::sync_channel::<Arc<AtomicBool>>(1);
+    let (av_offset_tx, av_offset_rx) = mpsc::sync_channel::<Arc<AtomicI64>>(1);
+
     let handle = std::thread::spawn(move || {
         let mut player = match avio::PreviewPlayer::open(&path) {
             Ok(p) => p,
@@ -151,24 +123,25 @@ pub fn spawn_player(
                 return;
             }
         };
-        // avio API gap: seek() takes &mut self so it cannot be called while
-        // run() blocks the player thread. We seek before play() here as a
+
+        // seek() still takes &mut self, so we seek before run() as a
         // start-position workaround for scrubbing.
         if let Some(pos) = start_pos
             && let Err(e) = player.seek(pos)
         {
             log::warn!("initial seek to {pos:?} failed: {e}");
         }
-        // Apply A/V offset before play().
-        // avio API gap: set_av_offset(&self) uses AtomicI64 so concurrent
-        // writes are safe, but there is no av_offset_handle() method.
-        // Without a handle the UI thread cannot reach the player while
-        // run() holds &mut self. Workaround: apply the offset on every spawn.
-        player.set_av_offset(av_offset_ms);
 
-        // Activate proxy transparently before play().
-        // use_proxy_if_available() scans proxy_dir for <stem>_half/quarter/eighth.mp4.
-        // Must be called after open() and before play(); calling after play() is a no-op.
+        // Apply the initial A/V offset and rate before run() blocks.
+        player.set_av_offset(av_offset_ms);
+        let initial_rate = f64::from_bits(rate.load(Ordering::Relaxed));
+        player.set_rate(initial_rate);
+
+        // Send all live-control handles back to the UI thread before blocking.
+        let _ = stop_tx.send(player.stop_handle());
+        let _ = pause_tx.send(player.pause_handle());
+        let _ = av_offset_tx.send(player.av_offset_handle());
+
         let proxy_active = if let Some(ref dir) = proxy_dir {
             let active = player.use_proxy_if_available(dir);
             if active {
@@ -183,9 +156,6 @@ pub fn spawn_player(
         };
         let _ = proxy_tx.send(proxy_active);
 
-        // Send the stop handle back before blocking in run().
-        let _ = stop_tx.send(player.stop_handle());
-
         player.set_sink(Box::new(TimedRgbaSink::new(
             frame_handle,
             ctx.clone(),
@@ -195,8 +165,8 @@ pub fn spawn_player(
         if let Err(e) = player.run() {
             log::warn!("PreviewPlayer::run failed: {e}");
         }
-        // Wake the render loop so the UI can update after playback ends.
         ctx.request_repaint();
     });
-    (handle, stop_rx, proxy_rx)
+
+    (handle, stop_rx, proxy_rx, pause_rx, av_offset_rx)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, AtomicU64};
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
 
@@ -27,6 +27,10 @@ pub struct AppState {
     pub player_thread: Option<std::thread::JoinHandle<()>>,
     pub player_stop: Option<Arc<AtomicBool>>,
     pub pending_stop_rx: Option<mpsc::Receiver<Arc<AtomicBool>>>,
+    pub player_pause: Option<Arc<AtomicBool>>,
+    pub pending_pause_rx: Option<mpsc::Receiver<Arc<AtomicBool>>>,
+    pub player_av_offset: Option<Arc<AtomicI64>>,
+    pub pending_av_offset_rx: Option<mpsc::Receiver<Arc<AtomicI64>>>,
     pub monitor_clip_index: Option<usize>,
     pub seek_pos_secs: f64,
     pub seek_exact: bool,
@@ -80,6 +84,10 @@ impl Default for AppState {
             player_thread: None,
             player_stop: None,
             pending_stop_rx: None,
+            player_pause: None,
+            pending_pause_rx: None,
+            player_av_offset: None,
+            pending_av_offset_rx: None,
             monitor_clip_index: None,
             seek_pos_secs: 0.0,
             seek_exact: false,
@@ -190,6 +198,9 @@ pub enum ExportStatus {
 
 pub struct ExportHandle {
     pub status: Arc<Mutex<ExportStatus>>,
+    /// Export progress `0.0..=1.0` stored as `f32::to_bits()`. `0.0` until the
+    /// first progress callback fires.
+    pub progress: Arc<AtomicU32>,
 }
 
 /// EBU R128 loudness measurement result.
@@ -275,8 +286,6 @@ pub struct TimelineClip {
     pub out_point: Option<Duration>,
     /// Transition applied at the start of this clip (between the previous clip and this one).
     /// `None` means a hard cut.
-    /// avio API gap: `ff_pipeline::Clip` has no transition field and `TimelineBuilder` has no
-    /// transition API, so this is stored as metadata only until avio adds export support.
     pub transition: Option<avio::XfadeTransition>,
     /// Duration of the transition. Default: 500 ms.
     pub transition_duration: Duration,

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -149,19 +149,22 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
     }
     if let Some(idx) = dbl_clicked_idx {
         state.selected_clip_index = Some(idx);
-        // Stop any current player.
+        // Stop any current player and clear all player state.
         if let Some(stop) = state.player_stop.take() {
             stop.store(true, std::sync::atomic::Ordering::Release);
         }
         state.player_thread = None;
         state.pending_stop_rx = None;
+        state.pending_proxy_rx = None;
+        state.pending_pause_rx = None;
+        state.pending_av_offset_rx = None;
+        state.player_pause = None;
+        state.player_av_offset = None;
         state.monitor_clip_index = Some(idx);
 
         // Only launch a player if the clip has a video stream.
-        // PreviewPlayer::open() fails for audio-only files because
-        // DecodeBuffer requires a video stream — avio API gap: a
-        // dedicated AudioPlayer (or an audio-only path in
-        // PreviewPlayer) would be needed.
+        // Audio-only files are supported by PreviewPlayer in avio 0.13.1 but we
+        // have no audio output (cpal not wired), so we skip playback for them.
         let has_video = state
             .clips
             .get(idx)
@@ -181,7 +184,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 .get(idx)
                 .and_then(|c| c.path.parent())
                 .map(|p| p.join("proxies"));
-            let (thread, stop_rx, proxy_rx) = player::spawn_player(
+            let (thread, stop_rx, proxy_rx, pause_rx, av_offset_rx) = player::spawn_player(
                 path,
                 Arc::clone(&state.frame_handle),
                 ctx.clone(),
@@ -193,6 +196,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
             state.player_thread = Some(thread);
             state.pending_stop_rx = Some(stop_rx);
             state.pending_proxy_rx = Some(proxy_rx);
+            state.pending_pause_rx = Some(pause_rx);
+            state.pending_av_offset_rx = Some(av_offset_rx);
             state.proxy_active = false;
         }
     }

--- a/src/ui/drain.rs
+++ b/src/ui/drain.rs
@@ -142,14 +142,24 @@ fn drain_player_handles(state: &mut AppState) {
         state.proxy_active = active;
         state.pending_proxy_rx = None;
     }
+    if let Some(rx) = &state.pending_pause_rx
+        && let Ok(pause) = rx.try_recv()
+    {
+        state.player_pause = Some(pause);
+        state.pending_pause_rx = None;
+    }
+    if let Some(rx) = &state.pending_av_offset_rx
+        && let Ok(av_offset) = rx.try_recv()
+    {
+        state.player_av_offset = Some(av_offset);
+        state.pending_av_offset_rx = None;
+    }
 }
 
 fn drain_frame(state: &mut AppState, ctx: &egui::Context) {
     if let Ok(mut guard) = state.frame_handle.try_lock()
         && let Some(frame) = guard.take()
     {
-        // avio API gap: PreviewPlayer has no current_pts() — track pts
-        // from TimedRgbaSink::push_frame() into AppState::current_pts.
         state.current_pts = Some(frame.pts);
         let image = egui::ColorImage::from_rgba_unmultiplied(
             [frame.width as usize, frame.height as usize],

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use crate::{player, state};
@@ -13,13 +14,17 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
     });
     ui.separator();
 
-    let is_playing = state
+    let is_active = state
         .player_thread
         .as_ref()
         .map(|h| !h.is_finished())
         .unwrap_or(false);
+    let is_paused = state
+        .player_pause
+        .as_ref()
+        .map(|h| h.load(Ordering::Relaxed))
+        .unwrap_or(false);
 
-    // Two control rows when a clip is loaded: seek bar + timecode, then buttons.
     let ctrl_height = if state.monitor_clip_index.is_some() {
         128.0
     } else {
@@ -29,7 +34,6 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
     let video_size = egui::vec2(available.x, (available.y - ctrl_height).max(0.0));
 
     if state.monitor_clip_index.is_some() {
-        // Playback mode: show video frame (or "Loading…" while the first frame arrives).
         if let Some(tex) = &state.preview_texture {
             ui.image(egui::load::SizedTexture::new(tex.id(), video_size));
         } else {
@@ -42,7 +46,6 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
     } else if let Some(idx) = state.selected_clip_index
         && let Some(clip) = state.clips.get(idx)
     {
-        // Info mode: show MediaInfo for the selected clip.
         ui.allocate_ui(video_size, |ui| {
             egui::ScrollArea::vertical()
                 .id_salt("probe_info_scroll")
@@ -137,11 +140,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
             .unwrap_or(1.0)
             .max(1.0);
 
-        // Sync slider from current PTS while playing.
-        // avio API gap: PreviewPlayer has no current_pts() method —
-        // we track pts from TimedRgbaSink::push_frame() into
-        // AppState::current_pts.
-        if is_playing && let Some(pts) = state.current_pts {
+        if is_active && let Some(pts) = state.current_pts {
             state.seek_pos_secs = pts.as_secs_f64().min(duration_secs);
         }
 
@@ -150,7 +149,6 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 egui::Slider::new(&mut state.seek_pos_secs, 0.0..=duration_secs).show_value(false),
             );
 
-            // Draw IN (green) and OUT (orange) markers on the seek bar.
             if let Some(clip) = state.clips.get(idx) {
                 let r = slider_resp.rect;
                 if let Some(in_pt) = clip.in_point {
@@ -171,7 +169,6 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 }
             }
 
-            // Draw keyframe tick marks (blue, 4 px tall) above the seek bar.
             {
                 let r = slider_resp.rect;
                 for kf in &state.keyframes {
@@ -184,7 +181,6 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 }
             }
 
-            // Timecode: HH:MM:SS.mmm
             let t = state.seek_pos_secs;
             let h = (t / 3600.0) as u64;
             let m = ((t % 3600.0) / 60.0) as u64;
@@ -192,28 +188,19 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
             let ms = ((t % 1.0) * 1000.0) as u64;
             ui.monospace(format!("{h:02}:{m:02}:{s:02}.{ms:03}"));
 
-            // Seek mode toggle.
-            // avio API gap: DecodeBuffer::seek_coarse() is not exposed at
-            // PreviewPlayer level, so both modes currently use player.seek()
-            // (exact). The toggle is wired for when avio surfaces coarse seek.
+            // seek_coarse() still takes &mut self (same constraint as seek()),
+            // so both modes stop + respawn from the target position. The toggle
+            // decides whether to snap to the nearest keyframe first.
             let mode_label = if state.seek_exact { "Exact" } else { "Coarse" };
             ui.toggle_value(&mut state.seek_exact, mode_label)
                 .on_hover_text("Exact: frame-accurate but slow\nCoarse: nearest keyframe, fast");
 
-            // avio API gap: seek() takes &mut self — cannot call during
-            // run(). Workaround: stop + respawn from the target position.
             if slider_resp.drag_stopped() {
-                // Snap to nearest keyframe in Coarse mode.
                 if !state.seek_exact {
                     state.seek_pos_secs =
                         snap_to_nearest_keyframe(state.seek_pos_secs, &state.keyframes, 0.5);
                 }
-                if let Some(stop) = state.player_stop.take() {
-                    stop.store(true, std::sync::atomic::Ordering::Release);
-                }
-                state.player_thread = None;
-                state.pending_stop_rx = None;
-                state.pending_proxy_rx = None;
+                stop_player(state);
                 let target = Duration::from_secs_f64(state.seek_pos_secs);
                 if let Some(path) = state.clips.get(idx).map(|c| c.path.clone()) {
                     let proxy_dir = state
@@ -221,39 +208,27 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                         .get(idx)
                         .and_then(|c| c.path.parent())
                         .map(|p| p.join("proxies"));
-                    let (thread, stop_rx, proxy_rx) = player::spawn_player(
-                        path,
-                        Arc::clone(&state.frame_handle),
-                        ctx.clone(),
-                        Some(target),
-                        proxy_dir,
-                        Arc::clone(&state.rate_handle),
-                        state.av_offset_ms as i64,
-                    );
-                    state.player_thread = Some(thread);
-                    state.pending_stop_rx = Some(stop_rx);
-                    state.pending_proxy_rx = Some(proxy_rx);
-                    state.proxy_active = false;
+                    spawn_and_store(state, path, ctx, Some(target), proxy_dir);
                 }
             }
         });
     }
 
     ui.horizontal(|ui| {
-        if is_playing {
-            // avio API gap: pause() takes &mut self so it cannot be called
-            // while run() blocks the player thread. Pause stops playback.
-            if ui.button("⏸ Pause").clicked()
-                && let Some(stop) = state.player_stop.take()
+        if is_active {
+            if is_paused {
+                if ui.button("▶ Resume").clicked()
+                    && let Some(pause) = &state.player_pause
+                {
+                    pause.store(false, Ordering::Relaxed);
+                }
+            } else if ui.button("⏸ Pause").clicked()
+                && let Some(pause) = &state.player_pause
             {
-                stop.store(true, std::sync::atomic::Ordering::Release);
-                state.proxy_active = false;
+                pause.store(true, Ordering::Relaxed);
             }
-            if ui.button("⏹ Stop").clicked()
-                && let Some(stop) = state.player_stop.take()
-            {
-                stop.store(true, std::sync::atomic::Ordering::Release);
-                state.proxy_active = false;
+            if ui.button("⏹ Stop").clicked() {
+                stop_player(state);
             }
         } else if let Some(idx) = state.monitor_clip_index {
             let has_video = state
@@ -270,26 +245,12 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                     .get(idx)
                     .and_then(|c| c.path.parent())
                     .map(|p| p.join("proxies"));
-                let (thread, stop_rx, proxy_rx) = player::spawn_player(
-                    path,
-                    Arc::clone(&state.frame_handle),
-                    ctx.clone(),
-                    None,
-                    proxy_dir,
-                    Arc::clone(&state.rate_handle),
-                    state.av_offset_ms as i64,
-                );
-                state.player_thread = Some(thread);
-                state.pending_stop_rx = Some(stop_rx);
-                state.pending_proxy_rx = Some(proxy_rx);
-                state.proxy_active = false;
+                spawn_and_store(state, path, ctx, None, proxy_dir);
             } else if !has_video {
                 ui.label("No video stream");
             }
         }
-        // Rate selector — visible whenever a clip is loaded.
-        // avio API gap: PreviewPlayer has no set_rate() — rate is applied
-        // inside TimedRgbaSink::push_frame by scaling the sleep duration.
+
         if state.monitor_clip_index.is_some() {
             ui.separator();
             for (rate, label) in [(0.25_f64, "0.25×"), (0.5, "0.5×"), (1.0, "1×"), (2.0, "2×")]
@@ -299,21 +260,14 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                     .clicked()
                 {
                     state.playback_rate = rate;
-                    state
-                        .rate_handle
-                        .store(rate.to_bits(), std::sync::atomic::Ordering::Relaxed);
+                    state.rate_handle.store(rate.to_bits(), Ordering::Relaxed);
                 }
             }
         }
     });
 
-    // A/V offset row — visible whenever a clip is loaded.
-    // avio API gap: set_av_offset(&self) uses AtomicI64 (thread-safe)
-    // but there is no av_offset_handle() method analogous to
-    // stop_handle(). Without a handle the UI thread cannot write to
-    // the player while run() holds &mut self on the player thread.
-    // Workaround: stop + respawn at current position on drag release.
-    if let Some(idx) = state.monitor_clip_index {
+    // A/V offset row — live-updates via av_offset_handle (no stop+respawn needed).
+    if state.monitor_clip_index.is_some() {
         ui.horizontal(|ui| {
             ui.label("A/V:");
             let av_resp = ui.add(
@@ -323,65 +277,13 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                     .suffix(" ms"),
             );
             let should_apply = av_resp.drag_stopped() || (!av_resp.dragged() && av_resp.changed());
-            if should_apply && is_playing {
-                if let Some(stop) = state.player_stop.take() {
-                    stop.store(true, std::sync::atomic::Ordering::Release);
-                }
-                state.player_thread = None;
-                state.pending_stop_rx = None;
-                state.pending_proxy_rx = None;
-                let target = Duration::from_secs_f64(state.seek_pos_secs);
-                if let Some(path) = state.clips.get(idx).map(|c| c.path.clone()) {
-                    let proxy_dir = state
-                        .clips
-                        .get(idx)
-                        .and_then(|c| c.path.parent())
-                        .map(|p| p.join("proxies"));
-                    let (thread, stop_rx, proxy_rx) = player::spawn_player(
-                        path,
-                        Arc::clone(&state.frame_handle),
-                        ctx.clone(),
-                        Some(target),
-                        proxy_dir,
-                        Arc::clone(&state.rate_handle),
-                        state.av_offset_ms as i64,
-                    );
-                    state.player_thread = Some(thread);
-                    state.pending_stop_rx = Some(stop_rx);
-                    state.pending_proxy_rx = Some(proxy_rx);
-                    state.proxy_active = false;
-                }
+            if should_apply && let Some(av_offset) = &state.player_av_offset {
+                av_offset.store(state.av_offset_ms as i64, Ordering::Relaxed);
             }
             if ui.small_button("Reset").clicked() {
                 state.av_offset_ms = 0;
-                if is_playing {
-                    if let Some(stop) = state.player_stop.take() {
-                        stop.store(true, std::sync::atomic::Ordering::Release);
-                    }
-                    state.player_thread = None;
-                    state.pending_stop_rx = None;
-                    state.pending_proxy_rx = None;
-                    let target = Duration::from_secs_f64(state.seek_pos_secs);
-                    if let Some(path) = state.clips.get(idx).map(|c| c.path.clone()) {
-                        let proxy_dir = state
-                            .clips
-                            .get(idx)
-                            .and_then(|c| c.path.parent())
-                            .map(|p| p.join("proxies"));
-                        let (thread, stop_rx, proxy_rx) = player::spawn_player(
-                            path,
-                            Arc::clone(&state.frame_handle),
-                            ctx.clone(),
-                            Some(target),
-                            proxy_dir,
-                            Arc::clone(&state.rate_handle),
-                            0_i64,
-                        );
-                        state.player_thread = Some(thread);
-                        state.pending_stop_rx = Some(stop_rx);
-                        state.pending_proxy_rx = Some(proxy_rx);
-                        state.proxy_active = false;
-                    }
+                if let Some(av_offset) = &state.player_av_offset {
+                    av_offset.store(0, Ordering::Relaxed);
                 }
             }
         });
@@ -424,7 +326,6 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                     egui::Color32::from_rgb(255, 140, 0),
                     format!("OUT {out_str}"),
                 );
-                // Warn if in_point ≥ out_point (invalid range).
                 if let (Some(i), Some(o)) = (clip.in_point, clip.out_point)
                     && i >= o
                 {
@@ -433,6 +334,46 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
             }
         });
     }
+}
+
+/// Stops the active player and clears all player-related state.
+fn stop_player(state: &mut state::AppState) {
+    if let Some(stop) = state.player_stop.take() {
+        stop.store(true, Ordering::Release);
+    }
+    state.player_thread = None;
+    state.pending_stop_rx = None;
+    state.pending_proxy_rx = None;
+    state.pending_pause_rx = None;
+    state.pending_av_offset_rx = None;
+    state.player_pause = None;
+    state.player_av_offset = None;
+    state.proxy_active = false;
+}
+
+/// Spawns a new player and stores all resulting handles in `state`.
+fn spawn_and_store(
+    state: &mut state::AppState,
+    path: std::path::PathBuf,
+    ctx: &egui::Context,
+    start_pos: Option<Duration>,
+    proxy_dir: Option<std::path::PathBuf>,
+) {
+    let (thread, stop_rx, proxy_rx, pause_rx, av_offset_rx) = player::spawn_player(
+        path,
+        Arc::clone(&state.frame_handle),
+        ctx.clone(),
+        start_pos,
+        proxy_dir,
+        Arc::clone(&state.rate_handle),
+        state.av_offset_ms as i64,
+    );
+    state.player_thread = Some(thread);
+    state.pending_stop_rx = Some(stop_rx);
+    state.pending_proxy_rx = Some(proxy_rx);
+    state.pending_pause_rx = Some(pause_rx);
+    state.pending_av_offset_rx = Some(av_offset_rx);
+    state.proxy_active = false;
 }
 
 fn snap_to_nearest_keyframe(

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -28,6 +28,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     start_on_track: tc.start_on_track,
                     in_point: tc.in_point,
                     out_point: tc.out_point,
+                    transition: tc.transition,
+                    transition_duration: tc.transition_duration,
                 };
                 let snapshot = export::ExportSnapshot {
                     v1_clips: state.timeline.tracks[0]
@@ -212,7 +214,16 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
         let status = handle.status.lock().unwrap().clone();
         match status {
             state::ExportStatus::Running => {
-                ui.add(egui::ProgressBar::new(0.0).animate(true).text("Exporting…"));
+                let pct =
+                    f32::from_bits(handle.progress.load(std::sync::atomic::Ordering::Relaxed))
+                        / 100.0;
+                let bar = egui::ProgressBar::new(pct).animate(pct == 0.0);
+                let bar = if pct > 0.0 {
+                    bar.text(format!("{:.0}%", pct * 100.0))
+                } else {
+                    bar.text("Exporting…")
+                };
+                ui.add(bar);
             }
             state::ExportStatus::Done(path) => {
                 ui.horizontal(|ui| {


### PR DESCRIPTION
## Summary

Bumps avio to 0.13.1 and adopts the new APIs it exposes, removing the workarounds that were in place for the gaps those APIs resolve. The most visible changes are true pause/resume (no longer stops playback), live A/V offset adjustment (no stop+respawn), real export progress percentage, and transitions that now actually fire during `Timeline::render`.

## Changes

- **`Cargo.toml`**: avio `0.13.0` → `0.13.1`
- **`src/player.rs`**: `spawn_player` now returns `pause_rx` and `av_offset_rx` channels delivering the player's own `Arc<AtomicBool>` / `Arc<AtomicI64>` handles; `player.set_rate()` called before `run()` so `MasterClock::System` respects the initial rate
- **`src/state.rs`**: added `player_pause`, `pending_pause_rx`, `player_av_offset`, `pending_av_offset_rx`; added `progress: Arc<AtomicU32>` to `ExportHandle`; removed stale "avio API gap" comment from `TimelineClip.transition`
- **`src/ui/drain.rs`**: drains the two new handle channels; removed stale `current_pts()` gap comment
- **`src/export.rs`**: `ExportClip` gains `transition`/`transition_duration`; `clips_to_avio` calls `with_transition()`; `build_and_render` uses `render_with_progress()` with real progress reporting
- **`src/ui/timeline.rs`**: `make_clip` passes transition fields; progress bar shows real percentage
- **`src/ui/monitor.rs`**: Pause button truly pauses and shows Resume; A/V offset updates live without stop+respawn; stop sequences clear all new handles; `stop_player`/`spawn_and_store` helpers eliminate four duplicated spawn blocks
- **`src/ui/clip_browser.rs`**: updated spawn call and stop sequence for new handle fields; updated audio-only comment

## Related Issues

N/A — maintenance upgrade triggered by avio 0.13.1 release

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes