### PR TITLE
feat(timeline): multi-track real-time playback with playhead and transport controls

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -5,6 +5,18 @@ use std::time::{Duration, Instant};
 
 use avio::{PlayerHandle, RgbaFrame};
 
+// ── TrackClipData ─────────────────────────────────────────────────────────────
+
+/// Minimal clip description for `spawn_timeline_player`.
+pub struct TrackClipData {
+    pub path: PathBuf,
+    pub start_on_track: Duration,
+    pub in_point: Option<Duration>,
+    pub out_point: Option<Duration>,
+    pub transition: Option<avio::XfadeTransition>,
+    pub transition_duration: Duration,
+}
+
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
 
 /// `FrameSink` that stores the latest RGBA frame and wakes the egui render loop.
@@ -340,4 +352,97 @@ pub fn spawn_player(
     });
 
     (thread, handle_rx, proxy_rx)
+}
+
+// ── spawn_timeline_player ──────────────────────────────────────────────────────
+
+/// Spawns a background thread running `TimelineRunner::run()` for multi-track playback.
+///
+/// Returns `(thread, handle_rx)`. `handle_rx` delivers the `PlayerHandle` once
+/// the runner is ready (one-shot).
+pub fn spawn_timeline_player(
+    v1: Vec<TrackClipData>,
+    v2: Vec<TrackClipData>,
+    a1: Vec<TrackClipData>,
+    frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
+    ctx: egui::Context,
+    start_pos: Duration,
+    cpal_rate: Arc<AtomicU64>,
+) -> (std::thread::JoinHandle<()>, mpsc::Receiver<PlayerHandle>) {
+    let (handle_tx, handle_rx) = mpsc::sync_channel::<PlayerHandle>(1);
+
+    let thread = std::thread::spawn(move || {
+        let make_clip = |tc: TrackClipData| -> avio::Clip {
+            let mut c = avio::Clip::new(&tc.path).offset(tc.start_on_track);
+            c.in_point = tc.in_point;
+            c.out_point = tc.out_point;
+            if let Some(kind) = tc.transition {
+                c = c.with_transition(kind, tc.transition_duration);
+            }
+            c
+        };
+
+        let v1_clips: Vec<avio::Clip> = v1.into_iter().map(make_clip).collect();
+        let v2_clips: Vec<avio::Clip> = v2.into_iter().map(make_clip).collect();
+        let a1_clips: Vec<avio::Clip> = a1.into_iter().map(make_clip).collect();
+
+        if v1_clips.is_empty() {
+            log::warn!("spawn_timeline_player: no V1 clips");
+            return;
+        }
+
+        let mut builder = avio::Timeline::builder().video_track(v1_clips);
+        if !v2_clips.is_empty() {
+            builder = builder.video_track(v2_clips);
+        }
+        if !a1_clips.is_empty() {
+            builder = builder.audio_track(a1_clips);
+        }
+
+        let timeline = match builder.build() {
+            Ok(t) => t,
+            Err(e) => {
+                log::warn!("Timeline::builder().build() failed: {e}");
+                return;
+            }
+        };
+
+        let (mut runner, handle) = match avio::TimelinePlayer::open(&timeline) {
+            Ok(pair) => pair,
+            Err(e) => {
+                log::warn!("TimelinePlayer::open failed: {e}");
+                return;
+            }
+        };
+
+        let audio_frames = Arc::new(AtomicU64::new(0));
+
+        runner.set_sink(Box::new(EguiFrameSink {
+            frame_handle,
+            ctx: ctx.clone(),
+            audio_frames: Arc::clone(&audio_frames),
+            cpal_rate: Arc::clone(&cpal_rate),
+            frame_count: 0,
+            start_time: None,
+            diag_pts_base_ms: 0.0,
+            diag_frames_base: 0,
+            diag_rate: 1.0,
+        }));
+
+        if start_pos > Duration::ZERO {
+            handle.seek(start_pos);
+        }
+
+        let _ = handle_tx.send(handle.clone());
+        handle.play();
+
+        let _audio_stream = try_start_audio_output(handle.clone(), audio_frames, cpal_rate);
+
+        if let Err(e) = runner.run() {
+            log::warn!("TimelineRunner::run failed: {e}");
+        }
+        ctx.request_repaint();
+    });
+
+    (thread, handle_rx)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -39,6 +39,13 @@ pub struct AppState {
     /// Shared with the cpal audio callback; stores `f64::to_bits(rate)`.
     /// Audio is muted in the callback at rates other than 1.0.
     pub cpal_rate: Arc<AtomicU64>,
+    // ── Timeline playback ────────────────────────────────────────────────────
+    /// Current playhead position on the timeline in seconds.
+    pub timeline_playhead_secs: f64,
+    pub timeline_player_thread: Option<std::thread::JoinHandle<()>>,
+    pub timeline_player_handle: Option<avio::PlayerHandle>,
+    pub timeline_pending_handle_rx: Option<mpsc::Receiver<avio::PlayerHandle>>,
+    pub timeline_is_paused: bool,
     pub av_offset_ms: i32,
     pub export: Option<ExportHandle>,
     pub encoder_config: EncoderConfigDraft,
@@ -93,6 +100,11 @@ impl Default for AppState {
             pending_proxy_rx: None,
             playback_rate: 1.0,
             cpal_rate: Arc::new(AtomicU64::new(1.0f64.to_bits())),
+            timeline_playhead_secs: 0.0,
+            timeline_player_thread: None,
+            timeline_player_handle: None,
+            timeline_pending_handle_rx: None,
+            timeline_is_paused: false,
             av_offset_ms: 0,
             export: None,
             encoder_config: EncoderConfigDraft::default(),
@@ -311,6 +323,28 @@ impl Default for TimelineState {
             ],
             pixels_per_second: 60.0,
         }
+    }
+}
+
+impl AppState {
+    pub fn stop_source_monitor_player(&mut self) {
+        if let Some(h) = self.player_handle.take() {
+            h.stop();
+        }
+        self.player_thread = None;
+        self.pending_handle_rx = None;
+        self.pending_proxy_rx = None;
+        self.is_paused = false;
+        self.proxy_active = false;
+    }
+
+    pub fn stop_timeline_player(&mut self) {
+        if let Some(h) = self.timeline_player_handle.take() {
+            h.stop();
+        }
+        self.timeline_player_thread = None;
+        self.timeline_pending_handle_rx = None;
+        self.timeline_is_paused = false;
     }
 }
 

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -164,14 +164,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
     }
     if let Some(idx) = dbl_clicked_idx {
         state.selected_clip_index = Some(idx);
-        // Stop any current player and clear all player state.
-        if let Some(handle) = state.player_handle.take() {
-            handle.stop();
-        }
-        state.player_thread = None;
-        state.pending_handle_rx = None;
-        state.pending_proxy_rx = None;
-        state.is_paused = false;
+        state.stop_source_monitor_player();
+        state.stop_timeline_player();
         state.monitor_clip_index = Some(idx);
 
         let has_video = state

--- a/src/ui/drain.rs
+++ b/src/ui/drain.rs
@@ -7,6 +7,7 @@ pub fn drain_background_jobs(state: &mut AppState, ctx: &egui::Context) {
     drain_gif_jobs(state);
     drain_proxy_jobs(state);
     drain_player_handles(state);
+    drain_timeline_player(state);
     drain_frame(state, ctx);
     drain_analysis_results(state, ctx);
 }
@@ -144,11 +145,40 @@ fn drain_player_handles(state: &mut AppState) {
     }
 }
 
+fn drain_timeline_player(state: &mut AppState) {
+    if let Some(rx) = &state.timeline_pending_handle_rx
+        && let Ok(handle) = rx.try_recv()
+    {
+        state.timeline_player_handle = Some(handle);
+        state.timeline_pending_handle_rx = None;
+    }
+    // Detect EOF: thread finished but handle still held
+    if state
+        .timeline_player_thread
+        .as_ref()
+        .map(|h| h.is_finished())
+        .unwrap_or(false)
+        && state.timeline_player_handle.is_some()
+    {
+        state.stop_timeline_player();
+    }
+}
+
 fn drain_frame(state: &mut AppState, ctx: &egui::Context) {
     if let Ok(mut guard) = state.frame_handle.try_lock()
         && let Some(frame) = guard.take()
     {
-        state.current_pts = Some(frame.pts);
+        // Route PTS to the right player's position indicator
+        if state
+            .timeline_player_thread
+            .as_ref()
+            .map(|h| !h.is_finished())
+            .unwrap_or(false)
+        {
+            state.timeline_playhead_secs = frame.pts.as_secs_f64();
+        } else {
+            state.current_pts = Some(frame.pts);
+        }
         let image = egui::ColorImage::from_rgba_unmultiplied(
             [frame.width as usize, frame.height as usize],
             &frame.data,

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -20,7 +20,15 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
         .unwrap_or(false);
     let is_paused = state.is_paused;
 
-    let ctrl_height = if state.monitor_clip_index.is_some() {
+    let timeline_is_active = state
+        .timeline_player_thread
+        .as_ref()
+        .map(|h| !h.is_finished())
+        .unwrap_or(false);
+
+    let ctrl_height = if timeline_is_active {
+        0.0
+    } else if state.monitor_clip_index.is_some() {
         128.0
     } else {
         36.0
@@ -28,7 +36,17 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
     let available = ui.available_size();
     let video_size = egui::vec2(available.x, (available.y - ctrl_height).max(0.0));
 
-    if state.monitor_clip_index.is_some() {
+    if timeline_is_active {
+        if let Some(tex) = &state.preview_texture {
+            ui.image(egui::load::SizedTexture::new(tex.id(), video_size));
+        } else {
+            ui.allocate_ui(video_size, |ui| {
+                ui.centered_and_justified(|ui| {
+                    ui.label("Loading…");
+                });
+            });
+        }
+    } else if state.monitor_clip_index.is_some() {
         let is_audio_only = state
             .monitor_clip_index
             .and_then(|idx| state.clips.get(idx))

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -1,7 +1,8 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::presets::PresetFile;
-use crate::{export, state};
+use crate::{export, player, state};
 
 pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
     // Header: "Timeline" heading + Export button aligned right
@@ -250,6 +251,88 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
         state.export = None;
     }
 
+    // ── Timeline playback controls ────────────────────────────────────────────
+    ui.horizontal(|ui| {
+        let v1_empty = state.timeline.tracks[0].clips.is_empty();
+        let is_playing = state
+            .timeline_player_thread
+            .as_ref()
+            .map(|h| !h.is_finished())
+            .unwrap_or(false);
+        let is_paused = state.timeline_is_paused;
+
+        if ui
+            .add_enabled(!v1_empty && !is_playing, egui::Button::new("▶ Play"))
+            .clicked()
+        {
+            state.stop_source_monitor_player();
+            state.stop_timeline_player();
+            state.monitor_clip_index = None;
+
+            let clips = &state.clips;
+            let make_tcd = |tc: &state::TimelineClip| player::TrackClipData {
+                path: clips[tc.source_index].path.clone(),
+                start_on_track: tc.start_on_track,
+                in_point: tc.in_point,
+                out_point: tc.out_point,
+                transition: tc.transition,
+                transition_duration: tc.transition_duration,
+            };
+            let v1: Vec<_> = state.timeline.tracks[0]
+                .clips
+                .iter()
+                .map(make_tcd)
+                .collect();
+            let v2: Vec<_> = state.timeline.tracks[1]
+                .clips
+                .iter()
+                .map(make_tcd)
+                .collect();
+            let a1: Vec<_> = state.timeline.tracks[2]
+                .clips
+                .iter()
+                .map(make_tcd)
+                .collect();
+
+            let start = Duration::from_secs_f64(state.timeline_playhead_secs.max(0.0));
+            // Timeline always plays at 1×; reset cpal_rate to 1.0
+            state
+                .cpal_rate
+                .store(1.0f64.to_bits(), std::sync::atomic::Ordering::Relaxed);
+            let (thread, handle_rx) = player::spawn_timeline_player(
+                v1,
+                v2,
+                a1,
+                Arc::clone(&state.frame_handle),
+                ui.ctx().clone(),
+                start,
+                Arc::clone(&state.cpal_rate),
+            );
+            state.timeline_player_thread = Some(thread);
+            state.timeline_pending_handle_rx = Some(handle_rx);
+            state.timeline_is_paused = false;
+        }
+
+        if is_playing {
+            let pause_label = if is_paused { "⏵ Resume" } else { "⏸ Pause" };
+            if ui.button(pause_label).clicked()
+                && let Some(h) = &state.timeline_player_handle
+            {
+                if is_paused {
+                    h.play();
+                } else {
+                    h.pause();
+                }
+                state.timeline_is_paused = !is_paused;
+            }
+            if ui.button("⏹ Stop").clicked() {
+                state.stop_timeline_player();
+            }
+        }
+
+        ui.label(format!("{:.2}s", state.timeline_playhead_secs));
+    });
+
     ui.separator();
 
     const TRACK_HEIGHT: f32 = 40.0;
@@ -283,7 +366,20 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
         .id_salt("timeline_scroll")
         .show(ui, |ui| {
             // ── Ruler ──────────────────────────────────────────────────────────
-            let (_, ruler_rect) = ui.allocate_space(egui::vec2(content_width, 24.0));
+            let (ruler_rect, ruler_resp) = ui.allocate_exact_size(
+                egui::vec2(content_width, 24.0),
+                egui::Sense::click_and_drag(),
+            );
+            // Click or drag on ruler to reposition playhead
+            if (ruler_resp.clicked() || ruler_resp.dragged())
+                && let Some(pos) = ruler_resp.interact_pointer_pos()
+            {
+                let secs = ((pos.x - ruler_rect.left()) / pps).max(0.0) as f64;
+                state.timeline_playhead_secs = secs;
+                if let Some(h) = &state.timeline_player_handle {
+                    h.seek(Duration::from_secs_f64(secs));
+                }
+            }
             let painter = ui.painter_at(ruler_rect);
             painter.rect_filled(ruler_rect, 0.0, egui::Color32::from_gray(40));
 
@@ -560,6 +656,15 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     }
                 });
             }
+            // ── Playhead ────────────────────────────────────────────────────────
+            let playhead_x = ruler_rect.left() + state.timeline_playhead_secs as f32 * pps;
+            let tracks_bottom =
+                ruler_rect.bottom() + TRACK_HEIGHT * state.timeline.tracks.len() as f32;
+            ui.painter().vline(
+                playhead_x,
+                ruler_rect.top()..=tracks_bottom,
+                egui::Stroke::new(2.0, egui::Color32::RED),
+            );
         }); // end ScrollArea
 
     // Apply drops after the ScrollArea closure to avoid borrow conflicts.


### PR DESCRIPTION
## Summary

Implements real-time multi-track timeline playback using `avio::TimelinePlayer`. Clips placed on V1, V2, and A1 tracks can now be previewed together with ▶/⏸/⏹ transport controls, a click/drag ruler playhead, and live video display in the Source Monitor panel. Also fixes two bugs in `avio`'s `TimelinePlayer`: V2 overlay clips were silently dropped from audio mixing, and `mixer_arc` was not declared `mut` preventing lazy mixer creation for audio-only tracks.

## Changes

- `src/player.rs` — add `spawn_timeline_player()`: builds `avio::Timeline` from V1/V2/A1 `TrackClipData`, calls `TimelinePlayer::open()`, wires `EguiFrameSink` + cpal, returns `(thread, handle_rx)`
- `src/state.rs` — add `timeline_player_thread`, `timeline_player_handle`, `timeline_pending_handle_rx`, `timeline_is_paused`, `timeline_playhead_secs` fields; add `stop_timeline_player()` and refactor `stop_source_monitor_player()`
- `src/ui/timeline.rs` — add ▶ Play / ⏸ Pause / ⏹ Stop controls; ruler responds to click/drag to reposition playhead; red playhead line drawn across all track lanes; timeline play clears `monitor_clip_index` to avoid source-monitor seek bar conflict
- `src/ui/drain.rs` — add `drain_timeline_player()` (receive handle, detect EOF); `drain_frame()` routes PTS to `timeline_playhead_secs` when timeline player is active
- `src/ui/monitor.rs` — add `timeline_is_active` display path: shows `preview_texture` unconditionally when the timeline player is running, regardless of `monitor_clip_index`
- `src/ui/clip_browser.rs` — double-clicking a clip now also calls `stop_timeline_player()` before spawning the source monitor player
- `avio/crates/ff-preview/src/timeline/mod.rs` — fix: V2 overlay clips that carry audio are now registered as `AudioOnlyTrack` entries (same mechanism as A1), so their audio is mixed and started/stopped as the playhead crosses their window; fix `mut mixer_arc` so Phase 5 lazy mixer creation compiles

## Related Issues

Resolves #10

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes