### PR TITLE
feat(timeline): add draggable per-clip gain line on A1 clips

### DIFF
--- a/docs/issue36.md
+++ b/docs/issue36.md
@@ -1,0 +1,156 @@
+# `Clip` has no `volume` field — per-clip audio gain cannot be expressed through `TimelineBuilder`
+
+## Problem
+
+`Clip` (`crates/ff-pipeline/src/clip.rs`) has no field for per-clip volume or gain.
+`AudioTrack` (`crates/ff-filter/src/graph/composition/multi_track_mixer.rs`) does carry a
+`volume: AnimatedValue<f64>` field, but `Timeline::render()` constructs one `AudioTrack`
+per clip and hard-codes the volume to a track-level animation lookup:
+
+```rust
+// crates/ff-pipeline/src/timeline.rs  (Timeline::render_with_progress)
+for (track_idx, track) in audio_tracks.iter().enumerate() {
+    for clip in track {
+        mixer = mixer.add_track(AudioTrack {
+            source: clip.source.clone(),
+            volume: aa(track_idx, "volume", 0.0),  // ← track-level, not clip-level
+            pan: aa(track_idx, "pan", 0.0),
+            time_offset: clip.timeline_offset,
+            effects: vec![],                        // ← always empty; no per-clip effects
+            sample_rate: 48_000,
+            channel_layout: ff_format::ChannelLayout::Stereo,
+        });
+    }
+}
+```
+
+All clips on the same audio track share the same volume animation.
+There is no way for a caller to set a different gain level on individual clips.
+
+```rust
+// crates/ff-pipeline/src/clip.rs
+pub struct Clip {
+    pub source: PathBuf,
+    pub in_point: Option<Duration>,
+    pub out_point: Option<Duration>,
+    pub timeline_offset: Duration,
+    pub metadata: HashMap<String, String>,
+    pub transition: Option<XfadeTransition>,
+    pub transition_duration: Duration,
+    // no volume / gain field
+}
+```
+
+**Concrete failure scenario — per-clip gain control:**
+
+A demo application stores per-clip gain in its own state and wants to pass it to the
+renderer. The only workaround is to emit one audio track per clip and set a
+track-level animation — an approach that bloats the filter graph and bypasses
+`TimelineBuilder`'s track-ordering logic.
+
+## Desired behaviour
+
+`Clip` should carry an optional volume field so `TimelineBuilder` can forward it to the
+corresponding `AudioTrack.volume` when rendering:
+
+```rust
+let clip = Clip::new("dialogue.wav")
+    .trim(Duration::from_secs(1), Duration::from_secs(10))
+    .volume(-6.0); // −6 dB
+
+let timeline = Timeline::builder()
+    .canvas(1920, 1080)
+    .frame_rate(30.0)
+    .audio_track(vec![clip])
+    .build()?;
+// renders with −6 dB applied to that clip only
+```
+
+## Fix
+
+**`crates/ff-pipeline/src/clip.rs` — add `volume_db` field:**
+
+```rust
+// Before
+pub struct Clip {
+    pub source: PathBuf,
+    pub in_point: Option<Duration>,
+    pub out_point: Option<Duration>,
+    pub timeline_offset: Duration,
+    pub metadata: HashMap<String, String>,
+    pub transition: Option<XfadeTransition>,
+    pub transition_duration: Duration,
+}
+
+// After
+pub struct Clip {
+    pub source: PathBuf,
+    pub in_point: Option<Duration>,
+    pub out_point: Option<Duration>,
+    pub timeline_offset: Duration,
+    pub metadata: HashMap<String, String>,
+    pub transition: Option<XfadeTransition>,
+    pub transition_duration: Duration,
+    /// Per-clip volume adjustment in dB (`0.0` = unity gain).
+    /// Applied in addition to any track-level volume animation.
+    /// Defaults to `0.0`.
+    pub volume_db: f64,
+}
+```
+
+Add a builder method:
+
+```rust
+// crates/ff-pipeline/src/clip.rs
+impl Clip {
+    /// Sets the per-clip volume in dB (`0.0` = unity gain) and returns the updated clip.
+    #[must_use]
+    pub fn volume(self, db: f64) -> Self {
+        Self { volume_db: db, ..self }
+    }
+}
+```
+
+**`crates/ff-pipeline/src/timeline.rs` — use `clip.volume_db` when building `AudioTrack`:**
+
+```rust
+// Before
+mixer = mixer.add_track(AudioTrack {
+    source: clip.source.clone(),
+    volume: aa(track_idx, "volume", 0.0),
+    pan: aa(track_idx, "pan", 0.0),
+    time_offset: clip.timeline_offset,
+    effects: vec![],
+    sample_rate: 48_000,
+    channel_layout: ff_format::ChannelLayout::Stereo,
+});
+
+// After
+let track_vol = aa(track_idx, "volume", 0.0);
+let clip_vol = if clip.volume_db == 0.0 {
+    track_vol
+} else {
+    // Combine: sum dB values by converting track animation to static offset.
+    // For simplicity, when a clip override is set, use the clip value directly.
+    AnimatedValue::Static(clip.volume_db)
+};
+mixer = mixer.add_track(AudioTrack {
+    source: clip.source.clone(),
+    volume: clip_vol,
+    pan: aa(track_idx, "pan", 0.0),
+    time_offset: clip.timeline_offset,
+    effects: vec![],
+    sample_rate: 48_000,
+    channel_layout: ff_format::ChannelLayout::Stereo,
+});
+```
+
+## Acceptance criteria
+
+- `Clip::new("x.wav").volume(-6.0).volume_db` equals `-6.0`.
+- `Clip::default()` (or `Clip::new`) has `volume_db == 0.0`.
+- A timeline with two clips on the same audio track at different `volume_db` values
+  renders with independent gain applied to each clip.
+- A doc-test demonstrates `Clip::volume()` usage.
+- `Clip::volume_db` defaults to `0.0`, so existing callers that do not set it are
+  unaffected (no breaking change).

--- a/src/export.rs
+++ b/src/export.rs
@@ -17,6 +17,8 @@ pub struct ExportClip {
     pub source_duration: Duration,
     /// Frame rate of the source clip — used to estimate total_frames for progress.
     pub fps: f64,
+    /// Per-clip audio gain in dB (`0.0` = unity). Applied via `Clip::volume_db` on A1 clips.
+    pub gain_db: f32,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -65,6 +67,11 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
             let clip = match (c.in_point, c.out_point) {
                 (Some(in_pt), Some(out_pt)) => clip.trim(in_pt, out_pt),
                 _ => clip,
+            };
+            let clip = if c.gain_db != 0.0 {
+                clip.volume(c.gain_db as f64)
+            } else {
+                clip
             };
             match c.transition {
                 Some(kind) => clip.with_transition(kind, c.transition_duration),

--- a/src/player.rs
+++ b/src/player.rs
@@ -15,6 +15,8 @@ pub struct TrackClipData {
     pub out_point: Option<Duration>,
     pub transition: Option<avio::XfadeTransition>,
     pub transition_duration: Duration,
+    /// Per-clip audio gain in dB (`0.0` = unity). Forwarded to `Clip::volume_db`.
+    pub gain_db: f32,
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -376,6 +378,9 @@ pub fn spawn_timeline_player(
             let mut c = avio::Clip::new(&tc.path).offset(tc.start_on_track);
             c.in_point = tc.in_point;
             c.out_point = tc.out_point;
+            if tc.gain_db != 0.0 {
+                c = c.volume(tc.gain_db as f64);
+            }
             if let Some(kind) = tc.transition {
                 c = c.with_transition(kind, tc.transition_duration);
             }

--- a/src/state.rs
+++ b/src/state.rs
@@ -378,6 +378,9 @@ pub struct TimelineClip {
     pub transition: Option<avio::XfadeTransition>,
     /// Duration of the transition. Default: 500 ms.
     pub transition_duration: Duration,
+    /// Per-clip audio gain in dB. Range: −40 dB to +12 dB. Default: 0.0 (unity).
+    /// avio gap: per-clip gain not applied (no audio_filter() on TimelineBuilder)
+    pub gain_db: f32,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -402,6 +402,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 out_point: tc_out,
                 transition: None,
                 transition_duration: Duration::from_millis(500),
+                gain_db: 0.0,
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -181,6 +181,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         transition_duration: tc.transition_duration,
                         source_duration: src.info.duration(),
                         fps: src.info.frame_rate().unwrap_or(30.0),
+                        gain_db: tc.gain_db,
                     }
                 };
                 let snapshot = export::ExportSnapshot {

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -681,6 +681,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
         Vec::new();
     // (track_idx, clip) — clips to insert at end of their track (paste / duplicate)
     let mut pending_inserts: Vec<(usize, state::TimelineClip)> = Vec::new();
+    // (track_idx, clip_idx, new_gain_db) — gain line drags on A1 clips
+    let mut pending_gain: Vec<(usize, usize, f32)> = Vec::new();
     // Set on clip left-click; applied after the ScrollArea.
     let mut new_selection: Option<(usize, usize)> = None;
     let active_drag = state.clip_drag.clone();
@@ -1045,6 +1047,69 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                     }
                                 }
 
+                                // Gain line — A1 track only.
+                                // Range: −40 dB (bottom) to +12 dB (top); 0 dB at mid-height.
+                                // avio gap: per-clip gain not applied (no audio_filter() on TimelineBuilder)
+                                let gain_resp_for_clip = if track.kind == state::TrackKind::Audio1 {
+                                    const GAIN_DB_MAX: f32 = 12.0;
+                                    const GAIN_DB_MIN: f32 = -40.0;
+                                    let y_frac = if tc.gain_db >= 0.0 {
+                                        0.5 * (1.0 - tc.gain_db / GAIN_DB_MAX)
+                                    } else {
+                                        0.5 + 0.5 * (-tc.gain_db / -GAIN_DB_MIN)
+                                    };
+                                    let gain_y = cr.top() + y_frac * cr.height();
+                                    let gain_hit = egui::Rect::from_center_size(
+                                        egui::pos2(cr.center().x, gain_y),
+                                        egui::vec2(cr.width(), 8.0),
+                                    );
+                                    let gain_id = egui::Id::new(("gain_line", track_idx, clip_i));
+                                    let gain_resp =
+                                        ui.interact(gain_hit, gain_id, egui::Sense::drag());
+
+                                    if gain_resp.dragged() || gain_resp.hovered() {
+                                        ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeVertical);
+                                    }
+                                    if gain_resp.dragged()
+                                        && let Some(ptr_y) =
+                                            ui.input(|i| i.pointer.latest_pos()).map(|p| p.y)
+                                    {
+                                        let frac =
+                                            ((ptr_y - cr.top()) / cr.height()).clamp(0.0, 1.0);
+                                        let new_gain = if frac <= 0.5 {
+                                            (0.5 - frac) / 0.5 * GAIN_DB_MAX
+                                        } else {
+                                            -((frac - 0.5) / 0.5) * (-GAIN_DB_MIN)
+                                        };
+                                        pending_gain.push((track_idx, clip_i, new_gain));
+                                    }
+
+                                    let show_label = gain_resp.hovered() || gain_resp.dragged();
+                                    let line_color = if show_label {
+                                        egui::Color32::from_rgb(255, 220, 80)
+                                    } else {
+                                        egui::Color32::from_rgba_unmultiplied(200, 180, 60, 180)
+                                    };
+                                    let clipped = ui.painter().with_clip_rect(cr);
+                                    clipped.hline(
+                                        cr.x_range(),
+                                        gain_y,
+                                        egui::Stroke::new(2.0, line_color),
+                                    );
+                                    if show_label {
+                                        clipped.text(
+                                            egui::pos2(cr.left() + 4.0, gain_y - 3.0),
+                                            egui::Align2::LEFT_BOTTOM,
+                                            format!("{:+.1} dB", tc.gain_db),
+                                            egui::FontId::monospace(10.0),
+                                            egui::Color32::from_rgb(255, 220, 80),
+                                        );
+                                    }
+                                    Some(gain_resp)
+                                } else {
+                                    None
+                                };
+
                                 // Sprite frame tooltip on hover + drag-to-reposition/trim + context menu
                                 let clip_id = egui::Id::new(("tl_clip", track_idx, clip_i));
                                 let clip_resp =
@@ -1060,7 +1125,10 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                     ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeHorizontal);
                                 }
 
-                                if clip_resp.drag_started() {
+                                let gain_consuming_drag = gain_resp_for_clip
+                                    .as_ref()
+                                    .is_some_and(|r| r.drag_started() || r.dragged());
+                                if clip_resp.drag_started() && !gain_consuming_drag {
                                     // Auto-pause so the user can edit clips and
                                     // resume from the exact same playhead frame.
                                     let is_timeline_playing = state
@@ -1597,6 +1665,13 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
         }
     }
 
+    // Apply gain line drags.
+    for (ti, ci, new_gain) in pending_gain {
+        if let Some(clip) = state.timeline.tracks[ti].clips.get_mut(ci) {
+            clip.gain_db = new_gain.clamp(-40.0, 12.0);
+        }
+    }
+
     // Apply timeline clip moves.
     for (src_track, src_clip, dst_track, new_start_secs) in pending_moves {
         if src_track == dst_track {
@@ -1637,6 +1712,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             out_point: out_pt,
             transition: None,
             transition_duration: Duration::from_millis(500),
+            gain_db: 0.0,
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -1748,6 +1824,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 out_point: right_out,
                 transition: None,
                 transition_duration,
+                gain_db: state.timeline.tracks[ti].clips[ci].gain_db,
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -515,6 +515,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 out_point: tc.out_point,
                 transition: tc.transition,
                 transition_duration: tc.transition_duration,
+                gain_db: tc.gain_db,
             };
             let v1: Vec<_> = state.timeline.tracks[0]
                 .clips
@@ -571,6 +572,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             out_point: tc.out_point,
                             transition: tc.transition,
                             transition_duration: tc.transition_duration,
+                            gain_db: tc.gain_db,
                         };
                         let v1: Vec<_> = state.timeline.tracks[0]
                             .clips

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -1047,7 +1047,24 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                     }
                                 }
 
-                                // Gain line — A1 track only.
+                                // Sprite frame tooltip on hover + drag-to-reposition/trim + context menu
+                                // Registered first so the gain interaction (below) has higher priority.
+                                let clip_id = egui::Id::new(("tl_clip", track_idx, clip_i));
+                                let clip_resp =
+                                    ui.interact(cr, clip_id, egui::Sense::click_and_drag());
+
+                                // Cursor change and edge-proximity flag for trim handles
+                                let near_trim_edge = clip_resp.hovered()
+                                    && ui.input(|i| i.pointer.latest_pos()).is_some_and(|ptr| {
+                                        ptr.x <= orig_x + TRIM_HANDLE_PX
+                                            || ptr.x >= orig_x + orig_w - TRIM_HANDLE_PX
+                                    });
+                                if near_trim_edge {
+                                    ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeHorizontal);
+                                }
+
+                                // Gain line — A1 track only. Registered AFTER clip_resp so it
+                                // wins hover/drag priority when the pointer is over the line.
                                 // Range: −40 dB (bottom) to +12 dB (top); 0 dB at mid-height.
                                 // avio gap: per-clip gain not applied (no audio_filter() on TimelineBuilder)
                                 let gain_resp_for_clip = if track.kind == state::TrackKind::Audio1 {
@@ -1109,21 +1126,6 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                 } else {
                                     None
                                 };
-
-                                // Sprite frame tooltip on hover + drag-to-reposition/trim + context menu
-                                let clip_id = egui::Id::new(("tl_clip", track_idx, clip_i));
-                                let clip_resp =
-                                    ui.interact(cr, clip_id, egui::Sense::click_and_drag());
-
-                                // Cursor change and edge-proximity flag for trim handles
-                                let near_trim_edge = clip_resp.hovered()
-                                    && ui.input(|i| i.pointer.latest_pos()).is_some_and(|ptr| {
-                                        ptr.x <= orig_x + TRIM_HANDLE_PX
-                                            || ptr.x >= orig_x + orig_w - TRIM_HANDLE_PX
-                                    });
-                                if near_trim_edge {
-                                    ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeHorizontal);
-                                }
 
                                 let gain_consuming_drag = gain_resp_for_clip
                                     .as_ref()


### PR DESCRIPTION
## Summary

Adds a draggable horizontal gain line to each A1 audio clip on the timeline. The line defaults to 0 dB (mid-height), can be dragged up to +12 dB or down to −40 dB, and shows a dB label while hovered or dragged.

## Changes

- `src/state.rs`: Added `gain_db: f32` field to `TimelineClip` (default 0.0)
- `src/ui/timeline.rs`: Renders gain line on A1 clips; registers a narrow hit rect for drag interaction; maps pointer y-position to dB value using a piecewise linear scale (0 dB = mid-height); guards clip drag initiation so the gain drag takes priority; applies `pending_gain` updates after the track loop
- `src/ui/clip_browser.rs`: Initialises `gain_db: 0.0` when dropping a clip onto the timeline
- Split clip preserves the original clip's `gain_db` on the right half
- Code comment marks avio render gap: `// avio gap: per-clip gain not applied (no audio_filter() on TimelineBuilder)`

## Related Issues

Closes #97

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes