### PR TITLE
fix(clip_browser): restore click/double-click broken by PR #83

### DIFF
--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -105,7 +105,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                         };
 
                         let dnd = ui.dnd_drag_source(dnd_id, idx, |ui| {
-                            let frame_resp = egui::Frame::new()
+                            egui::Frame::new()
                                 .fill(card_bg)
                                 .corner_radius(egui::CornerRadius::same(4))
                                 .inner_margin(egui::Margin::same(3))
@@ -196,12 +196,6 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                                         }
                                     });
                                 });
-                            // dnd_id (not ui.id()) avoids layer-ID collision between DnD ghost and background
-                            ui.interact(
-                                frame_resp.response.rect,
-                                dnd_id.with("card"),
-                                egui::Sense::click(),
-                            )
                         });
 
                         if is_dragging {
@@ -209,10 +203,21 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                         } else if dnd.response.hovered() {
                             ui.ctx().set_cursor_icon(egui::CursorIcon::Default);
                         }
-                        if dnd.inner.clicked() {
+
+                        // Register click sense OUTSIDE the dnd closure so it sits on top of
+                        // the drag widget in egui's hit-test order. When a Sense::drag()-only
+                        // widget is on top, egui suppresses the click widget below it — placing
+                        // the click widget after the drag widget reverses the priority.
+                        // Using a stable per-card ID avoids the layer-hash collision from #82.
+                        let card_response = ui.interact(
+                            dnd.response.rect,
+                            egui::Id::new(("clip_card_click", idx)),
+                            egui::Sense::click(),
+                        );
+                        if card_response.clicked() {
                             clicked_idx = Some(idx);
                         }
-                        if dnd.inner.double_clicked() {
+                        if card_response.double_clicked() {
                             dbl_clicked_idx = Some(idx);
                         }
 

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -257,8 +257,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 .show(&ctx, |ui| {
                     ui.set_min_width(300.0);
                     let fraction = (pct / 100.0).clamp(0.0, 1.0);
-                    let bar = egui::ProgressBar::new(fraction)
-                        .desired_width(300.0);
+                    let bar = egui::ProgressBar::new(fraction).desired_width(300.0);
                     let bar = if pct > 0.0 {
                         bar.text(format!("{:.0}%", pct))
                     } else {


### PR DESCRIPTION
## Summary

Fixes a regression introduced in PR #83 where clicking a clip card no longer selected it and double-clicking no longer started preview playback. The root cause is an egui 0.33 hit-test behavior: when a `Sense::drag()`-only widget is registered on top of a `Sense::click()` widget at the same rect, egui suppresses the click widget entirely.

## Changes

- `src/ui/clip_browser.rs`: Remove `ui.interact()` from inside the `dnd_drag_source` closure; register the click/double-click interaction via `ui.interact()` **after** (outside) `dnd_drag_source` using `egui::Id::new(("clip_card_click", idx))`. This places the click widget above the drag widget in egui's hit-test order, so the hit-test correctly returns both. The stable per-card ID also prevents the layer-hash collision that caused the #82 crash.
- `src/ui/timeline.rs`: Fix `cargo fmt` line-wrap in the progress bar builder chain.

## Root Cause

`dnd_drag_source` internally calls `self.interact(rect, dnd_id, Sense::drag())` **after** the closure, making the drag widget topmost. egui's `hit_test_on_close` has an explicit rule: if a `Sense::drag()`-only widget is on top and the pointer is over it, the click widget below is ignored (`click: None`). This meant `potential_click_id` was never set, so `clicked()` and `double_clicked()` always returned `false`.

## Related Issues

Resolves #83

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes