### PR TITLE
feat(player): clear source monitor on stop; reset timeline playhead on stop

### DIFF
--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -252,6 +252,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
             }
             if ui.button("⏹ Stop").clicked() {
                 stop_player(state);
+                state.monitor_clip_index = None;
+                state.seek_pos_secs = 0.0;
             }
         } else if let Some(idx) = state.monitor_clip_index {
             let has_media = state

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -380,6 +380,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             }
             if ui.button("⏹ Stop").clicked() {
                 state.stop_timeline_player();
+                state.timeline_playhead_secs = 0.0;
             }
         }
 


### PR DESCRIPTION
## Summary

Changes the Stop button behavior based on which player is active. Stopping a source monitor preview now clears the monitor display entirely, and stopping timeline playback resets the playhead indicator to position 0.

## Changes

- `src/ui/monitor.rs`: After stopping the source monitor player, set `monitor_clip_index = None` and `seek_pos_secs = 0.0` so the source monitor clears back to the clip info / idle state.
- `src/ui/timeline.rs`: After stopping the timeline player, set `timeline_playhead_secs = 0.0` so the playhead indicator returns to the start of the timeline.

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes