### PR TITLE
fix(clip_browser): prevent crash on 3rd clip import caused by egui layer-ID collision

### DIFF
--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -196,10 +196,10 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                                         }
                                     });
                                 });
-                            // Overlay a click-sense region over the whole card
+                            // dnd_id (not ui.id()) avoids layer-ID collision between DnD ghost and background
                             ui.interact(
                                 frame_resp.response.rect,
-                                ui.id().with("card"),
+                                dnd_id.with("card"),
                                 egui::Sense::click(),
                             )
                         });


### PR DESCRIPTION
## Summary

Importing a third video file crashed the app in debug builds because the click-sense overlay inside `dnd_drag_source` used `ui.id().with("card")` as its widget ID. Since `ui.id()` returns the **current Ui's ID** — which differs between the Background-layer render and the Tooltip-layer DnD ghost render — a same-hash collision could occur within one frame, triggering egui 0.33's `debug_assert` in `widget_rect.rs:164`.

## Changes

- `src/ui/clip_browser.rs`: replaced `ui.id().with("card")` with `dnd_id.with("card")` in the `ui.interact()` call inside `dnd_drag_source`. `dnd_id` is `egui::Id::new(("clip_dnd", idx))` — explicitly unique per card and stable across both layer contexts.

## Related Issues

Fixes #82

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes