### PR TITLE
feat(timeline): replace respawn with update_timeline on clip-drag resume

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -354,6 +354,46 @@ pub fn spawn_player(
     (thread, handle_rx, proxy_rx)
 }
 
+// ── build_timeline ─────────────────────────────────────────────────────────────
+
+/// Constructs an `avio::Timeline` from `TrackClipData` lists without spawning a
+/// player thread. Used by the Resume handler when clips were repositioned while
+/// paused: instead of tearing down and respawning `TimelineRunner`, the caller
+/// builds the updated timeline and calls `handle.update_timeline()`.
+pub fn build_timeline(
+    v1: Vec<TrackClipData>,
+    v2: Vec<TrackClipData>,
+    a1: Vec<TrackClipData>,
+) -> Result<avio::Timeline, String> {
+    let make_clip = |tc: TrackClipData| -> avio::Clip {
+        let mut c = avio::Clip::new(&tc.path).offset(tc.start_on_track);
+        c.in_point = tc.in_point;
+        c.out_point = tc.out_point;
+        if let Some(kind) = tc.transition {
+            c = c.with_transition(kind, tc.transition_duration);
+        }
+        c
+    };
+
+    let v1_clips: Vec<avio::Clip> = v1.into_iter().map(make_clip).collect();
+    let v2_clips: Vec<avio::Clip> = v2.into_iter().map(make_clip).collect();
+    let a1_clips: Vec<avio::Clip> = a1.into_iter().map(make_clip).collect();
+
+    if v1_clips.is_empty() {
+        return Err("no V1 clips".into());
+    }
+
+    let mut builder = avio::Timeline::builder().video_track(v1_clips);
+    if !v2_clips.is_empty() {
+        builder = builder.video_track(v2_clips);
+    }
+    if !a1_clips.is_empty() {
+        builder = builder.audio_track(a1_clips);
+    }
+
+    builder.build().map_err(|e| e.to_string())
+}
+
 // ── spawn_timeline_player ──────────────────────────────────────────────────────
 
 /// Spawns a background thread running `TimelineRunner::run()` for multi-track playback.

--- a/src/state.rs
+++ b/src/state.rs
@@ -55,6 +55,10 @@ pub struct AppState {
     pub timeline_player_handle: Option<avio::PlayerHandle>,
     pub timeline_pending_handle_rx: Option<mpsc::Receiver<avio::PlayerHandle>>,
     pub timeline_is_paused: bool,
+    /// Set when one or more timeline clips are moved while the player is paused.
+    /// Causes Resume to respawn the player (which rebuilds clip positions) instead
+    /// of calling h.play() on the stale runner.
+    pub clips_moved_while_paused: bool,
     pub av_offset_ms: i32,
     pub export: Option<ExportHandle>,
     pub encoder_config: EncoderConfigDraft,
@@ -117,6 +121,7 @@ impl Default for AppState {
             timeline_player_handle: None,
             timeline_pending_handle_rx: None,
             timeline_is_paused: false,
+            clips_moved_while_paused: false,
             av_offset_ms: 0,
             export: None,
             encoder_config: EncoderConfigDraft::default(),
@@ -360,6 +365,7 @@ impl AppState {
         self.timeline_player_thread = None;
         self.timeline_pending_handle_rx = None;
         self.timeline_is_paused = false;
+        self.clips_moved_while_paused = false;
     }
 }
 

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -370,50 +370,48 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             let pause_label = if is_paused { "⏵ Resume" } else { "⏸ Pause" };
             if ui.button(pause_label).clicked() {
                 if is_paused {
-                    // Respawn from the current playhead rather than calling h.play().
-                    // seek-while-paused only moves the video decoder; the audio buffer
-                    // stays at the pause point, causing A/V drift on resume.
-                    // A fresh player always starts both streams in sync.
-                    state.stop_timeline_player();
-                    let clips = &state.clips;
-                    let make_tcd = |tc: &state::TimelineClip| player::TrackClipData {
-                        path: clips[tc.source_index].path.clone(),
-                        start_on_track: tc.start_on_track,
-                        in_point: tc.in_point,
-                        out_point: tc.out_point,
-                        transition: tc.transition,
-                        transition_duration: tc.transition_duration,
-                    };
-                    let v1: Vec<_> = state.timeline.tracks[0]
-                        .clips
-                        .iter()
-                        .map(make_tcd)
-                        .collect();
-                    let v2: Vec<_> = state.timeline.tracks[1]
-                        .clips
-                        .iter()
-                        .map(make_tcd)
-                        .collect();
-                    let a1: Vec<_> = state.timeline.tracks[2]
-                        .clips
-                        .iter()
-                        .map(make_tcd)
-                        .collect();
-                    let start = Duration::from_secs_f64(state.timeline_playhead_secs.max(0.0));
-                    state
-                        .cpal_rate
-                        .store(1.0f64.to_bits(), std::sync::atomic::Ordering::Relaxed);
-                    let (thread, handle_rx) = player::spawn_timeline_player(
-                        v1,
-                        v2,
-                        a1,
-                        Arc::clone(&state.frame_handle),
-                        ctx.clone(),
-                        start,
-                        Arc::clone(&state.cpal_rate),
-                    );
-                    state.timeline_player_thread = Some(thread);
-                    state.timeline_pending_handle_rx = Some(handle_rx);
+                    if state.clips_moved_while_paused {
+                        // One or more clips were repositioned while paused.
+                        // Send the updated layout to the running runner so it
+                        // updates positions in place and seeks to the last known
+                        // PTS — no teardown needed.
+                        let clips = &state.clips;
+                        let make_tcd = |tc: &state::TimelineClip| player::TrackClipData {
+                            path: clips[tc.source_index].path.clone(),
+                            start_on_track: tc.start_on_track,
+                            in_point: tc.in_point,
+                            out_point: tc.out_point,
+                            transition: tc.transition,
+                            transition_duration: tc.transition_duration,
+                        };
+                        let v1: Vec<_> = state.timeline.tracks[0]
+                            .clips
+                            .iter()
+                            .map(make_tcd)
+                            .collect();
+                        let v2: Vec<_> = state.timeline.tracks[1]
+                            .clips
+                            .iter()
+                            .map(make_tcd)
+                            .collect();
+                        let a1: Vec<_> = state.timeline.tracks[2]
+                            .clips
+                            .iter()
+                            .map(make_tcd)
+                            .collect();
+                        match player::build_timeline(v1, v2, a1) {
+                            Ok(tl) => {
+                                if let Some(h) = &state.timeline_player_handle {
+                                    h.update_timeline(tl);
+                                }
+                            }
+                            Err(e) => log::warn!("build_timeline failed: {e}"),
+                        }
+                        state.clips_moved_while_paused = false;
+                    }
+                    if let Some(h) = &state.timeline_player_handle {
+                        h.play();
+                    }
                     state.timeline_is_paused = false;
                 } else if let Some(h) = &state.timeline_player_handle {
                     h.pause();
@@ -462,6 +460,10 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
     let active_drag = state.clip_drag.clone();
     let mut new_drag: Option<state::TimelineClipDrag> = None;
     let mut clear_drag = false;
+    // Set to true when a clip is dropped to a new position while the player is
+    // paused. Resume must respawn the player so TimelineRunner gets the updated
+    // clip layout; h.play() alone cannot update the runner's internal state.
+    let mut moved_while_paused = false;
     let tracks_count = state.timeline.tracks.len();
 
     egui::ScrollArea::horizontal()
@@ -750,6 +752,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                             dst_track,
                                             new_start,
                                         ));
+                                        if state.timeline_is_paused {
+                                            moved_while_paused = true;
+                                        }
                                     }
                                     clear_drag = true;
                                 }
@@ -958,6 +963,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
     }
     if let Some(nd) = new_drag {
         state.clip_drag = Some(nd);
+    }
+    if moved_while_paused {
+        state.clips_moved_while_paused = true;
     }
 
     // Apply timeline clip moves.


### PR DESCRIPTION
## Summary

Replace the full player teardown/respawn on clip-drag resume with `PlayerHandle::update_timeline()`, the new avio API that pushes a repositioned clip layout to the running `TimelineRunner` in-place. The clock and paused/stopped state are unaffected, so playback resumes from the exact frame where it was paused with no A/V glitch.

## Changes

- `src/player.rs`: add `build_timeline()` helper that constructs an `avio::Timeline` from `TrackClipData` lists without spawning a thread
- `src/state.rs`: add `clips_moved_while_paused: bool` flag; reset in `stop_timeline_player()`
- `src/ui/timeline.rs`: set `clips_moved_while_paused` on drag-stop when paused; on resume, call `build_timeline` + `h.update_timeline()` instead of `stop_timeline_player` + `spawn_timeline_player`

## Related Issues

Resolves #88

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes