### PR TITLE
feat(ui): add View menu with Light / Dark / System theme switcher

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,11 +40,30 @@ impl eframe::App for AvioEditorApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         ui::drain_background_jobs(&mut self.state, ctx);
 
+        // Apply the user-selected theme every frame.
+        ctx.set_theme(self.state.theme_preference);
+
         // 1. Top menu bar (must come before all other panels)
         egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
             egui::MenuBar::new().ui(ui, |ui| {
                 ui.menu_button("File", |_ui| {});
                 ui.menu_button("Export", |_ui| {});
+                ui.menu_button("View", |ui| {
+                    ui.label("Theme");
+                    ui.separator();
+                    for (pref, label) in [
+                        (egui::ThemePreference::System, "System"),
+                        (egui::ThemePreference::Dark, "Dark"),
+                        (egui::ThemePreference::Light, "Light"),
+                    ] {
+                        if ui
+                            .radio_value(&mut self.state.theme_preference, pref, label)
+                            .clicked()
+                        {
+                            ui.close();
+                        }
+                    }
+                });
             });
         });
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -66,6 +66,7 @@ pub struct AppState {
     pub loudness_rx: mpsc::Receiver<Option<LoudnessResult>>,
     pub clip_drag: Option<TimelineClipDrag>,
     pub show_export_settings: bool,
+    pub theme_preference: egui::ThemePreference,
 }
 
 impl Default for AppState {
@@ -127,6 +128,7 @@ impl Default for AppState {
             loudness_rx,
             clip_drag: None,
             show_export_settings: false,
+            theme_preference: egui::ThemePreference::System,
         }
     }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,6 +1,8 @@
 /// Studio-grade dark theme for avio-editor-demo.
 ///
 /// Call once from the eframe CreationContext before the first frame.
+/// Stores the custom dark visuals in the Dark theme slot so that switching
+/// between Dark / Light / System all works correctly via `ctx.set_theme()`.
 pub fn apply(ctx: &egui::Context) {
     let mut v = egui::Visuals::dark();
 
@@ -69,23 +71,24 @@ pub fn apply(ctx: &egui::Context) {
         color: egui::Color32::from_black_alpha(120),
     };
 
-    ctx.set_visuals(v);
+    // Store in the Dark slot so ctx.set_theme(Dark/System) always applies these visuals.
+    ctx.set_visuals_of(egui::Theme::Dark, v);
 
-    // Slightly more comfortable spacing and font sizes
-    let mut style = (*ctx.style()).clone();
-    style.text_styles.insert(
-        egui::TextStyle::Body,
-        egui::FontId::new(13.0, egui::FontFamily::Proportional),
-    );
-    style.text_styles.insert(
-        egui::TextStyle::Button,
-        egui::FontId::new(13.0, egui::FontFamily::Proportional),
-    );
-    style.text_styles.insert(
-        egui::TextStyle::Small,
-        egui::FontId::new(11.0, egui::FontFamily::Proportional),
-    );
-    style.spacing.button_padding = egui::vec2(8.0, 4.0);
-    style.spacing.item_spacing = egui::vec2(8.0, 5.0);
-    ctx.set_style(style);
+    // Apply comfortable spacing and font sizes to both themes.
+    ctx.all_styles_mut(|style| {
+        style.text_styles.insert(
+            egui::TextStyle::Body,
+            egui::FontId::new(13.0, egui::FontFamily::Proportional),
+        );
+        style.text_styles.insert(
+            egui::TextStyle::Button,
+            egui::FontId::new(13.0, egui::FontFamily::Proportional),
+        );
+        style.text_styles.insert(
+            egui::TextStyle::Small,
+            egui::FontId::new(11.0, egui::FontFamily::Proportional),
+        );
+        style.spacing.button_padding = egui::vec2(8.0, 4.0);
+        style.spacing.item_spacing = egui::vec2(8.0, 5.0);
+    });
 }


### PR DESCRIPTION
## Summary

Adds a **View** menu to the menu bar with Light, Dark, and System theme options. The default is System (follows the OS dark/light preference). The custom studio dark theme is preserved when switching to Dark or System mode.

## Changes

- `src/main.rs`: Apply `ctx.set_theme(state.theme_preference)` each frame; add View menu with radio buttons for System / Dark / Light.
- `src/state.rs`: Add `theme_preference: egui::ThemePreference` field (default: `System`).
- `src/ui/theme.rs`: Switch from `ctx.set_visuals()` to `ctx.set_visuals_of(Theme::Dark, v)` so the custom dark visuals are stored in the Dark slot and survive theme switches. Apply font sizes and spacing via `ctx.all_styles_mut()` so they apply to both themes.

## Related Issues

Closes #87

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes