### PR TITLE
fix(ui): enable audio-only clip playback and fix clip browser row layout

### DIFF
--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -91,7 +91,22 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                     ));
                 }
                 None => {
-                    ui.label("\u{1F3AC}");
+                    let (rect, _) =
+                        ui.allocate_exact_size(egui::vec2(48.0, 27.0), egui::Sense::hover());
+                    let icon = if clip.info.primary_video().is_none()
+                        && clip.info.primary_audio().is_some()
+                    {
+                        "\u{1F3B5}"
+                    } else {
+                        "\u{1F3AC}"
+                    };
+                    ui.painter().text(
+                        rect.center(),
+                        egui::Align2::CENTER_CENTER,
+                        icon,
+                        egui::FontId::proportional(14.0),
+                        ui.visuals().text_color(),
+                    );
                 }
             }
             let name = clip.path.file_name().unwrap_or_default().to_string_lossy();
@@ -159,23 +174,29 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
         state.is_paused = false;
         state.monitor_clip_index = Some(idx);
 
-        // Only launch a player if the clip has a video stream.
-        // Audio-only files are supported by PreviewPlayer in avio 0.13.1 but we
-        // have no audio output (cpal not wired), so we skip playback for them.
         let has_video = state
             .clips
             .get(idx)
             .map(|c| c.info.primary_video().is_some())
             .unwrap_or(false);
-        if has_video && let Some(path) = state.clips.get(idx).map(|c| c.path.clone()) {
-            // Clear stale keyframes and enumerate new ones for this clip.
-            state.keyframes.clear();
-            let kf_tx = state.keyframe_tx.clone();
-            let kf_path = path.clone();
-            tokio::task::spawn_blocking(move || {
-                let kfs = analysis::enumerate_keyframes(&kf_path);
-                let _ = kf_tx.send(kfs);
-            });
+        let has_audio = state
+            .clips
+            .get(idx)
+            .map(|c| c.info.primary_audio().is_some())
+            .unwrap_or(false);
+        if (has_video || has_audio)
+            && let Some(path) = state.clips.get(idx).map(|c| c.path.clone())
+        {
+            if has_video {
+                // Clear stale keyframes and enumerate new ones for this clip.
+                state.keyframes.clear();
+                let kf_tx = state.keyframe_tx.clone();
+                let kf_path = path.clone();
+                tokio::task::spawn_blocking(move || {
+                    let kfs = analysis::enumerate_keyframes(&kf_path);
+                    let _ = kf_tx.send(kfs);
+                });
+            }
             let proxy_dir = state
                 .clips
                 .get(idx)

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -29,8 +29,19 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
     let video_size = egui::vec2(available.x, (available.y - ctrl_height).max(0.0));
 
     if state.monitor_clip_index.is_some() {
+        let is_audio_only = state
+            .monitor_clip_index
+            .and_then(|idx| state.clips.get(idx))
+            .map(|c| c.info.primary_video().is_none() && c.info.primary_audio().is_some())
+            .unwrap_or(false);
         if let Some(tex) = &state.preview_texture {
             ui.image(egui::load::SizedTexture::new(tex.id(), video_size));
+        } else if is_audio_only {
+            ui.allocate_ui(video_size, |ui| {
+                ui.centered_and_justified(|ui| {
+                    ui.heading("\u{1F3B5}");
+                });
+            });
         } else {
             ui.allocate_ui(video_size, |ui| {
                 ui.centered_and_justified(|ui| {
@@ -225,12 +236,12 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 stop_player(state);
             }
         } else if let Some(idx) = state.monitor_clip_index {
-            let has_video = state
+            let has_media = state
                 .clips
                 .get(idx)
-                .map(|c| c.info.primary_video().is_some())
+                .map(|c| c.info.primary_video().is_some() || c.info.primary_audio().is_some())
                 .unwrap_or(false);
-            if has_video
+            if has_media
                 && ui.button("▶ Play").clicked()
                 && let Some(path) = state.clips.get(idx).map(|c| c.path.clone())
             {
@@ -240,8 +251,6 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                     .and_then(|c| c.path.parent())
                     .map(|p| p.join("proxies"));
                 spawn_and_store(state, path, ctx, None, proxy_dir);
-            } else if !has_video {
-                ui.label("No video stream");
             }
         }
 


### PR DESCRIPTION
## Summary

Audio-only files (MP3, AAC, WAV, FLAC) could not be played from the Clip Browser and had inconsistent row layout compared to video clips. This PR fixes double-click playback, the clip row hover highlight, the Source Monitor Play button, and the monitor placeholder for audio-only files.

## Changes

- **`clip_browser.rs`**: Double-click on an audio-only clip now spawns the player (the old `has_video` guard has been replaced with `has_video || has_audio`). The icon area for clips without a thumbnail now uses `allocate_exact_size(48×27)` instead of `ui.label(emoji)`, making all rows the same height and restoring the `selectable_label` hover highlight. Audio-only clips show 🎵; video clips waiting for a thumbnail show 🎬.
- **`monitor.rs`**: The Play button is now shown for any clip with video or audio (was blocked by `has_video` guard, showing "No video stream" for audio-only files). When an audio-only clip is loaded the monitor area displays 🎵 instead of "Loading…" indefinitely (no video frame will ever arrive for audio-only files).

## Related Issues

No dedicated issue — standalone bug fix.

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes