### PR TITLE
fix(player): fix A/V desync at non-1× rates and correct diagnostic log

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -13,35 +13,59 @@ struct EguiFrameSink {
     ctx: egui::Context,
     /// Stereo frames consumed by the cpal callback (shared with `try_start_audio_output`).
     audio_frames: Arc<AtomicU64>,
+    /// Current playback rate (shared with the cpal callback and UI).
+    cpal_rate: Arc<AtomicU64>,
     frame_count: u64,
-    /// Wall-clock time of first frame, used to measure audio advancement rate.
+    /// Wall-clock time of first frame, used to measure hardware clock rate.
     start_time: Option<Instant>,
+    // ── Rate-corrected A/V diff diagnostic ──────────────────────────────────
+    // Tracks audio media time independently of rate so the diff is always
+    // meaningful.  On every rate change the baseline is re-anchored to the
+    // current video PTS, which eliminates the spurious constant offset that
+    // would otherwise accumulate when switching between rates.
+    diag_pts_base_ms: f64,
+    diag_frames_base: u64,
+    diag_rate: f64,
 }
 
 impl avio::FrameSink for EguiFrameSink {
     fn push_frame(&mut self, rgba: &[u8], width: u32, height: u32, pts: Duration) {
         let audio_f = self.audio_frames.load(Ordering::Relaxed);
-        let audio_ms = audio_f * 1000 / 48_000;
-        let video_ms = pts.as_millis() as u64;
-        let diff_ms = audio_ms as i64 - video_ms as i64;
-        if self.frame_count < 10 || diff_ms.abs() > 100 {
+        let audio_ms_hw = audio_f * 1000 / 48_000; // hardware wall-clock ms (for rate check)
+        let rate = f64::from_bits(self.cpal_rate.load(Ordering::Relaxed));
+        let video_ms = pts.as_secs_f64() * 1000.0;
+
+        // Re-baseline on rate change or first frame so that audio_media_ms is
+        // anchored to the current video PTS.  After re-baselining, diff measures
+        // media-time alignment between audio clock and video PTS — not the
+        // accumulated difference between hardware time and media time.
+        if self.frame_count == 0 || (rate - self.diag_rate).abs() > 0.01 {
+            self.diag_pts_base_ms = video_ms;
+            self.diag_frames_base = audio_f;
+            self.diag_rate = rate;
+        }
+        let delta = audio_f.saturating_sub(self.diag_frames_base);
+        let audio_media_ms = self.diag_pts_base_ms + delta as f64 * 1000.0 / 48_000.0 * rate;
+        let diff_ms = audio_media_ms - video_ms;
+
+        if self.frame_count < 10 || diff_ms.abs() > 50.0 {
             log::warn!(
-                "A/V frame={} video={video_ms}ms audio={audio_ms}ms diff={diff_ms:+}ms",
+                "A/V frame={} video={video_ms:.0}ms audio_media={audio_media_ms:.0}ms diff={diff_ms:+.0}ms",
                 self.frame_count
             );
         }
 
-        // Periodic audio rate check: logs how fast audio_ms is advancing relative
-        // to wall clock. 100% = real-time; 200% = 2x speed (audio running too fast).
+        // Periodic hardware-rate check: audio_ms_hw should advance at ~100%
+        // of wall clock regardless of playback rate.
         if self.start_time.is_none() {
             self.start_time = Some(Instant::now());
         }
         if self.frame_count > 0 && self.frame_count % 300 == 299 {
             let elapsed_ms = self.start_time.unwrap().elapsed().as_millis() as u64;
             if elapsed_ms > 0 {
-                let rate_pct = audio_ms * 100 / elapsed_ms;
+                let rate_pct = audio_ms_hw * 100 / elapsed_ms;
                 log::warn!(
-                    "A/V rate @frame={}: audio={audio_ms}ms wall={elapsed_ms}ms audio_rate={rate_pct}%",
+                    "A/V rate @frame={}: audio_hw={audio_ms_hw}ms wall={elapsed_ms}ms audio_rate={rate_pct}%",
                     self.frame_count
                 );
             }
@@ -75,6 +99,7 @@ impl avio::FrameSink for EguiFrameSink {
 fn try_start_audio_output(
     handle: PlayerHandle,
     audio_frames: Arc<AtomicU64>,
+    cpal_rate: Arc<AtomicU64>,
 ) -> Option<cpal::Stream> {
     use cpal::SampleFormat;
     use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -116,16 +141,38 @@ fn try_start_audio_output(
             let mut total_returned: u64 = 0;
             let mut cb_count: u64 = 0;
             let diag_start = std::time::Instant::now();
+            let cpal_rate_f32 = Arc::clone(&cpal_rate);
             device.build_output_stream(
                 &stream_config,
                 move |data: &mut [f32], _| {
-                    let samples = handle.pop_audio_samples(data.len());
-                    let n = samples.len().min(data.len());
-                    data[..n].copy_from_slice(&samples[..n]);
-                    data[n..].fill(0.0);
-                    audio_frames.fetch_add((n / 2) as u64, Ordering::Relaxed);
-                    total_samples += data.len() as u64;
-                    total_returned += n as u64;
+                    let rate = f64::from_bits(cpal_rate_f32.load(Ordering::Relaxed));
+                    let out_len = data.len();
+                    // Consume rate× decoded samples so the ring buffer drains at
+                    // the media rate. Resample (nearest-neighbour) to the hardware
+                    // output size to produce rate-scaled (pitch-shifted) audio.
+                    //
+                    // Clock advancement: always out_len/2 hardware stereo pairs so
+                    // MasterClock::Audio's formula (delta/sr * rate) yields correct
+                    // media PTS without double-counting rate.
+                    let pop_count = ((out_len as f64) * rate).round() as usize;
+                    let pop_count = pop_count.max(2);
+                    let samples =
+                        handle.pop_audio_samples_for_rate(pop_count, (out_len / 2) as u64);
+                    let in_len = samples.len();
+                    if in_len == 0 {
+                        data.fill(0.0);
+                    } else if in_len == out_len {
+                        data.copy_from_slice(&samples);
+                    } else {
+                        for (i, out) in data.iter_mut().enumerate() {
+                            let src =
+                                ((i as f64) * (in_len as f64) / (out_len as f64)) as usize;
+                            *out = samples[src.min(in_len - 1)];
+                        }
+                    }
+                    audio_frames.fetch_add((out_len / 2) as u64, Ordering::Relaxed);
+                    total_samples += out_len as u64;
+                    total_returned += in_len as u64;
                     cb_count += 1;
                     if cb_count == 200 {
                         let secs = diag_start.elapsed().as_secs_f64();
@@ -142,18 +189,32 @@ fn try_start_audio_output(
         }
         SampleFormat::I16 => {
             let audio_frames_i16 = Arc::clone(&audio_frames);
+            let cpal_rate_i16 = Arc::clone(&cpal_rate);
             device.build_output_stream(
                 &stream_config,
                 move |data: &mut [i16], _| {
-                    let samples = handle.pop_audio_samples(data.len());
-                    let n = samples.len().min(data.len());
-                    for (dst, &src) in data.iter_mut().zip(samples.iter()) {
-                        *dst = (src.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+                    let rate = f64::from_bits(cpal_rate_i16.load(Ordering::Relaxed));
+                    let out_len = data.len();
+                    let pop_count = ((out_len as f64) * rate).round() as usize;
+                    let pop_count = pop_count.max(2);
+                    let samples =
+                        handle.pop_audio_samples_for_rate(pop_count, (out_len / 2) as u64);
+                    let in_len = samples.len();
+                    if in_len == 0 {
+                        data.fill(0);
+                    } else if in_len == out_len {
+                        for (dst, &src) in data.iter_mut().zip(samples.iter()) {
+                            *dst = (src.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+                        }
+                    } else {
+                        for (i, out) in data.iter_mut().enumerate() {
+                            let src_idx =
+                                ((i as f64) * (in_len as f64) / (out_len as f64)) as usize;
+                            let src = samples[src_idx.min(in_len - 1)];
+                            *out = (src.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+                        }
                     }
-                    if n < data.len() {
-                        data[n..].fill(0);
-                    }
-                    audio_frames_i16.fetch_add((n / 2) as u64, Ordering::Relaxed);
+                    audio_frames_i16.fetch_add((out_len / 2) as u64, Ordering::Relaxed);
                 },
                 |e| log::warn!("cpal stream error: {e}"),
                 None,
@@ -188,6 +249,7 @@ fn try_start_audio_output(
 /// Returns `(thread, handle_rx, proxy_rx)`. `handle_rx` delivers the
 /// `PlayerHandle` once the runner is ready; `proxy_rx` delivers whether a
 /// proxy was activated. Both are one-shot.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_player(
     path: PathBuf,
     frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
@@ -196,6 +258,7 @@ pub fn spawn_player(
     proxy_dir: Option<PathBuf>,
     playback_rate: f64,
     av_offset_ms: i64,
+    cpal_rate: Arc<std::sync::atomic::AtomicU64>,
 ) -> (
     std::thread::JoinHandle<()>,
     mpsc::Receiver<PlayerHandle>,
@@ -233,8 +296,12 @@ pub fn spawn_player(
             frame_handle,
             ctx: ctx.clone(),
             audio_frames: Arc::clone(&audio_frames),
+            cpal_rate: Arc::clone(&cpal_rate),
             frame_count: 0,
             start_time: None,
+            diag_pts_base_ms: 0.0,
+            diag_frames_base: 0,
+            diag_rate: 1.0,
         }));
 
         let proxy_active = if let Some(ref dir) = proxy_dir {
@@ -264,7 +331,7 @@ pub fn spawn_player(
 
         // Wire audio output. Keeps stream alive for the duration of run().
         // Drives MasterClock::Audio so frame pacing works for audio-bearing files.
-        let _audio_stream = try_start_audio_output(handle.clone(), audio_frames);
+        let _audio_stream = try_start_audio_output(handle.clone(), audio_frames, cpal_rate);
 
         if let Err(e) = runner.run() {
             log::warn!("PlayerRunner::run failed: {e}");

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::atomic::AtomicU32;
+use std::sync::atomic::{AtomicU32, AtomicU64};
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
 
@@ -36,6 +36,9 @@ pub struct AppState {
     pub proxy_active: bool,
     pub pending_proxy_rx: Option<mpsc::Receiver<bool>>,
     pub playback_rate: f64,
+    /// Shared with the cpal audio callback; stores `f64::to_bits(rate)`.
+    /// Audio is muted in the callback at rates other than 1.0.
+    pub cpal_rate: Arc<AtomicU64>,
     pub av_offset_ms: i32,
     pub export: Option<ExportHandle>,
     pub encoder_config: EncoderConfigDraft,
@@ -89,6 +92,7 @@ impl Default for AppState {
             proxy_active: false,
             pending_proxy_rx: None,
             playback_rate: 1.0,
+            cpal_rate: Arc::new(AtomicU64::new(1.0f64.to_bits())),
             av_offset_ms: 0,
             export: None,
             encoder_config: EncoderConfigDraft::default(),

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -202,6 +202,10 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 .get(idx)
                 .and_then(|c| c.path.parent())
                 .map(|p| p.join("proxies"));
+            state.cpal_rate.store(
+                state.playback_rate.to_bits(),
+                std::sync::atomic::Ordering::Relaxed,
+            );
             let (thread, handle_rx, proxy_rx) = player::spawn_player(
                 path,
                 Arc::clone(&state.frame_handle),
@@ -210,6 +214,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 proxy_dir,
                 state.playback_rate,
                 state.av_offset_ms as i64,
+                Arc::clone(&state.cpal_rate),
             );
             state.player_thread = Some(thread);
             state.pending_handle_rx = Some(handle_rx);

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -263,6 +263,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                     .clicked()
                 {
                     state.playback_rate = rate;
+                    state
+                        .cpal_rate
+                        .store(rate.to_bits(), std::sync::atomic::Ordering::Relaxed);
                     if let Some(handle) = &state.player_handle {
                         handle.set_rate(rate);
                     }
@@ -361,6 +364,10 @@ fn spawn_and_store(
     start_pos: Option<Duration>,
     proxy_dir: Option<std::path::PathBuf>,
 ) {
+    state.cpal_rate.store(
+        state.playback_rate.to_bits(),
+        std::sync::atomic::Ordering::Relaxed,
+    );
     let (thread, handle_rx, proxy_rx) = player::spawn_player(
         path,
         Arc::clone(&state.frame_handle),
@@ -369,6 +376,7 @@ fn spawn_and_store(
         proxy_dir,
         state.playback_rate,
         state.av_offset_ms as i64,
+        Arc::clone(&state.cpal_rate),
     );
     state.player_thread = Some(thread);
     state.pending_handle_rx = Some(handle_rx);


### PR DESCRIPTION
## Summary

At playback rates other than 1×, the cpal callback was passing `out_len * rate` to `pop_audio_samples()`, which advanced `samples_consumed` at `rate × hardware_rate`. `MasterClock::Audio` then multiplied by `rate` again, causing the clock to run at `rate²` (4× at 2×, 0.0625× at 0.25×). This PR switches to the new `pop_audio_samples_for_rate()` API so the sync clock always advances at the hardware output rate only. It also adds a rate-corrected A/V diff diagnostic that re-baselines on each rate change.

## Changes

- **`src/player.rs`**: Switch F32 and I16 cpal callbacks to `pop_audio_samples_for_rate(pop_count, out_len/2)` — clock advances by hardware pairs only, ring buffer still drains at `rate × hardware` speed for nearest-neighbour resampling
- **`src/player.rs`**: Add `cpal_rate: Arc<AtomicU64>` to `EguiFrameSink`; re-baseline A/V diff diagnostic on every rate change so diff shows true media-time alignment rather than a growing hardware-vs-media offset
- **`src/state.rs`**: Add `cpal_rate: Arc<AtomicU64>` to `AppState`, shared between the UI rate selector and the cpal callback
- **`src/ui/clip_browser.rs`**, **`src/ui/monitor.rs`**: Store `cpal_rate` atomically on rate change and pass `Arc::clone(&state.cpal_rate)` to `spawn_player`

## Related Issues

Resolves avio issues 20 and 21 (documented in `docs/issue20.md` and `docs/issue21.md`; filed upstream in the avio repository).

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes