### PR TITLE
fix(export): add audio to V1-only exports; fix AAC encoding via avio FIFO and extradata

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -84,6 +84,10 @@ fn build_and_render(
     }
 
     let config = snapshot.encoder_config.to_encoder_config();
+
+    // When A1 has no clips, mirror V1 so the video clips' embedded audio is exported.
+    let effective_a1 = if a1.is_empty() { v1.clone() } else { a1 };
+
     let mut builder = avio::Timeline::builder().video_track(v1);
 
     if snapshot.export_filters.scale_enabled {
@@ -106,8 +110,8 @@ fn build_and_render(
     if !v2.is_empty() {
         builder = builder.video_track(v2);
     }
-    if !a1.is_empty() {
-        builder = builder.audio_track(a1);
+    if !effective_a1.is_empty() {
+        builder = builder.audio_track(effective_a1);
     }
 
     let timeline = builder.build().map_err(|e| e.to_string())?;

--- a/src/export.rs
+++ b/src/export.rs
@@ -13,6 +13,10 @@ pub struct ExportClip {
     pub out_point: Option<Duration>,
     pub transition: Option<avio::XfadeTransition>,
     pub transition_duration: Duration,
+    /// Full source duration from MediaInfo — used to estimate progress when out_point is unset.
+    pub source_duration: Duration,
+    /// Frame rate of the source clip — used to estimate total_frames for progress.
+    pub fps: f64,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -75,6 +79,23 @@ fn build_and_render(
     output: &std::path::Path,
     progress: &Arc<AtomicU32>,
 ) -> Result<(), String> {
+    // Compute the estimate before snapshot fields are moved into clips_to_avio.
+    // Used as a fallback when avio cannot determine total_frames (clips without out_point).
+    let total_frames_estimate: Option<u64> = {
+        let fps = snapshot.v1_clips.first().map(|c| c.fps).unwrap_or(30.0);
+        let total_dur: Duration = snapshot
+            .v1_clips
+            .iter()
+            .map(|c| {
+                let end = c.out_point.unwrap_or(c.source_duration);
+                let start = c.in_point.unwrap_or(Duration::ZERO);
+                end.saturating_sub(start)
+            })
+            .sum();
+        let frames = (total_dur.as_secs_f64() * fps).round() as u64;
+        if frames > 0 { Some(frames) } else { None }
+    };
+
     let v1 = clips_to_avio(snapshot.v1_clips);
     let v2 = clips_to_avio(snapshot.v2_clips);
     let a1 = clips_to_avio(snapshot.a1_clips);
@@ -119,9 +140,13 @@ fn build_and_render(
     let progress_ref = Arc::clone(progress);
     timeline
         .render_with_progress(output, config, move |p| {
-            if let Some(pct) = p.percent() {
-                progress_ref.store((pct as f32).to_bits(), Ordering::Relaxed);
-            }
+            let pct = p.percent().unwrap_or_else(|| {
+                total_frames_estimate
+                    .filter(|&total| total > 0)
+                    .map(|total| (p.frames_processed as f64 / total as f64 * 100.0).min(99.0))
+                    .unwrap_or(0.0)
+            });
+            progress_ref.store((pct as f32).to_bits(), Ordering::Relaxed);
             true
         })
         .map_err(|e| e.to_string())?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -270,7 +270,10 @@ impl Default for EncoderConfigDraft {
     fn default() -> Self {
         Self {
             video_codec: avio::VideoCodec::H264,
-            audio_codec: avio::AudioCodec::Aac,
+            // FLAC avoids the avio AAC FIFO gap (push_audio_frame sends frames
+            // without normalizing to 1024 samples; FLAC's frame_size=4096 > resampled
+            // output so the nb_samples > frame_size error never fires).
+            audio_codec: avio::AudioCodec::Flac,
             crf: 23,
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -270,10 +270,7 @@ impl Default for EncoderConfigDraft {
     fn default() -> Self {
         Self {
             video_codec: avio::VideoCodec::H264,
-            // PCM (pcm_s16le) has frame_size=0 so push_audio_frame can send any
-            // number of samples without triggering the avio FIFO gap that causes
-            // "nb_samples > frame_size" errors with AAC/FLAC/ALAC.
-            audio_codec: avio::AudioCodec::Pcm,
+            audio_codec: avio::AudioCodec::Aac,
             crf: 23,
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -270,10 +270,10 @@ impl Default for EncoderConfigDraft {
     fn default() -> Self {
         Self {
             video_codec: avio::VideoCodec::H264,
-            // FLAC avoids the avio AAC FIFO gap (push_audio_frame sends frames
-            // without normalizing to 1024 samples; FLAC's frame_size=4096 > resampled
-            // output so the nb_samples > frame_size error never fires).
-            audio_codec: avio::AudioCodec::Flac,
+            // PCM (pcm_s16le) has frame_size=0 so push_audio_frame can send any
+            // number of samples without triggering the avio FIFO gap that causes
+            // "nb_samples > frame_size" errors with AAC/FLAC/ALAC.
+            audio_codec: avio::AudioCodec::Pcm,
             crf: 23,
         }
     }

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -94,6 +94,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     .selected_text(state.encoder_config.audio_codec.display_name())
                     .show_ui(ui, |ui| {
                         for codec in [
+                            avio::AudioCodec::Pcm,
                             avio::AudioCodec::Aac,
                             avio::AudioCodec::Mp3,
                             avio::AudioCodec::Opus,

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -26,13 +26,18 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     .save_file()
             {
                 let clips = &state.clips;
-                let make_clip = |tc: &state::TimelineClip| export::ExportClip {
-                    path: clips[tc.source_index].path.clone(),
-                    start_on_track: tc.start_on_track,
-                    in_point: tc.in_point,
-                    out_point: tc.out_point,
-                    transition: tc.transition,
-                    transition_duration: tc.transition_duration,
+                let make_clip = |tc: &state::TimelineClip| {
+                    let src = &clips[tc.source_index];
+                    export::ExportClip {
+                        path: src.path.clone(),
+                        start_on_track: tc.start_on_track,
+                        in_point: tc.in_point,
+                        out_point: tc.out_point,
+                        transition: tc.transition,
+                        transition_duration: tc.transition_duration,
+                        source_duration: src.info.duration(),
+                        fps: src.info.frame_rate().unwrap_or(30.0),
+                    }
                 };
                 let snapshot = export::ExportSnapshot {
                     v1_clips: state.timeline.tracks[0]
@@ -253,7 +258,6 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     ui.set_min_width(300.0);
                     let fraction = (pct / 100.0).clamp(0.0, 1.0);
                     let bar = egui::ProgressBar::new(fraction)
-                        .animate(true)
                         .desired_width(300.0);
                     let bar = if pct > 0.0 {
                         bar.text(format!("{:.0}%", pct))

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -235,29 +235,53 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             });
         });
 
-    // Export status row (shown while running or after completion)
+    // Export progress window (floating, centered) — shown while running.
+    // Done / Failed states remain as an inline status row below.
     if let Some(handle) = &state.export {
-        let status = handle.status.lock().unwrap().clone();
+        let status = handle
+            .status
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        if matches!(status, state::ExportStatus::Running) {
+            let pct = f32::from_bits(handle.progress.load(std::sync::atomic::Ordering::Relaxed));
+            egui::Window::new("Exporting…")
+                .collapsible(false)
+                .resizable(false)
+                .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+                .show(&ctx, |ui| {
+                    ui.set_min_width(300.0);
+                    let fraction = (pct / 100.0).clamp(0.0, 1.0);
+                    let bar = egui::ProgressBar::new(fraction)
+                        .animate(true)
+                        .desired_width(300.0);
+                    let bar = if pct > 0.0 {
+                        bar.text(format!("{:.0}%", pct))
+                    } else {
+                        bar.text("Encoding…")
+                    };
+                    ui.add(bar);
+                });
+            // Keep the UI updating while the background task runs.
+            ctx.request_repaint_after(std::time::Duration::from_millis(200));
+        }
+    }
+
+    // Export completion / failure row
+    if let Some(handle) = &state.export {
+        let status = handle
+            .status
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
         match status {
-            state::ExportStatus::Running => {
-                let pct =
-                    f32::from_bits(handle.progress.load(std::sync::atomic::Ordering::Relaxed))
-                        / 100.0;
-                let bar = egui::ProgressBar::new(pct).animate(pct == 0.0);
-                let bar = if pct > 0.0 {
-                    bar.text(format!("{:.0}%", pct * 100.0))
-                } else {
-                    bar.text("Exporting…")
-                };
-                ui.add(bar);
-            }
             state::ExportStatus::Done(path) => {
                 ui.horizontal(|ui| {
                     ui.colored_label(
                         egui::Color32::GREEN,
                         format!("Exported: {}", path.display()),
                     );
-                    if ui.button("Clear").clicked() {
+                    if ui.button("✕").clicked() {
                         clear_export = true;
                     }
                 });
@@ -265,11 +289,12 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             state::ExportStatus::Failed(msg) => {
                 ui.horizontal(|ui| {
                     ui.colored_label(egui::Color32::RED, format!("Export failed: {msg}"));
-                    if ui.button("Dismiss").clicked() {
+                    if ui.button("✕").clicked() {
                         clear_export = true;
                     }
                 });
             }
+            state::ExportStatus::Running => {}
         }
     }
     if clear_export {


### PR DESCRIPTION
## Summary

Fixes three export bugs discovered while validating the avio v0.14 API:

1. **Silent export when A1 track is empty** — V1 clips with embedded audio were silently dropped. Now V1 clips are mirrored to the audio track when A1 has no clips.
2. **AAC encoding failure (`nb_samples > frame_size`)** — Fixed on the avio side by adding `AVAudioFifo` buffering to `push_audio_frame` so AAC's fixed 1024-sample frame size is respected. Also fixed `init_audio_encoder` to use `avcodec_parameters_from_context`, which copies `extradata` (AAC AudioSpecificConfig) required by Windows' built-in decoder.
3. **Progress bar always showing 0%** — `render_with_progress` cannot determine `total_frames` when clips have no `out_point` (play to EOF). Fixed by computing a client-side frame count estimate from `MediaInfo.duration()` and `fps`, used as a fallback when `p.percent()` returns `None`.

## Changes

- `src/export.rs`: Mirror V1 to audio track when A1 is empty; add `source_duration`/`fps` fields to `ExportClip`; compute `total_frames_estimate` as progress fallback; store progress on every frame (not only when `percent()` is `Some`)
- `src/ui/timeline.rs`: Populate `source_duration`/`fps` from `ImportedClip.info`; replace inline progress bar with centered floating window with `request_repaint_after`; remove `.animate(true)` spinner from `ProgressBar`; add PCM to audio codec selector
- `src/state.rs`: Default audio codec set to AAC
- `docs/issue25.md`, `docs/issue26.md`, `docs/issue27.md`: avio gap reports for the three root causes (FIFO, `frame_size` in `codecpar`, `extradata` in `codecpar`)
- avio crate (`ff-encode`): `AVAudioFifo` buffering in `push_audio_frame`; `avcodec_parameters_from_context` in `init_audio_encoder`; FIFO alloc/free lifecycle in `init_audio_encoder`/`cleanup`

## Related Issues

Closes #28
Closes #29
Closes #30

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes