### PR TITLE
feat(timeline): add loop region playback with I/O markers

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -117,6 +117,10 @@ pub struct AppState {
     pub jkl_forward_rate: f64,
     /// Current J-key reverse rate. 0.0 = not reversing; positive = 1/2/4/8×.
     pub jkl_reverse_rate: f64,
+    // ── Timeline loop region ─────────────────────────────────────────────────
+    pub timeline_loop_in: Option<std::time::Duration>,
+    pub timeline_loop_out: Option<std::time::Duration>,
+    pub timeline_loop_enabled: bool,
 }
 
 impl Default for AppState {
@@ -187,6 +191,9 @@ impl Default for AppState {
             timeline_clipboard: None,
             jkl_forward_rate: 0.0,
             jkl_reverse_rate: 0.0,
+            timeline_loop_in: None,
+            timeline_loop_out: None,
+            timeline_loop_enabled: false,
         }
     }
 }

--- a/src/ui/drain.rs
+++ b/src/ui/drain.rs
@@ -176,6 +176,19 @@ fn drain_frame(state: &mut AppState, ctx: &egui::Context) {
             .unwrap_or(false)
         {
             state.timeline_playhead_secs = frame.pts.as_secs_f64();
+            // Loop-back: when loop is enabled and the presented frame reaches the
+            // out-point, seek back to the in-point.
+            if state.timeline_loop_enabled
+                && !state.timeline_is_paused
+                && let Some(loop_out) = state.timeline_loop_out
+                && let Some(loop_in) = state.timeline_loop_in
+                && loop_in < loop_out
+                && frame.pts >= loop_out
+                && let Some(handle) = &state.timeline_player_handle
+            {
+                handle.seek(loop_in);
+                state.timeline_playhead_secs = loop_in.as_secs_f64();
+            }
         } else {
             state.current_pts = Some(frame.pts);
         }

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -484,6 +484,10 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
         });
     let do_duplicate =
         !wants_kb && ui.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::D));
+    let do_loop_in =
+        !wants_kb && ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::I));
+    let do_loop_out =
+        !wants_kb && ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::O));
 
     ui.horizontal(|ui| {
         let v1_empty = state.timeline.tracks[0].clips.is_empty();
@@ -612,6 +616,17 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             if ui.button("⏹ Stop").clicked() {
                 state.stop_timeline_player();
                 state.timeline_playhead_secs = 0.0;
+                state.timeline_loop_in = None;
+                state.timeline_loop_out = None;
+                state.timeline_loop_enabled = false;
+            }
+            ui.separator();
+            if ui
+                .selectable_label(state.timeline_loop_enabled, "⟲")
+                .on_hover_text("Loop between I/O markers (I = in, O = out)")
+                .clicked()
+            {
+                state.timeline_loop_enabled = !state.timeline_loop_enabled;
             }
         }
 
@@ -737,6 +752,55 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             );
                         }
                     }
+                }
+            }
+
+            // Loop region: shaded band + I/O marker lines
+            if let (Some(li), Some(lo)) = (state.timeline_loop_in, state.timeline_loop_out)
+                && li < lo
+            {
+                let x1 = (timeline_left + li.as_secs_f32() * pps).max(timeline_left);
+                let x2 = (timeline_left + lo.as_secs_f32() * pps).min(ruler_rect.right());
+                if x1 < x2 {
+                    painter.rect_filled(
+                        egui::Rect::from_x_y_ranges(x1..=x2, ruler_rect.y_range()),
+                        0.0,
+                        egui::Color32::from_rgba_unmultiplied(100, 200, 255, 40),
+                    );
+                }
+            }
+            if let Some(li) = state.timeline_loop_in {
+                let x = timeline_left + li.as_secs_f32() * pps;
+                if x >= timeline_left && x <= ruler_rect.right() {
+                    painter.vline(
+                        x,
+                        ruler_rect.y_range(),
+                        egui::Stroke::new(2.0, egui::Color32::from_rgb(100, 200, 255)),
+                    );
+                    painter.text(
+                        egui::pos2(x + 2.0, ruler_rect.top() + 2.0),
+                        egui::Align2::LEFT_TOP,
+                        "I",
+                        egui::FontId::monospace(9.0),
+                        egui::Color32::from_rgb(100, 200, 255),
+                    );
+                }
+            }
+            if let Some(lo) = state.timeline_loop_out {
+                let x = timeline_left + lo.as_secs_f32() * pps;
+                if x >= timeline_left && x <= ruler_rect.right() {
+                    painter.vline(
+                        x,
+                        ruler_rect.y_range(),
+                        egui::Stroke::new(2.0, egui::Color32::from_rgb(100, 200, 255)),
+                    );
+                    painter.text(
+                        egui::pos2(x + 2.0, ruler_rect.top() + 2.0),
+                        egui::Align2::LEFT_TOP,
+                        "O",
+                        egui::FontId::monospace(9.0),
+                        egui::Color32::from_rgb(100, 200, 255),
+                    );
                 }
             }
 
@@ -1730,5 +1794,16 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 state.push_edit(state::EditCommand::TrackSnapshot { snapshots, label });
             }
         }
+    }
+
+    if do_loop_in {
+        state.timeline_loop_in = Some(std::time::Duration::from_secs_f64(
+            state.timeline_playhead_secs,
+        ));
+    }
+    if do_loop_out {
+        state.timeline_loop_out = Some(std::time::Duration::from_secs_f64(
+            state.timeline_playhead_secs,
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Implements timeline loop region playback. Users can mark a loop in-point (I key) and out-point (O key) on the timeline ruler, enable looping via the ⟲ button, and playback will automatically seek back to the in-point when it reaches the out-point.

## Changes

- `src/state.rs`: Added `timeline_loop_in`, `timeline_loop_out` (both `Option<Duration>`), and `timeline_loop_enabled` (bool) to `AppState`
- `src/ui/timeline.rs`: I/O key handlers to set loop markers at current playhead; ⟲ toggle button in transport bar; ruler shading (semi-transparent blue band + I/O marker lines); Stop button clears all loop state
- `src/ui/drain.rs`: Loop-back detection after playhead update — when loop is enabled, paused=false, and presented frame PTS ≥ loop_out, seeks back to loop_in

## Related Issues

Closes #96

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes