### PR TITLE
feat(timeline): undo/redo with 50-step history and Edit menu

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,42 @@ impl eframe::App for AvioEditorApp {
         egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
             egui::MenuBar::new().ui(ui, |ui| {
                 ui.menu_button("File", |_ui| {});
+                ui.menu_button("Edit", |ui| {
+                    let can_undo = !self.state.undo_stack.is_empty();
+                    let can_redo = !self.state.redo_stack.is_empty();
+                    let undo_label = self
+                        .state
+                        .undo_stack
+                        .last()
+                        .map(|c| format!("Undo {}", c.label()))
+                        .unwrap_or_else(|| "Undo".to_string());
+                    let redo_label = self
+                        .state
+                        .redo_stack
+                        .last()
+                        .map(|c| format!("Redo {}", c.label()))
+                        .unwrap_or_else(|| "Redo".to_string());
+                    if ui
+                        .add_enabled(
+                            can_undo,
+                            egui::Button::new(undo_label).shortcut_text("Ctrl+Z"),
+                        )
+                        .clicked()
+                    {
+                        self.state.apply_undo();
+                        ui.close();
+                    }
+                    if ui
+                        .add_enabled(
+                            can_redo,
+                            egui::Button::new(redo_label).shortcut_text("Ctrl+Y"),
+                        )
+                        .clicked()
+                    {
+                        self.state.apply_redo();
+                        ui.close();
+                    }
+                });
                 ui.menu_button("Export", |_ui| {});
                 ui.menu_button("View", |ui| {
                     ui.label("Theme");

--- a/src/state.rs
+++ b/src/state.rs
@@ -27,6 +27,25 @@ pub struct TimelineClipDrag {
     pub grab_offset_secs: f32,
 }
 
+/// A reversible timeline edit stored as per-track clip-vec snapshots.
+/// Undo = restore `before`; redo = restore `after`.
+#[derive(Clone)]
+pub enum EditCommand {
+    TrackSnapshot {
+        /// `(track_index, clips_before, clips_after)` for every modified track.
+        snapshots: Vec<(usize, Vec<TimelineClip>, Vec<TimelineClip>)>,
+        label: &'static str,
+    },
+}
+
+impl EditCommand {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::TrackSnapshot { label, .. } => label,
+        }
+    }
+}
+
 pub struct AppState {
     pub clips: Vec<ImportedClip>,
     pub selected_clip_index: Option<usize>,
@@ -87,6 +106,8 @@ pub struct AppState {
     pub clip_trim: Option<TimelineClipTrimDrag>,
     pub show_export_settings: bool,
     pub theme_preference: egui::ThemePreference,
+    pub undo_stack: Vec<EditCommand>,
+    pub redo_stack: Vec<EditCommand>,
 }
 
 impl Default for AppState {
@@ -151,6 +172,8 @@ impl Default for AppState {
             clip_trim: None,
             show_export_settings: false,
             theme_preference: egui::ThemePreference::System,
+            undo_stack: Vec::new(),
+            redo_stack: Vec::new(),
         }
     }
 }
@@ -324,6 +347,7 @@ pub struct Track {
     pub clips: Vec<TimelineClip>,
 }
 
+#[derive(Clone, PartialEq)]
 pub struct TimelineClip {
     pub source_index: usize,
     pub start_on_track: Duration,
@@ -383,6 +407,58 @@ impl AppState {
         self.timeline_pending_handle_rx = None;
         self.timeline_is_paused = false;
         self.clips_moved_while_paused = false;
+    }
+
+    pub fn push_edit(&mut self, cmd: EditCommand) {
+        self.redo_stack.clear();
+        self.undo_stack.push(cmd);
+        if self.undo_stack.len() > 50 {
+            self.undo_stack.remove(0);
+        }
+    }
+
+    fn pause_timeline_if_playing(&mut self) {
+        let is_playing = self
+            .timeline_player_thread
+            .as_ref()
+            .map(|h| !h.is_finished())
+            .unwrap_or(false);
+        if is_playing && !self.timeline_is_paused {
+            if let Some(h) = &self.timeline_player_handle {
+                h.pause();
+            }
+            self.timeline_is_paused = true;
+        }
+    }
+
+    pub fn apply_undo(&mut self) {
+        self.pause_timeline_if_playing();
+        if let Some(cmd) = self.undo_stack.pop() {
+            match &cmd {
+                EditCommand::TrackSnapshot { snapshots, .. } => {
+                    for (ti, before, _) in snapshots {
+                        self.timeline.tracks[*ti].clips = before.clone();
+                    }
+                }
+            }
+            self.redo_stack.push(cmd);
+            self.clips_moved_while_paused = true;
+        }
+    }
+
+    pub fn apply_redo(&mut self) {
+        self.pause_timeline_if_playing();
+        if let Some(cmd) = self.redo_stack.pop() {
+            match &cmd {
+                EditCommand::TrackSnapshot { snapshots, .. } => {
+                    for (ti, _, after) in snapshots {
+                        self.timeline.tracks[*ti].clips = after.clone();
+                    }
+                }
+            }
+            self.undo_stack.push(cmd);
+            self.clips_moved_while_paused = true;
+        }
     }
 }
 

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -305,8 +305,15 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
     }
 
     // ── Timeline playback controls ────────────────────────────────────────────
-    let mut do_split = !ui.ctx().wants_keyboard_input()
-        && ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::X));
+    let wants_kb = ui.ctx().wants_keyboard_input();
+    let mut do_split =
+        !wants_kb && ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::X));
+    let do_undo = !wants_kb && ui.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::Z));
+    let do_redo = !wants_kb
+        && (ui.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::Y))
+            || ui.input_mut(|i| {
+                i.consume_key(egui::Modifiers::CTRL | egui::Modifiers::SHIFT, egui::Key::Z)
+            }));
 
     ui.horizontal(|ui| {
         let v1_empty = state.timeline.tracks[0].clips.is_empty();
@@ -1163,6 +1170,28 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             );
         }); // end ScrollArea
 
+    // Apply undo/redo — must happen before the snapshot.
+    let mut applied_undo_redo = false;
+    if do_undo {
+        state.apply_undo();
+        applied_undo_redo = true;
+    }
+    if do_redo {
+        state.apply_redo();
+        applied_undo_redo = true;
+    }
+
+    // Snapshot all 3 tracks before applying any pending ops.
+    let tracks_before: [Vec<state::TimelineClip>; 3] =
+        std::array::from_fn(|i| state.timeline.tracks[i].clips.clone());
+    // Flags captured before pending vecs are consumed by for-loops.
+    let had_trims = !pending_trims.is_empty();
+    let had_moves = !pending_moves.is_empty();
+    let had_clips = !pending_clips.is_empty();
+    let had_transitions = !pending_transitions.is_empty();
+    let had_ripple_delete = pending_deletes.iter().any(|d| d.2);
+    let had_deletes = !pending_deletes.is_empty();
+
     // Apply drag / trim state changes.
     if clear_drag {
         state.clip_drag = None;
@@ -1311,6 +1340,42 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
         }
         if state.timeline_is_paused {
             state.clips_moved_while_paused = true;
+        }
+    }
+
+    // Record undo command if tracks changed and this wasn't an undo/redo.
+    if !applied_undo_redo {
+        let label: &'static str = if do_split {
+            "Split Clip"
+        } else if had_ripple_delete {
+            "Ripple Delete"
+        } else if had_deletes {
+            "Delete Clip"
+        } else if had_moves {
+            "Move Clip"
+        } else if had_trims {
+            "Trim Clip"
+        } else if had_transitions {
+            "Set Transition"
+        } else if had_clips {
+            "Add Clip"
+        } else {
+            ""
+        };
+        if !label.is_empty() {
+            let snapshots: Vec<_> = (0..3_usize)
+                .filter(|&i| state.timeline.tracks[i].clips != tracks_before[i])
+                .map(|i| {
+                    (
+                        i,
+                        tracks_before[i].clone(),
+                        state.timeline.tracks[i].clips.clone(),
+                    )
+                })
+                .collect();
+            if !snapshots.is_empty() {
+                state.push_edit(state::EditCommand::TrackSnapshot { snapshots, label });
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements a 50-step undo/redo history for all destructive timeline edit operations. Every move, trim, split, delete, ripple delete, and add-clip action is captured as a before/after snapshot. Ctrl+Z / Ctrl+Y (or Ctrl+Shift+Z) reverse and replay edits; an Edit menu shows the operation name.

## Changes

- `src/state.rs`: Added `EditCommand::TrackSnapshot` enum with per-track `Vec<TimelineClip>` snapshots and a label string; added `undo_stack` / `redo_stack` to `AppState`; added `push_edit`, `apply_undo`, `apply_redo` methods (undo/redo auto-pauses the timeline player and sets `clips_moved_while_paused`)
- `src/ui/timeline.rs`: Detects Ctrl+Z / Ctrl+Y / Ctrl+Shift+Z before the ScrollArea; after the ScrollArea, applies undo/redo first, snapshots all 3 tracks, applies all pending ops, then diffs and pushes an `EditCommand` only when tracks actually changed and the action was not itself an undo/redo
- `src/main.rs`: Added Edit menu between File and Export with greyed-out Undo/Redo items displaying the operation name and keyboard shortcut hints

## Related Issues

Closes #93

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes