### PR TITLE
fix(ui): shorten avio-gap labels and move detail to hover tooltip

### DIFF
--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -149,7 +149,10 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
         // See docs/issue13.md. UI is present for gap documentation purposes.
         ui.checkbox(
             &mut state.export_filters.colorbalance_enabled,
-            "Color adjust (UI only — avio gap, not applied during render)",
+            "Color adjust",
+        )
+        .on_hover_text(
+            "Color balance is not applied during render — avio filter API pending (issue #13)",
         );
         if state.export_filters.colorbalance_enabled {
             ui.add(
@@ -198,10 +201,10 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
     });
     // avio API gap: audio_filter() not available on TimelineBuilder (docs/issue13.md).
     ui.horizontal(|ui| {
-        ui.checkbox(
-            &mut state.loudness_normalize,
-            "Normalize to (UI only — avio gap, not applied during render)",
-        );
+        ui.checkbox(&mut state.loudness_normalize, "Normalize to target LUFS")
+            .on_hover_text(
+                "Render output is not yet normalized — avio audio filter API pending (issue #13)",
+            );
         ui.add(
             egui::DragValue::new(&mut state.loudness_target)
                 .range(-40.0..=-5.0)


### PR DESCRIPTION
## Summary

Two checkboxes exposed internal avio API gap annotations directly as visible label text, making the UI look unfinished. The labels are shortened to clean user-facing copy and the gap explanation is moved into an `on_hover_text` tooltip.

## Changes

- `src/ui/timeline.rs`: Color adjust checkbox label shortened; gap note moved to hover tooltip
- `src/ui/timeline.rs`: Loudness normalize checkbox label shortened; gap note moved to hover tooltip

## Related Issues

Fixes #74

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes