### PR TITLE
chore(avio): migrate to 0.14 PlayerHandle API and add A/V sync diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,12 +167,12 @@ dependencies = [
  "android-properties",
  "bitflags 2.11.0",
  "cc",
- "jni",
+ "jni 0.22.4",
  "libc",
  "log",
- "ndk",
+ "ndk 0.9.0",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror 2.0.18",
 ]
@@ -242,7 +264,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -468,9 +490,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avio"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25728b9cf0b7db79d867d06d5bdb42ad779a0cb279e7502e8b992b12ed1d0185"
+version = "0.14.2"
 dependencies = [
  "ff-common",
  "ff-decode",
@@ -487,6 +507,7 @@ name = "avio-editor-demo"
 version = "0.1.0"
 dependencies = [
  "avio",
+ "cpal",
  "eframe",
  "egui",
  "env_logger",
@@ -684,6 +705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +858,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk 0.8.0",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +926,12 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "dispatch"
@@ -1140,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1207,18 +1283,14 @@ dependencies = [
 
 [[package]]
 name = "ff-common"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05168bf7aa0bd5f18bc9a560052c23935bf10dfdcde98db7ba08327a5597687c"
+version = "0.14.2"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "ff-decode"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "208c31b978c652e51633e5062040d6e3ee02e0004aa547beb0816bcde2b6d4c0"
+version = "0.14.2"
 dependencies = [
  "ff-common",
  "ff-format",
@@ -1231,9 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "ff-encode"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0417ce610fa32671b9b977f2c35880f17540a4c3e5fc4087f73d505e854eb2c"
+version = "0.14.2"
 dependencies = [
  "ff-format",
  "ff-sys",
@@ -1244,9 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "ff-filter"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96168a7289598ba9ed2125986ceb2a1d188cdc88f04b548fdb9bd1673aceb318"
+version = "0.14.2"
 dependencies = [
  "ff-common",
  "ff-format",
@@ -1258,9 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "ff-format"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b906e213d928015762650cb69f1948f69df988d8118b293de66f9a4f2ad24bea"
+version = "0.14.2"
 dependencies = [
  "ff-common",
  "log",
@@ -1269,9 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "ff-pipeline"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3ca41a104437f525c0cbd0480e59ad3ea51f7b94f5277c9ad7311fb7995785"
+version = "0.14.2"
 dependencies = [
  "ff-common",
  "ff-decode",
@@ -1284,9 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "ff-preview"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2899b596b4cde8f98368234eed5aa3ddfe3e5725ddc6899b1214b6696439649"
+version = "0.14.2"
 dependencies = [
  "ff-decode",
  "ff-encode",
@@ -1302,9 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "ff-probe"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f648d9aa3579035c18c7be0325538c717e21967db088bf3496bdad5a5cf41e"
+version = "0.14.2"
 dependencies = [
  "ff-format",
  "ff-sys",
@@ -1314,9 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sys"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab4398e887edc782ee6bc9f245f21cebbfc58dcb051bd149903b02119888876"
+version = "0.14.2"
 dependencies = [
  "bindgen",
  "log",
@@ -1912,6 +1970,22 @@ dependencies = [
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -2087,6 +2161,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2282,20 @@ dependencies = [
 
 [[package]]
 name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -2206,7 +2303,7 @@ dependencies = [
  "bitflags 2.11.0",
  "jni-sys 0.3.1",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -2217,6 +2314,15 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
+]
 
 [[package]]
 name = "ndk-sys"
@@ -2241,6 +2347,17 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2554,6 +2671,29 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni 0.21.1",
+ "ndk 0.8.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2990,7 +3130,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3293,7 +3433,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3866,7 +4006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
 dependencies = [
  "core-foundation 0.10.1",
- "jni",
+ "jni 0.22.4",
  "log",
  "ndk-context",
  "objc2 0.6.4",
@@ -3998,7 +4138,7 @@ dependencies = [
  "log",
  "metal",
  "naga",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "objc",
  "once_cell",
  "ordered-float",
@@ -4038,7 +4178,17 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4071,6 +4221,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4178,6 +4338,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
@@ -4215,6 +4384,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4233,20 +4411,26 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4258,28 +4442,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4293,15 +4460,21 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
+name = "windows_aarch64_msvc"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4310,10 +4483,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
+name = "windows_i686_gnu"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4322,22 +4495,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
+name = "windows_i686_msvc"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4346,10 +4513,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
+name = "windows_x86_64_gnu"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4358,10 +4525,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4370,22 +4537,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
+name = "windows_x86_64_msvc"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"
@@ -4409,7 +4570,7 @@ dependencies = [
  "js-sys",
  "libc",
  "memmap2",
- "ndk",
+ "ndk 0.9.0",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-avio = { version = "0.13.1", features = [
+avio = { version = "0.14.1", features = [
     "decode",
     "encode",
     "filter",
@@ -24,3 +24,16 @@ env_logger = "0.11.10"
 image      = { version = "0.25.10", default-features = false, features = ["png"] }
 serde      = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+cpal       = "0.15"
+
+[patch.crates-io]
+avio        = { path = "../avio/crates/avio" }
+ff-preview  = { path = "../avio/crates/ff-preview" }
+ff-pipeline = { path = "../avio/crates/ff-pipeline" }
+ff-filter   = { path = "../avio/crates/ff-filter" }
+ff-decode   = { path = "../avio/crates/ff-decode" }
+ff-encode   = { path = "../avio/crates/ff-encode" }
+ff-format   = { path = "../avio/crates/ff-format" }
+ff-probe    = { path = "../avio/crates/ff-probe" }
+ff-sys      = { path = "../avio/crates/ff-sys" }
+ff-common   = { path = "../avio/crates/ff-common" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ mod trim;
 mod ui;
 
 fn main() -> eframe::Result<()> {
-    env_logger::init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
     let rt = tokio::runtime::Runtime::new().map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
     let _rt_guard = rt.enter();
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,76 +1,53 @@
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
-use avio::RgbaFrame;
+use avio::{PlayerHandle, RgbaFrame};
 
-// ── TimedRgbaSink ──────────────────────────────────────────────────────────────
+// ── EguiFrameSink ─────────────────────────────────────────────────────────────
 
-/// `FrameSink` implementation that stores the latest RGBA frame and applies
-/// wall-clock pacing for audio files.
-///
-/// `PreviewPlayer::run()` uses `MasterClock::Audio` when the file has an audio
-/// stream, advancing only when `pop_audio_samples()` is called. Since we have
-/// no audio output (cpal not wired), the audio clock never starts and frames
-/// arrive at decoder speed. We compensate with wall-clock pacing here.
-///
-/// For video-only files (`MasterClock::System`) the player already paces via
-/// `Instant`. `TimedRgbaSink` adds the residual delay between the player's 1×
-/// pacing and the target rate, which is zero at 1× and correct at ≤1× rates.
-/// At >1× rates the player's 1× pacing is the bottleneck; callers should also
-/// call `player.set_rate()` to make `MasterClock::System` aware of the rate.
-struct TimedRgbaSink {
+/// `FrameSink` that stores the latest RGBA frame and wakes the egui render loop.
+struct EguiFrameSink {
     frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
     ctx: egui::Context,
-    /// `(wall_clock_start, base_pts)` set on the first frame (and reset on rate change).
-    start: Option<(Instant, Duration)>,
-    /// Playback rate as `f64` bits stored atomically. Read each frame.
-    rate: Arc<AtomicU64>,
-    /// Last observed rate. When the rate changes, `start` is reset so the new
-    /// rate is applied from the current position rather than the clip origin.
-    last_rate: f64,
+    /// Stereo frames consumed by the cpal callback (shared with `try_start_audio_output`).
+    audio_frames: Arc<AtomicU64>,
+    frame_count: u64,
+    /// Wall-clock time of first frame, used to measure audio advancement rate.
+    start_time: Option<Instant>,
 }
 
-impl TimedRgbaSink {
-    fn new(
-        frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
-        ctx: egui::Context,
-        rate: Arc<AtomicU64>,
-    ) -> Self {
-        Self {
-            frame_handle,
-            ctx,
-            start: None,
-            rate,
-            last_rate: 1.0,
-        }
-    }
-}
-
-impl avio::FrameSink for TimedRgbaSink {
+impl avio::FrameSink for EguiFrameSink {
     fn push_frame(&mut self, rgba: &[u8], width: u32, height: u32, pts: Duration) {
-        let rate = f64::from_bits(self.rate.load(Ordering::Relaxed));
-
-        // Reset the clock reference whenever the rate changes mid-playback so
-        // that `target_wall = video_relative / new_rate` doesn't over- or
-        // under-sleep relative to the new reference point.
-        if (rate - self.last_rate).abs() > f64::EPSILON {
-            self.start = None;
-            self.last_rate = rate;
+        let audio_f = self.audio_frames.load(Ordering::Relaxed);
+        let audio_ms = audio_f * 1000 / 48_000;
+        let video_ms = pts.as_millis() as u64;
+        let diff_ms = audio_ms as i64 - video_ms as i64;
+        if self.frame_count < 10 || diff_ms.abs() > 100 {
+            log::warn!(
+                "A/V frame={} video={video_ms}ms audio={audio_ms}ms diff={diff_ms:+}ms",
+                self.frame_count
+            );
         }
 
-        let (wall_start, pts_base) = self.start.get_or_insert_with(|| (Instant::now(), pts));
-
-        let video_relative = pts.saturating_sub(*pts_base);
-        let wall_elapsed = wall_start.elapsed();
-
-        let target_wall = video_relative.div_f64(rate);
-        if let Some(ahead) = target_wall.checked_sub(wall_elapsed)
-            && ahead > Duration::from_millis(1)
-        {
-            std::thread::sleep(ahead);
+        // Periodic audio rate check: logs how fast audio_ms is advancing relative
+        // to wall clock. 100% = real-time; 200% = 2x speed (audio running too fast).
+        if self.start_time.is_none() {
+            self.start_time = Some(Instant::now());
         }
+        if self.frame_count > 0 && self.frame_count % 300 == 299 {
+            let elapsed_ms = self.start_time.unwrap().elapsed().as_millis() as u64;
+            if elapsed_ms > 0 {
+                let rate_pct = audio_ms * 100 / elapsed_ms;
+                log::warn!(
+                    "A/V rate @frame={}: audio={audio_ms}ms wall={elapsed_ms}ms audio_rate={rate_pct}%",
+                    self.frame_count
+                );
+            }
+        }
+
+        self.frame_count += 1;
 
         let mut guard = self
             .frame_handle
@@ -82,41 +59,165 @@ impl avio::FrameSink for TimedRgbaSink {
             height,
             pts,
         });
+        drop(guard);
         self.ctx.request_repaint();
+    }
+}
+
+// ── cpal audio output ─────────────────────────────────────────────────────────
+
+/// Opens the default cpal output stream and drives it with `PlayerHandle::pop_audio_samples`.
+///
+/// This advances `MasterClock::Audio` so the player's A/V sync loop correctly
+/// paces video frames. Returns `None` when no audio output device is available
+/// or the stream cannot be opened; in that case video plays at decoder speed
+/// (too fast for audio-bearing files).
+fn try_start_audio_output(
+    handle: PlayerHandle,
+    audio_frames: Arc<AtomicU64>,
+) -> Option<cpal::Stream> {
+    use cpal::SampleFormat;
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+    let host = cpal::default_host();
+    let device = match host.default_output_device() {
+        Some(d) => d,
+        None => {
+            log::warn!("cpal: no default output device found");
+            return None;
+        }
+    };
+    let default_cfg = match device.default_output_config() {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("cpal: no default output config: {e}");
+            return None;
+        }
+    };
+
+    let fmt = default_cfg.sample_format();
+    let device_rate = default_cfg.sample_rate().0;
+    let avio_rate = handle.audio_sample_rate().unwrap_or(48_000);
+    log::warn!(
+        "cpal: device default {}Hz {}ch {fmt:?}; opening at {avio_rate}Hz 2ch F32",
+        device_rate,
+        default_cfg.channels(),
+    );
+
+    let stream_config = cpal::StreamConfig {
+        channels: 2,
+        sample_rate: cpal::SampleRate(avio_rate),
+        buffer_size: cpal::BufferSize::Default,
+    };
+
+    let build_result = match fmt {
+        SampleFormat::F32 => {
+            let mut total_samples: u64 = 0;
+            let mut total_returned: u64 = 0;
+            let mut cb_count: u64 = 0;
+            let diag_start = std::time::Instant::now();
+            device.build_output_stream(
+                &stream_config,
+                move |data: &mut [f32], _| {
+                    let samples = handle.pop_audio_samples(data.len());
+                    let n = samples.len().min(data.len());
+                    data[..n].copy_from_slice(&samples[..n]);
+                    data[n..].fill(0.0);
+                    audio_frames.fetch_add((n / 2) as u64, Ordering::Relaxed);
+                    total_samples += data.len() as u64;
+                    total_returned += n as u64;
+                    cb_count += 1;
+                    if cb_count == 200 {
+                        let secs = diag_start.elapsed().as_secs_f64();
+                        log::warn!(
+                            "cpal diag: {total_samples} requested, {total_returned} returned in {secs:.2}s \
+                             => effective rate {:.0} samp/s (expect 96000 for 48kHz stereo)",
+                            total_samples as f64 / secs
+                        );
+                    }
+                },
+                |e| log::warn!("cpal stream error: {e}"),
+                None,
+            )
+        }
+        SampleFormat::I16 => {
+            let audio_frames_i16 = Arc::clone(&audio_frames);
+            device.build_output_stream(
+                &stream_config,
+                move |data: &mut [i16], _| {
+                    let samples = handle.pop_audio_samples(data.len());
+                    let n = samples.len().min(data.len());
+                    for (dst, &src) in data.iter_mut().zip(samples.iter()) {
+                        *dst = (src.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+                    }
+                    if n < data.len() {
+                        data[n..].fill(0);
+                    }
+                    audio_frames_i16.fetch_add((n / 2) as u64, Ordering::Relaxed);
+                },
+                |e| log::warn!("cpal stream error: {e}"),
+                None,
+            )
+        }
+        other => {
+            log::warn!("cpal: unsupported sample format {other:?}, audio output disabled");
+            return None;
+        }
+    };
+
+    match build_result {
+        Ok(s) => {
+            if let Err(e) = s.play() {
+                log::warn!("cpal: stream.play() failed: {e}");
+                return None;
+            }
+            log::warn!("cpal: audio output started");
+            Some(s)
+        }
+        Err(e) => {
+            log::warn!("cpal: build_output_stream failed: {e}");
+            None
+        }
     }
 }
 
 // ── spawn_player ───────────────────────────────────────────────────────────────
 
-/// Spawns a background thread running `PreviewPlayer::run()`.
+/// Spawns a background thread running `PlayerRunner::run()`.
 ///
-/// Returns `(thread, stop_rx, proxy_rx, pause_rx, av_offset_rx)`. The last four
-/// are one-shot channels that deliver the player's own atomic handles, sent from
-/// the player thread before `run()` blocks. The UI thread can then toggle pause
-/// or update the A/V offset live without stopping the player.
-#[allow(clippy::type_complexity)]
+/// Returns `(thread, handle_rx, proxy_rx)`. `handle_rx` delivers the
+/// `PlayerHandle` once the runner is ready; `proxy_rx` delivers whether a
+/// proxy was activated. Both are one-shot.
 pub fn spawn_player(
     path: PathBuf,
     frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
     ctx: egui::Context,
     start_pos: Option<Duration>,
     proxy_dir: Option<PathBuf>,
-    rate: Arc<AtomicU64>,
+    playback_rate: f64,
     av_offset_ms: i64,
 ) -> (
     std::thread::JoinHandle<()>,
-    mpsc::Receiver<Arc<AtomicBool>>,
+    mpsc::Receiver<PlayerHandle>,
     mpsc::Receiver<bool>,
-    mpsc::Receiver<Arc<AtomicBool>>,
-    mpsc::Receiver<Arc<AtomicI64>>,
 ) {
-    let (stop_tx, stop_rx) = mpsc::sync_channel::<Arc<AtomicBool>>(1);
+    let (handle_tx, handle_rx) = mpsc::sync_channel::<PlayerHandle>(1);
     let (proxy_tx, proxy_rx) = mpsc::sync_channel::<bool>(1);
-    let (pause_tx, pause_rx) = mpsc::sync_channel::<Arc<AtomicBool>>(1);
-    let (av_offset_tx, av_offset_rx) = mpsc::sync_channel::<Arc<AtomicI64>>(1);
 
-    let handle = std::thread::spawn(move || {
-        let mut player = match avio::PreviewPlayer::open(&path) {
+    let thread = std::thread::spawn(move || {
+        // Log native audio rate before opening the player
+        if let Ok(info) = avio::open(&path)
+            && let Some(audio) = info.primary_audio()
+        {
+            log::warn!(
+                "file native audio: {}Hz {}ch codec={}",
+                audio.sample_rate(),
+                audio.channels(),
+                audio.codec_name(),
+            );
+        }
+
+        let player = match avio::PreviewPlayer::open(&path) {
             Ok(p) => p,
             Err(e) => {
                 log::warn!("PreviewPlayer::open failed path={path:?}: {e}");
@@ -124,30 +225,24 @@ pub fn spawn_player(
             }
         };
 
-        // seek() still takes &mut self, so we seek before run() as a
-        // start-position workaround for scrubbing.
-        if let Some(pos) = start_pos
-            && let Err(e) = player.seek(pos)
-        {
-            log::warn!("initial seek to {pos:?} failed: {e}");
-        }
+        let (mut runner, handle) = player.split();
 
-        // Apply the initial A/V offset and rate before run() blocks.
-        player.set_av_offset(av_offset_ms);
-        let initial_rate = f64::from_bits(rate.load(Ordering::Relaxed));
-        player.set_rate(initial_rate);
+        let audio_frames = Arc::new(AtomicU64::new(0));
 
-        // Send all live-control handles back to the UI thread before blocking.
-        let _ = stop_tx.send(player.stop_handle());
-        let _ = pause_tx.send(player.pause_handle());
-        let _ = av_offset_tx.send(player.av_offset_handle());
+        runner.set_sink(Box::new(EguiFrameSink {
+            frame_handle,
+            ctx: ctx.clone(),
+            audio_frames: Arc::clone(&audio_frames),
+            frame_count: 0,
+            start_time: None,
+        }));
 
         let proxy_active = if let Some(ref dir) = proxy_dir {
-            let active = player.use_proxy_if_available(dir);
+            let active = runner.use_proxy_if_available(dir);
             if active {
                 log::info!(
                     "source monitor: proxy active — {}",
-                    player.active_source().display()
+                    runner.active_source().display()
                 );
             }
             active
@@ -156,17 +251,26 @@ pub fn spawn_player(
         };
         let _ = proxy_tx.send(proxy_active);
 
-        player.set_sink(Box::new(TimedRgbaSink::new(
-            frame_handle,
-            ctx.clone(),
-            rate,
-        )));
-        player.play();
-        if let Err(e) = player.run() {
-            log::warn!("PreviewPlayer::run failed: {e}");
+        if let Some(pos) = start_pos {
+            handle.seek(pos);
+        }
+        handle.set_av_offset(av_offset_ms);
+        if playback_rate > 0.0 {
+            handle.set_rate(playback_rate);
+        }
+
+        let _ = handle_tx.send(handle.clone());
+        handle.play();
+
+        // Wire audio output. Keeps stream alive for the duration of run().
+        // Drives MasterClock::Audio so frame pacing works for audio-bearing files.
+        let _audio_stream = try_start_audio_output(handle.clone(), audio_frames);
+
+        if let Err(e) = runner.run() {
+            log::warn!("PlayerRunner::run failed: {e}");
         }
         ctx.request_repaint();
     });
 
-    (handle, stop_rx, proxy_rx, pause_rx, av_offset_rx)
+    (thread, handle_rx, proxy_rx)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, AtomicU64};
+use std::sync::atomic::AtomicU32;
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
 
@@ -25,12 +25,9 @@ pub struct AppState {
     pub frame_handle: Arc<Mutex<Option<avio::RgbaFrame>>>,
     pub preview_texture: Option<egui::TextureHandle>,
     pub player_thread: Option<std::thread::JoinHandle<()>>,
-    pub player_stop: Option<Arc<AtomicBool>>,
-    pub pending_stop_rx: Option<mpsc::Receiver<Arc<AtomicBool>>>,
-    pub player_pause: Option<Arc<AtomicBool>>,
-    pub pending_pause_rx: Option<mpsc::Receiver<Arc<AtomicBool>>>,
-    pub player_av_offset: Option<Arc<AtomicI64>>,
-    pub pending_av_offset_rx: Option<mpsc::Receiver<Arc<AtomicI64>>>,
+    pub player_handle: Option<avio::PlayerHandle>,
+    pub pending_handle_rx: Option<mpsc::Receiver<avio::PlayerHandle>>,
+    pub is_paused: bool,
     pub monitor_clip_index: Option<usize>,
     pub seek_pos_secs: f64,
     pub seek_exact: bool,
@@ -39,7 +36,6 @@ pub struct AppState {
     pub proxy_active: bool,
     pub pending_proxy_rx: Option<mpsc::Receiver<bool>>,
     pub playback_rate: f64,
-    pub rate_handle: Arc<AtomicU64>,
     pub av_offset_ms: i32,
     pub export: Option<ExportHandle>,
     pub encoder_config: EncoderConfigDraft,
@@ -82,12 +78,9 @@ impl Default for AppState {
             frame_handle: Arc::new(Mutex::new(None)),
             preview_texture: None,
             player_thread: None,
-            player_stop: None,
-            pending_stop_rx: None,
-            player_pause: None,
-            pending_pause_rx: None,
-            player_av_offset: None,
-            pending_av_offset_rx: None,
+            player_handle: None,
+            pending_handle_rx: None,
+            is_paused: false,
             monitor_clip_index: None,
             seek_pos_secs: 0.0,
             seek_exact: false,
@@ -96,7 +89,6 @@ impl Default for AppState {
             proxy_active: false,
             pending_proxy_rx: None,
             playback_rate: 1.0,
-            rate_handle: Arc::new(AtomicU64::new(1.0_f64.to_bits())),
             av_offset_ms: 0,
             export: None,
             encoder_config: EncoderConfigDraft::default(),

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -150,16 +150,13 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
     if let Some(idx) = dbl_clicked_idx {
         state.selected_clip_index = Some(idx);
         // Stop any current player and clear all player state.
-        if let Some(stop) = state.player_stop.take() {
-            stop.store(true, std::sync::atomic::Ordering::Release);
+        if let Some(handle) = state.player_handle.take() {
+            handle.stop();
         }
         state.player_thread = None;
-        state.pending_stop_rx = None;
+        state.pending_handle_rx = None;
         state.pending_proxy_rx = None;
-        state.pending_pause_rx = None;
-        state.pending_av_offset_rx = None;
-        state.player_pause = None;
-        state.player_av_offset = None;
+        state.is_paused = false;
         state.monitor_clip_index = Some(idx);
 
         // Only launch a player if the clip has a video stream.
@@ -184,21 +181,20 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 .get(idx)
                 .and_then(|c| c.path.parent())
                 .map(|p| p.join("proxies"));
-            let (thread, stop_rx, proxy_rx, pause_rx, av_offset_rx) = player::spawn_player(
+            let (thread, handle_rx, proxy_rx) = player::spawn_player(
                 path,
                 Arc::clone(&state.frame_handle),
                 ctx.clone(),
                 None,
                 proxy_dir,
-                Arc::clone(&state.rate_handle),
+                state.playback_rate,
                 state.av_offset_ms as i64,
             );
             state.player_thread = Some(thread);
-            state.pending_stop_rx = Some(stop_rx);
+            state.pending_handle_rx = Some(handle_rx);
             state.pending_proxy_rx = Some(proxy_rx);
-            state.pending_pause_rx = Some(pause_rx);
-            state.pending_av_offset_rx = Some(av_offset_rx);
             state.proxy_active = false;
+            state.is_paused = false;
         }
     }
 

--- a/src/ui/drain.rs
+++ b/src/ui/drain.rs
@@ -130,29 +130,17 @@ fn drain_proxy_jobs(state: &mut AppState) {
 }
 
 fn drain_player_handles(state: &mut AppState) {
-    if let Some(rx) = &state.pending_stop_rx
-        && let Ok(stop) = rx.try_recv()
+    if let Some(rx) = &state.pending_handle_rx
+        && let Ok(handle) = rx.try_recv()
     {
-        state.player_stop = Some(stop);
-        state.pending_stop_rx = None;
+        state.player_handle = Some(handle);
+        state.pending_handle_rx = None;
     }
     if let Some(rx) = &state.pending_proxy_rx
         && let Ok(active) = rx.try_recv()
     {
         state.proxy_active = active;
         state.pending_proxy_rx = None;
-    }
-    if let Some(rx) = &state.pending_pause_rx
-        && let Ok(pause) = rx.try_recv()
-    {
-        state.player_pause = Some(pause);
-        state.pending_pause_rx = None;
-    }
-    if let Some(rx) = &state.pending_av_offset_rx
-        && let Ok(av_offset) = rx.try_recv()
-    {
-        state.player_av_offset = Some(av_offset);
-        state.pending_av_offset_rx = None;
     }
 }
 

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use crate::{player, state};
@@ -19,11 +18,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
         .as_ref()
         .map(|h| !h.is_finished())
         .unwrap_or(false);
-    let is_paused = state
-        .player_pause
-        .as_ref()
-        .map(|h| h.load(Ordering::Relaxed))
-        .unwrap_or(false);
+    let is_paused = state.is_paused;
 
     let ctrl_height = if state.monitor_clip_index.is_some() {
         128.0
@@ -188,9 +183,6 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
             let ms = ((t % 1.0) * 1000.0) as u64;
             ui.monospace(format!("{h:02}:{m:02}:{s:02}.{ms:03}"));
 
-            // seek_coarse() still takes &mut self (same constraint as seek()),
-            // so both modes stop + respawn from the target position. The toggle
-            // decides whether to snap to the nearest keyframe first.
             let mode_label = if state.seek_exact { "Exact" } else { "Coarse" };
             ui.toggle_value(&mut state.seek_exact, mode_label)
                 .on_hover_text("Exact: frame-accurate but slow\nCoarse: nearest keyframe, fast");
@@ -218,14 +210,16 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
         if is_active {
             if is_paused {
                 if ui.button("▶ Resume").clicked()
-                    && let Some(pause) = &state.player_pause
+                    && let Some(handle) = &state.player_handle
                 {
-                    pause.store(false, Ordering::Relaxed);
+                    handle.play();
+                    state.is_paused = false;
                 }
             } else if ui.button("⏸ Pause").clicked()
-                && let Some(pause) = &state.player_pause
+                && let Some(handle) = &state.player_handle
             {
-                pause.store(true, Ordering::Relaxed);
+                handle.pause();
+                state.is_paused = true;
             }
             if ui.button("⏹ Stop").clicked() {
                 stop_player(state);
@@ -260,13 +254,15 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                     .clicked()
                 {
                     state.playback_rate = rate;
-                    state.rate_handle.store(rate.to_bits(), Ordering::Relaxed);
+                    if let Some(handle) = &state.player_handle {
+                        handle.set_rate(rate);
+                    }
                 }
             }
         }
     });
 
-    // A/V offset row — live-updates via av_offset_handle (no stop+respawn needed).
+    // A/V offset row — live-updates via PlayerHandle::set_av_offset (no stop+respawn needed).
     if state.monitor_clip_index.is_some() {
         ui.horizontal(|ui| {
             ui.label("A/V:");
@@ -277,13 +273,13 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                     .suffix(" ms"),
             );
             let should_apply = av_resp.drag_stopped() || (!av_resp.dragged() && av_resp.changed());
-            if should_apply && let Some(av_offset) = &state.player_av_offset {
-                av_offset.store(state.av_offset_ms as i64, Ordering::Relaxed);
+            if should_apply && let Some(handle) = &state.player_handle {
+                handle.set_av_offset(state.av_offset_ms as i64);
             }
             if ui.small_button("Reset").clicked() {
                 state.av_offset_ms = 0;
-                if let Some(av_offset) = &state.player_av_offset {
-                    av_offset.store(0, Ordering::Relaxed);
+                if let Some(handle) = &state.player_handle {
+                    handle.set_av_offset(0);
                 }
             }
         });
@@ -338,16 +334,13 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
 
 /// Stops the active player and clears all player-related state.
 fn stop_player(state: &mut state::AppState) {
-    if let Some(stop) = state.player_stop.take() {
-        stop.store(true, Ordering::Release);
+    if let Some(handle) = state.player_handle.take() {
+        handle.stop();
     }
     state.player_thread = None;
-    state.pending_stop_rx = None;
+    state.pending_handle_rx = None;
     state.pending_proxy_rx = None;
-    state.pending_pause_rx = None;
-    state.pending_av_offset_rx = None;
-    state.player_pause = None;
-    state.player_av_offset = None;
+    state.is_paused = false;
     state.proxy_active = false;
 }
 
@@ -359,21 +352,20 @@ fn spawn_and_store(
     start_pos: Option<Duration>,
     proxy_dir: Option<std::path::PathBuf>,
 ) {
-    let (thread, stop_rx, proxy_rx, pause_rx, av_offset_rx) = player::spawn_player(
+    let (thread, handle_rx, proxy_rx) = player::spawn_player(
         path,
         Arc::clone(&state.frame_handle),
         ctx.clone(),
         start_pos,
         proxy_dir,
-        Arc::clone(&state.rate_handle),
+        state.playback_rate,
         state.av_offset_ms as i64,
     );
     state.player_thread = Some(thread);
-    state.pending_stop_rx = Some(stop_rx);
+    state.pending_handle_rx = Some(handle_rx);
     state.pending_proxy_rx = Some(proxy_rx);
-    state.pending_pause_rx = Some(pause_rx);
-    state.pending_av_offset_rx = Some(av_offset_rx);
     state.proxy_active = false;
+    state.is_paused = false;
 }
 
 fn snap_to_nearest_keyframe(


### PR DESCRIPTION
## Summary

Migrates all player control from separate `AtomicBool`/`AtomicI64` handles to the unified `PlayerHandle` returned by `spawn_player`, matching the avio 0.14 API. Also wires cpal audio output directly inside `player.rs` and adds per-frame A/V diff logging plus a 300-frame `audio_rate` check that was essential for diagnosing two avio-side bugs (MasterClock freeze and ring-buffer sample drop).

## Changes

- **`Cargo.toml`**: bump avio to 0.14.1, add `cpal = "0.15"` dependency, add `[patch.crates-io]` to use local avio workspace during development
- **`src/player.rs`**: replace multi-channel spawn signature with single `PlayerHandle` channel; integrate cpal audio stream (`try_start_audio_output`); add `EguiFrameSink::start_time` and periodic `audio_rate=%` log every 300 frames
- **`src/state.rs`**: remove `player_stop`, `player_pause`, `player_av_offset`, `rate_handle` fields; replace with `player_handle: Option<PlayerHandle>` and `is_paused: bool`
- **`src/ui/monitor.rs`**: call `handle.play()` / `handle.pause()` / `handle.set_rate()` instead of atomic stores
- **`src/ui/clip_browser.rs`**: call `handle.stop()` instead of atomic store; simplify spawn call
- **`src/ui/drain.rs`**: drain single handle channel instead of three separate channels
- **`src/main.rs`**: set default log filter to `warn` so diagnostic logs appear without `RUST_LOG`

## Related Issues

Resolves #64

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes