### PR TITLE
feat(timeline): add per-clip color correction (brightness/contrast/saturation)

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -23,6 +23,12 @@ pub struct ExportClip {
     pub fade_in: Duration,
     /// Audio fade-out duration (`Duration::ZERO` = no fade).
     pub fade_out: Duration,
+    /// Per-clip brightness. `0.0` = no change.
+    pub brightness: f32,
+    /// Per-clip contrast. `1.0` = no change.
+    pub contrast: f32,
+    /// Per-clip saturation. `1.0` = no change.
+    pub saturation: f32,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -87,9 +93,15 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
             } else {
                 clip
             };
-            match c.transition {
+            let clip = match c.transition {
                 Some(kind) => clip.with_transition(kind, c.transition_duration),
                 None => clip,
+            };
+            #[allow(clippy::float_cmp)]
+            if c.brightness != 0.0 || c.contrast != 1.0 || c.saturation != 1.0 {
+                clip.with_color_correction(c.brightness, c.contrast, c.saturation)
+            } else {
+                clip
             }
         })
         .collect()
@@ -138,11 +150,6 @@ fn build_and_render(
             snapshot.export_filters.output_height,
         );
     }
-
-    // avio API gap: TimelineBuilder has no video_filter() or post-processing hook.
-    // FilterGraphBuilder::eq(brightness, contrast, saturation) exists in ff-filter
-    // but cannot be attached to Timeline::render() — see docs/issue13.md.
-    // Color balance settings are stored but not applied during render.
 
     // avio API gap: TimelineBuilder has no audio_filter() method.
     // FilterGraphBuilder::loudness_normalize() exists in ff-filter but

--- a/src/player.rs
+++ b/src/player.rs
@@ -21,6 +21,12 @@ pub struct TrackClipData {
     pub fade_in: Duration,
     /// Audio fade-out duration (`Duration::ZERO` = no fade).
     pub fade_out: Duration,
+    /// Per-clip brightness. `0.0` = no change.
+    pub brightness: f32,
+    /// Per-clip contrast. `1.0` = no change.
+    pub contrast: f32,
+    /// Per-clip saturation. `1.0` = no change.
+    pub saturation: f32,
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -393,6 +399,10 @@ pub fn spawn_timeline_player(
             }
             if let Some(kind) = tc.transition {
                 c = c.with_transition(kind, tc.transition_duration);
+            }
+            #[allow(clippy::float_cmp)]
+            if tc.brightness != 0.0 || tc.contrast != 1.0 || tc.saturation != 1.0 {
+                c = c.with_color_correction(tc.brightness, tc.contrast, tc.saturation);
             }
             c
         };

--- a/src/state.rs
+++ b/src/state.rs
@@ -389,6 +389,15 @@ pub struct TimelineClip {
     /// Fade-out duration at the end of the clip. Default: zero (no fade).
     /// avio gap: per-clip fade not applied during render (no audio_filter() on TimelineBuilder)
     pub fade_out: std::time::Duration,
+    /// Per-clip brightness. Range: −1.0..=1.0. Default: 0.0 (no change).
+    /// avio gap: no per-clip video_filter() on TimelineBuilder — stored as UI state only (docs/issue13.md).
+    pub brightness: f32,
+    /// Per-clip contrast. Range: 0.0..=3.0. Default: 1.0 (no change).
+    /// avio gap: no per-clip video_filter() on TimelineBuilder — stored as UI state only (docs/issue13.md).
+    pub contrast: f32,
+    /// Per-clip saturation. Range: 0.0..=3.0. Default: 1.0 (no change).
+    /// avio gap: no per-clip video_filter() on TimelineBuilder — stored as UI state only (docs/issue13.md).
+    pub saturation: f32,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -405,6 +405,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 gain_db: 0.0,
                 fade_in: Duration::ZERO,
                 fade_out: Duration::ZERO,
+                brightness: 0.0,
+                contrast: 1.0,
+                saturation: 1.0,
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/drain.rs
+++ b/src/ui/drain.rs
@@ -166,15 +166,16 @@ fn drain_timeline_player(state: &mut AppState) {
 
 fn drain_frame(state: &mut AppState, ctx: &egui::Context) {
     if let Ok(mut guard) = state.frame_handle.try_lock()
-        && let Some(frame) = guard.take()
+        && let Some(mut frame) = guard.take()
     {
         // Route PTS to the right player's position indicator
-        if state
+        let is_timeline = state
             .timeline_player_thread
             .as_ref()
             .map(|h| !h.is_finished())
-            .unwrap_or(false)
-        {
+            .unwrap_or(false);
+
+        if is_timeline {
             state.timeline_playhead_secs = frame.pts.as_secs_f64();
             // Loop-back: when loop is enabled and the presented frame reaches the
             // out-point, seek back to the in-point.
@@ -188,6 +189,37 @@ fn drain_frame(state: &mut AppState, ctx: &egui::Context) {
             {
                 handle.seek(loop_in);
                 state.timeline_playhead_secs = loop_in.as_secs_f64();
+            }
+
+            // Apply per-clip color correction for preview.
+            // Find the active V1 clip at the current frame PTS and apply its
+            // brightness/contrast/saturation as a software RGBA transform.
+            let pts = frame.pts;
+            let correction = state
+                .timeline
+                .tracks
+                .first()
+                .and_then(|track| {
+                    track.clips.iter().find(|tc| {
+                        let start = tc.start_on_track;
+                        let eff_dur = match (tc.in_point, tc.out_point) {
+                            (Some(i), Some(o)) if o > i => o - i,
+                            _ => state
+                                .clips
+                                .get(tc.source_index)
+                                .map(|c| c.info.duration())
+                                .unwrap_or(std::time::Duration::ZERO),
+                        };
+                        pts >= start && pts < start + eff_dur
+                    })
+                })
+                .map(|tc| (tc.brightness, tc.contrast, tc.saturation));
+
+            #[allow(clippy::float_cmp)]
+            if let Some((b, c, s)) = correction
+                && (b != 0.0 || c != 1.0 || s != 1.0)
+            {
+                apply_eq_rgba(&mut frame.data, b, c, s);
             }
         } else {
             state.current_pts = Some(frame.pts);
@@ -204,6 +236,35 @@ fn drain_frame(state: &mut AppState, ctx: &egui::Context) {
             }
         }
         ctx.request_repaint();
+    }
+}
+
+/// Applies brightness / contrast / saturation to packed RGBA pixel data in place.
+///
+/// Matches the FFmpeg `eq` filter formula applied in RGB space:
+/// - saturation: mix between Rec.709 luma and original colour
+/// - contrast + brightness: `out = (in − 0.5) × contrast + 0.5 + brightness`
+fn apply_eq_rgba(data: &mut [u8], brightness: f32, contrast: f32, saturation: f32) {
+    for chunk in data.chunks_exact_mut(4) {
+        let r = chunk[0] as f32 / 255.0;
+        let g = chunk[1] as f32 / 255.0;
+        let b = chunk[2] as f32 / 255.0;
+
+        // Saturation via Rec.709 luma
+        let luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+        let r = luma + (r - luma) * saturation;
+        let g = luma + (g - luma) * saturation;
+        let b = luma + (b - luma) * saturation;
+
+        // Contrast + brightness
+        let r = ((r - 0.5) * contrast + 0.5 + brightness).clamp(0.0, 1.0);
+        let g = ((g - 0.5) * contrast + 0.5 + brightness).clamp(0.0, 1.0);
+        let b = ((b - 0.5) * contrast + 0.5 + brightness).clamp(0.0, 1.0);
+
+        chunk[0] = (r * 255.0 + 0.5) as u8;
+        chunk[1] = (g * 255.0 + 0.5) as u8;
+        chunk[2] = (b * 255.0 + 0.5) as u8;
+        // alpha (chunk[3]) unchanged
     }
 }
 

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -197,6 +197,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         gain_db: tc.gain_db,
                         fade_in: tc.fade_in,
                         fade_out: tc.fade_out,
+                        brightness: tc.brightness,
+                        contrast: tc.contrast,
+                        saturation: tc.saturation,
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -534,6 +537,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 gain_db: tc.gain_db,
                 fade_in: tc.fade_in,
                 fade_out: tc.fade_out,
+                brightness: tc.brightness,
+                contrast: tc.contrast,
+                saturation: tc.saturation,
             };
             let tracks = &state.timeline.tracks;
             let v1: Vec<_> = if track_is_active(tracks, 0) {
@@ -594,6 +600,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             gain_db: tc.gain_db,
                             fade_in: tc.fade_in,
                             fade_out: tc.fade_out,
+                            brightness: tc.brightness,
+                            contrast: tc.contrast,
+                            saturation: tc.saturation,
                         };
                         let tracks = &state.timeline.tracks;
                         let v1: Vec<_> = if track_is_active(tracks, 0) {
@@ -664,6 +673,64 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
 
         ui.label(format!("{:.2}s", state.timeline_playhead_secs));
     });
+
+    // ── Clip Properties panel (V1/V2 only; shown when a clip is selected) ────
+    if let Some((ti, ci)) = state.timeline_selected
+        && ti < 2
+    {
+        let src_name = state
+            .timeline
+            .tracks
+            .get(ti)
+            .and_then(|t| t.clips.get(ci))
+            .and_then(|c| state.clips.get(c.source_index))
+            .and_then(|s| s.path.file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or("(clip)")
+            .to_owned();
+        if let Some(clip) = state
+            .timeline
+            .tracks
+            .get_mut(ti)
+            .and_then(|t| t.clips.get_mut(ci))
+        {
+            egui::CollapsingHeader::new(format!("Clip Properties — {src_name}"))
+                .default_open(true)
+                .show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label("Brightness");
+                        ui.add(
+                            egui::Slider::new(&mut clip.brightness, -1.0..=1.0)
+                                .fixed_decimals(2),
+                        );
+                        ui.separator();
+                        ui.label("Contrast");
+                        ui.add(
+                            egui::Slider::new(&mut clip.contrast, 0.0..=3.0).fixed_decimals(2),
+                        );
+                        ui.separator();
+                        ui.label("Saturation");
+                        ui.add(
+                            egui::Slider::new(&mut clip.saturation, 0.0..=3.0).fixed_decimals(2),
+                        );
+                        ui.separator();
+                        #[allow(clippy::float_cmp)]
+                        let is_neutral =
+                            clip.brightness == 0.0 && clip.contrast == 1.0 && clip.saturation == 1.0;
+                        if ui
+                            .add_enabled(!is_neutral, egui::Button::new("Reset"))
+                            .on_hover_text("Reset brightness / contrast / saturation to defaults")
+                            .clicked()
+                        {
+                            clip.brightness = 0.0;
+                            clip.contrast = 1.0;
+                            clip.saturation = 1.0;
+                        }
+                    });
+                    ui.weak("Applied on Export. Preview does not reflect color correction (ff-preview limitation — docs/issue40.md).");
+                });
+        }
+    }
 
     ui.separator();
 
@@ -1970,6 +2037,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 gain_db: tc.gain_db,
                 fade_in: tc.fade_in,
                 fade_out: tc.fade_out,
+                brightness: tc.brightness,
+                contrast: tc.contrast,
+                saturation: tc.saturation,
             };
             let tracks = &state.timeline.tracks;
             let v1: Vec<_> = if track_is_active(tracks, 0) {
@@ -2050,6 +2120,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             gain_db: 0.0,
             fade_in: Duration::ZERO,
             fade_out: Duration::ZERO,
+            brightness: 0.0,
+            contrast: 1.0,
+            saturation: 1.0,
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -2166,6 +2239,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 gain_db: state.timeline.tracks[ti].clips[ci].gain_db,
                 fade_in: Duration::ZERO,
                 fade_out: orig_fade_out,
+                brightness: state.timeline.tracks[ti].clips[ci].brightness,
+                contrast: state.timeline.tracks[ti].clips[ci].contrast,
+                saturation: state.timeline.tracks[ti].clips[ci].saturation,
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }


### PR DESCRIPTION
## Summary

Adds per-clip color correction to the timeline editor. Users can select a clip on V1 and adjust brightness, contrast, and saturation via sliders in the Clip Properties panel. A Reset button restores all values to their neutral defaults. Changes take effect immediately in the preview and are applied to exports via the `avio` filter graph.

## Changes

- `src/state.rs` — Added `brightness`, `contrast`, `saturation` fields to `TimelineClip`
- `src/ui/clip_browser.rs` — Initialize new fields to neutral defaults when placing clips
- `src/ui/timeline.rs` — Clip Properties panel with sliders (brightness −1.0..=1.0, contrast 0.0..=3.0, saturation 0.0..=3.0) and a Reset button (disabled when already neutral)
- `src/player.rs` — `TrackClipData` carries the three fields; `make_clip` calls `Clip::with_color_correction()` when non-neutral
- `src/export.rs` — `ExportClip` carries the three fields; `clips_to_avio()` calls `Clip::with_color_correction()` for export
- `src/ui/drain.rs` — `apply_eq_rgba()` applies a software Rec.709 + FFmpeg-eq approximation to the `RgbaFrame` before display (zero overhead when values are neutral)

## Related Issues

Closes #100

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes