### PR TITLE
feat(timeline): per-clip opacity for all tracks and dynamic video track support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -490,7 +490,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avio"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "ff-common",
  "ff-decode",
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1283,14 +1283,14 @@ dependencies = [
 
 [[package]]
 name = "ff-common"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "ff-decode"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "ff-common",
  "ff-format",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "ff-encode"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "ff-format",
  "ff-sys",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "ff-filter"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "ff-common",
  "ff-format",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "ff-format"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "ff-common",
  "log",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "ff-pipeline"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "ff-common",
  "ff-decode",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "ff-preview"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "ff-decode",
  "ff-encode",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "ff-probe"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "ff-format",
  "ff-sys",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sys"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "bindgen",
  "log",
@@ -3117,7 +3117,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3130,7 +3130,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3433,7 +3433,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4178,7 +4178,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4396,15 +4396,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/src/export.rs
+++ b/src/export.rs
@@ -31,13 +31,16 @@ pub struct ExportClip {
     pub saturation: f32,
     /// Per-clip speed multiplier. `1.0` = normal. Applied by trimming `out_point` (avio gap — docs/issue41.md).
     pub speed: f32,
+    /// Per-clip opacity (`1.0` = fully opaque). Forwarded to `Clip::with_opacity`.
+    pub opacity: f32,
+    /// Per-clip blend mode. Forwarded to `Clip::with_blend_mode`.
+    pub blend_mode: avio::BlendMode,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
 /// before handing off to `spawn_blocking`.
 pub struct ExportSnapshot {
-    pub v1_clips: Vec<ExportClip>,
-    pub v2_clips: Vec<ExportClip>,
+    pub video_clips: Vec<Vec<ExportClip>>,
     pub a1_clips: Vec<ExportClip>,
     pub encoder_config: crate::state::EncoderConfigDraft,
     pub export_filters: crate::state::ExportFilterDraft,
@@ -106,8 +109,19 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
                 None => clip,
             };
             #[allow(clippy::float_cmp)]
-            if c.brightness != 0.0 || c.contrast != 1.0 || c.saturation != 1.0 {
+            let clip = if c.brightness != 0.0 || c.contrast != 1.0 || c.saturation != 1.0 {
                 clip.with_color_correction(c.brightness, c.contrast, c.saturation)
+            } else {
+                clip
+            };
+            #[allow(clippy::float_cmp)]
+            let clip = if c.opacity != 1.0 {
+                clip.with_opacity(c.opacity)
+            } else {
+                clip
+            };
+            if c.blend_mode != avio::BlendMode::Normal {
+                clip.with_blend_mode(c.blend_mode)
             } else {
                 clip
             }
@@ -123,34 +137,50 @@ fn build_and_render(
     // Compute the estimate before snapshot fields are moved into clips_to_avio.
     // Used as a fallback when avio cannot determine total_frames (clips without out_point).
     let total_frames_estimate: Option<u64> = {
-        let fps = snapshot.v1_clips.first().map(|c| c.fps).unwrap_or(30.0);
+        let fps = snapshot
+            .video_clips
+            .first()
+            .and_then(|v| v.first())
+            .map(|c| c.fps)
+            .unwrap_or(30.0);
         let total_dur: Duration = snapshot
-            .v1_clips
-            .iter()
-            .map(|c| {
-                let end = c.out_point.unwrap_or(c.source_duration);
-                let start = c.in_point.unwrap_or(Duration::ZERO);
-                end.saturating_sub(start)
+            .video_clips
+            .first()
+            .map(|v| {
+                v.iter()
+                    .map(|c| {
+                        let end = c.out_point.unwrap_or(c.source_duration);
+                        let start = c.in_point.unwrap_or(Duration::ZERO);
+                        end.saturating_sub(start)
+                    })
+                    .sum()
             })
-            .sum();
+            .unwrap_or(Duration::ZERO);
         let frames = (total_dur.as_secs_f64() * fps).round() as u64;
         if frames > 0 { Some(frames) } else { None }
     };
 
-    let v1 = clips_to_avio(snapshot.v1_clips);
-    let v2 = clips_to_avio(snapshot.v2_clips);
+    let avio_video: Vec<Vec<avio::Clip>> = snapshot
+        .video_clips
+        .into_iter()
+        .map(clips_to_avio)
+        .collect();
     let a1 = clips_to_avio(snapshot.a1_clips);
 
-    if v1.is_empty() {
+    if avio_video.is_empty() || avio_video[0].is_empty() {
         return Err("V1 track has no clips to export".to_string());
     }
 
     let config = snapshot.encoder_config.to_encoder_config();
 
     // When A1 has no clips, mirror V1 so the video clips' embedded audio is exported.
-    let effective_a1 = if a1.is_empty() { v1.clone() } else { a1 };
+    let effective_a1 = if a1.is_empty() {
+        avio_video[0].clone()
+    } else {
+        a1
+    };
 
-    let mut builder = avio::Timeline::builder().video_track(v1);
+    let mut builder = avio::Timeline::builder().video_track(avio_video[0].clone());
 
     if snapshot.export_filters.scale_enabled {
         builder = builder.canvas(
@@ -164,8 +194,10 @@ fn build_and_render(
     // cannot be attached to Timeline — same gap as color balance (docs/issue13.md).
     // loudness_normalize is stored but not applied during render.
 
-    if !v2.is_empty() {
-        builder = builder.video_track(v2);
+    for vn in avio_video.into_iter().skip(1) {
+        if !vn.is_empty() {
+            builder = builder.video_track(vn);
+        }
     }
     if !effective_a1.is_empty() {
         builder = builder.audio_track(effective_a1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,8 +125,11 @@ fn active_frame_duration(state: &state::AppState) -> std::time::Duration {
 
     let fps = if tl_active {
         let playhead = std::time::Duration::from_secs_f64(state.timeline_playhead_secs);
-        state.timeline.tracks[..2]
+        state
+            .timeline
+            .tracks
             .iter()
+            .filter(|t| t.kind == state::TrackKind::Video)
             .flat_map(|t| &t.clips)
             .find_map(|c| {
                 let src = state.clips.get(c.source_index)?;

--- a/src/player.rs
+++ b/src/player.rs
@@ -29,6 +29,10 @@ pub struct TrackClipData {
     pub saturation: f32,
     /// Per-clip playback speed multiplier. `1.0` = normal speed.
     pub speed: f32,
+    /// Per-clip opacity (`1.0` = fully opaque). Forwarded to `Clip::with_opacity`.
+    pub opacity: f32,
+    /// Per-clip blend mode. Forwarded to `Clip::with_blend_mode`.
+    pub blend_mode: avio::BlendMode,
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -375,8 +379,7 @@ pub fn spawn_player(
 /// Returns `(thread, handle_rx)`. `handle_rx` delivers the `PlayerHandle` once
 /// the runner is ready (one-shot).
 pub fn spawn_timeline_player(
-    v1: Vec<TrackClipData>,
-    v2: Vec<TrackClipData>,
+    video_tracks: Vec<Vec<TrackClipData>>,
     a1: Vec<TrackClipData>,
     frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
     ctx: egui::Context,
@@ -410,21 +413,36 @@ pub fn spawn_timeline_player(
             if tc.brightness != 0.0 || tc.contrast != 1.0 || tc.saturation != 1.0 {
                 c = c.with_color_correction(tc.brightness, tc.contrast, tc.saturation);
             }
+            #[allow(clippy::float_cmp)]
+            if tc.opacity != 1.0 {
+                c = c.with_opacity(tc.opacity);
+            }
+            if tc.blend_mode != avio::BlendMode::Normal {
+                c = c.with_blend_mode(tc.blend_mode);
+            }
             c
         };
 
-        let v1_clips: Vec<avio::Clip> = v1.into_iter().map(make_clip).collect();
-        let v2_clips: Vec<avio::Clip> = v2.into_iter().map(make_clip).collect();
+        let avio_video_tracks: Vec<Vec<avio::Clip>> = video_tracks
+            .into_iter()
+            .map(|track| track.into_iter().map(make_clip).collect())
+            .collect();
         let a1_clips: Vec<avio::Clip> = a1.into_iter().map(make_clip).collect();
 
+        let Some(v1_clips) = avio_video_tracks.first() else {
+            log::warn!("spawn_timeline_player: no V1 clips");
+            return;
+        };
         if v1_clips.is_empty() {
             log::warn!("spawn_timeline_player: no V1 clips");
             return;
         }
 
-        let mut builder = avio::Timeline::builder().video_track(v1_clips);
-        if !v2_clips.is_empty() {
-            builder = builder.video_track(v2_clips);
+        let mut builder = avio::Timeline::builder().video_track(avio_video_tracks[0].clone());
+        for vn in avio_video_tracks.into_iter().skip(1) {
+            if !vn.is_empty() {
+                builder = builder.video_track(vn);
+            }
         }
         if !a1_clips.is_empty() {
             builder = builder.audio_track(a1_clips);

--- a/src/state.rs
+++ b/src/state.rs
@@ -356,12 +356,10 @@ impl EncoderConfigDraft {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum TrackKind {
-    Video1,
-    Video2,
-    Audio1,
+    Video,
+    Audio,
 }
 
-#[allow(dead_code)]
 pub struct Track {
     pub kind: TrackKind,
     pub clips: Vec<TimelineClip>,
@@ -402,31 +400,61 @@ pub struct TimelineClip {
     /// avio gap: `Clip` has no speed field; fast motion is approximated by trimming
     /// `out_point = in_point + source_dur / speed`. Slow motion is unsupported — docs/issue41.md.
     pub speed: f32,
+    /// Overlay opacity for V2 clips. Range: 0.0 (transparent)..=1.0 (fully opaque). Default: 1.0.
+    /// avio gap: `Clip` has no opacity field; `TimelineBuilder` exposes per-track opacity via
+    /// animation only — per-clip opacity is not supported (docs/issue43.md).
+    pub opacity: f32,
+    /// Blend mode for V2 compositing onto V1. Default: `avio::BlendMode::Normal`.
+    /// avio gap: `Clip` has no blend_mode field; `TimelineBuilder` has no blend-mode API for
+    /// overlay tracks — `FilterGraphBuilder::blend()` is not wired into the `Clip` pipeline
+    /// (docs/issue43.md).
+    pub blend_mode: avio::BlendMode,
 }
 
 pub struct TimelineState {
-    pub tracks: [Track; 3],
+    pub tracks: Vec<Track>,
     pub pixels_per_second: f32,
+}
+
+impl TimelineState {
+    /// Number of video tracks (always come before audio tracks in the flat vec).
+    pub fn video_track_count(&self) -> usize {
+        self.tracks
+            .iter()
+            .take_while(|t| t.kind == TrackKind::Video)
+            .count()
+    }
+    /// Index of the first audio track (= video_track_count()).
+    pub fn audio_track_start(&self) -> usize {
+        self.video_track_count()
+    }
+    /// Append a new empty video track before the first audio track.
+    pub fn add_video_track(&mut self) {
+        let audio_start = self.audio_track_start();
+        self.tracks.insert(
+            audio_start,
+            Track {
+                kind: TrackKind::Video,
+                clips: Vec::new(),
+                muted: false,
+                soloed: false,
+            },
+        );
+    }
 }
 
 impl Default for TimelineState {
     fn default() -> Self {
         Self {
-            tracks: [
+            tracks: vec![
                 Track {
-                    kind: TrackKind::Video1,
+                    kind: TrackKind::Video,
                     clips: Vec::new(),
                     muted: false,
                     soloed: false,
                 },
                 Track {
-                    kind: TrackKind::Video2,
-                    clips: Vec::new(),
-                    muted: false,
-                    soloed: false,
-                },
-                Track {
-                    kind: TrackKind::Audio1,
+                    kind: TrackKind::Audio,
                     clips: Vec::new(),
                     muted: false,
                     soloed: false,

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -409,6 +409,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 contrast: 1.0,
                 saturation: 1.0,
                 speed: 1.0,
+                opacity: 1.0,
+                blend_mode: avio::BlendMode::Normal,
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/drain.rs
+++ b/src/ui/drain.rs
@@ -215,8 +215,10 @@ fn drain_frame(state: &mut AppState, ctx: &egui::Context) {
                 })
                 .map(|tc| (tc.brightness, tc.contrast, tc.saturation));
 
+            let is_rgba = frame.data.len() == frame.width as usize * frame.height as usize * 4;
             #[allow(clippy::float_cmp)]
-            if let Some((b, c, s)) = correction
+            if is_rgba
+                && let Some((b, c, s)) = correction
                 && (b != 0.0 || c != 1.0 || s != 1.0)
             {
                 apply_eq_rgba(&mut frame.data, b, c, s);
@@ -224,10 +226,22 @@ fn drain_frame(state: &mut AppState, ctx: &egui::Context) {
         } else {
             state.current_pts = Some(frame.pts);
         }
-        let image = egui::ColorImage::from_rgba_unmultiplied(
-            [frame.width as usize, frame.height as usize],
-            &frame.data,
-        );
+        let w = frame.width as usize;
+        let h = frame.height as usize;
+        let pixels = w * h;
+        let image = if frame.data.len() == pixels * 4 {
+            egui::ColorImage::from_rgba_unmultiplied([w, h], &frame.data)
+        } else if frame.data.len() == pixels * 3 {
+            egui::ColorImage::from_rgb([w, h], &frame.data)
+        } else {
+            log::warn!(
+                "drain_frame: unexpected data length {} for {}x{} frame — skipping",
+                frame.data.len(),
+                w,
+                h
+            );
+            return;
+        };
         match &mut state.preview_texture {
             Some(tex) => tex.set(image, egui::TextureOptions::LINEAR),
             None => {

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -4,11 +4,21 @@ use std::time::Duration;
 use crate::presets::PresetFile;
 use crate::{export, player, state};
 
+fn blend_mode_label(mode: avio::BlendMode) -> &'static str {
+    match mode {
+        avio::BlendMode::Normal => "Normal",
+        avio::BlendMode::Multiply => "Multiply",
+        avio::BlendMode::Screen => "Screen",
+        avio::BlendMode::Overlay => "Overlay",
+        _ => "Custom",
+    }
+}
+
 /// Returns `true` when track `idx` should contribute clips to the player/exporter.
 ///
 /// Solo takes priority: if any track is soloed, only soloed tracks are active.
 /// Otherwise, a track is active unless it is muted.
-fn track_is_active(tracks: &[state::Track; 3], idx: usize) -> bool {
+fn track_is_active(tracks: &[state::Track], idx: usize) -> bool {
     let any_solo = tracks.iter().any(|t| t.soloed);
     if any_solo {
         tracks[idx].soloed
@@ -203,22 +213,25 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         contrast: tc.contrast,
                         saturation: tc.saturation,
                         speed: tc.speed,
+                        opacity: tc.opacity,
+                        blend_mode: tc.blend_mode,
                     }
                 };
                 let tracks = &state.timeline.tracks;
+                let audio_start = state.timeline.audio_track_start();
                 let snapshot = export::ExportSnapshot {
-                    v1_clips: if track_is_active(tracks, 0) {
-                        tracks[0].clips.iter().map(make_clip).collect()
-                    } else {
-                        vec![]
-                    },
-                    v2_clips: if track_is_active(tracks, 1) {
-                        tracks[1].clips.iter().map(make_clip).collect()
-                    } else {
-                        vec![]
-                    },
-                    a1_clips: if track_is_active(tracks, 2) {
-                        tracks[2].clips.iter().map(make_clip).collect()
+                    video_clips: (0..audio_start)
+                        .map(|ti| {
+                            if track_is_active(tracks, ti) {
+                                tracks[ti].clips.iter().map(make_clip).collect()
+                            } else {
+                                vec![]
+                            }
+                        })
+                        .collect(),
+                    a1_clips: if audio_start < tracks.len() && track_is_active(tracks, audio_start)
+                    {
+                        tracks[audio_start].clips.iter().map(make_clip).collect()
                     } else {
                         vec![]
                     },
@@ -365,11 +378,12 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
 
             // Loudness measurement
             ui.horizontal(|ui| {
-                let can_measure = !state.timeline.tracks[2].clips.is_empty();
+                let audio_start = state.timeline.audio_track_start();
+                let can_measure = state.timeline.tracks.get(audio_start).is_some_and(|t| !t.clips.is_empty());
                 if ui
                     .add_enabled(can_measure, egui::Button::new("Measure Loudness"))
                     .clicked()
-                    && let Some(tc) = state.timeline.tracks[2].clips.first()
+                    && let Some(tc) = state.timeline.tracks.get(audio_start).and_then(|t| t.clips.first())
                 {
                     let path = state.clips[tc.source_index].path.clone();
                     let tx = state.loudness_tx.clone();
@@ -544,20 +558,22 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 contrast: tc.contrast,
                 saturation: tc.saturation,
                 speed: tc.speed,
+                opacity: tc.opacity,
+                blend_mode: tc.blend_mode,
             };
             let tracks = &state.timeline.tracks;
-            let v1: Vec<_> = if track_is_active(tracks, 0) {
-                tracks[0].clips.iter().map(make_tcd).collect()
-            } else {
-                vec![]
-            };
-            let v2: Vec<_> = if track_is_active(tracks, 1) {
-                tracks[1].clips.iter().map(make_tcd).collect()
-            } else {
-                vec![]
-            };
-            let a1: Vec<_> = if track_is_active(tracks, 2) {
-                tracks[2].clips.iter().map(make_tcd).collect()
+            let audio_start = state.timeline.audio_track_start();
+            let video_tracks: Vec<Vec<_>> = (0..audio_start)
+                .map(|ti| {
+                    if track_is_active(tracks, ti) {
+                        tracks[ti].clips.iter().map(make_tcd).collect()
+                    } else {
+                        vec![]
+                    }
+                })
+                .collect();
+            let a1: Vec<_> = if audio_start < tracks.len() && track_is_active(tracks, audio_start) {
+                tracks[audio_start].clips.iter().map(make_tcd).collect()
             } else {
                 vec![]
             };
@@ -568,8 +584,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 .cpal_rate
                 .store(1.0f64.to_bits(), std::sync::atomic::Ordering::Relaxed);
             let (thread, handle_rx) = player::spawn_timeline_player(
-                v1,
-                v2,
+                video_tracks,
                 a1,
                 Arc::clone(&state.frame_handle),
                 ui.ctx().clone(),
@@ -608,29 +623,31 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             contrast: tc.contrast,
                             saturation: tc.saturation,
                             speed: tc.speed,
+                            opacity: tc.opacity,
+                            blend_mode: tc.blend_mode,
                         };
                         let tracks = &state.timeline.tracks;
-                        let v1: Vec<_> = if track_is_active(tracks, 0) {
-                            tracks[0].clips.iter().map(make_tcd).collect()
-                        } else {
-                            vec![]
-                        };
-                        let v2: Vec<_> = if track_is_active(tracks, 1) {
-                            tracks[1].clips.iter().map(make_tcd).collect()
-                        } else {
-                            vec![]
-                        };
-                        let a1: Vec<_> = if track_is_active(tracks, 2) {
-                            tracks[2].clips.iter().map(make_tcd).collect()
-                        } else {
-                            vec![]
-                        };
+                        let audio_start = state.timeline.audio_track_start();
+                        let video_tracks: Vec<Vec<_>> = (0..audio_start)
+                            .map(|ti| {
+                                if track_is_active(tracks, ti) {
+                                    tracks[ti].clips.iter().map(make_tcd).collect()
+                                } else {
+                                    vec![]
+                                }
+                            })
+                            .collect();
+                        let a1: Vec<_> =
+                            if audio_start < tracks.len() && track_is_active(tracks, audio_start) {
+                                tracks[audio_start].clips.iter().map(make_tcd).collect()
+                            } else {
+                                vec![]
+                            };
                         state
                             .cpal_rate
                             .store(1.0f64.to_bits(), std::sync::atomic::Ordering::Relaxed);
                         let (thread, handle_rx) = player::spawn_timeline_player(
-                            v1,
-                            v2,
+                            video_tracks,
                             a1,
                             Arc::clone(&state.frame_handle),
                             ui.ctx().clone(),
@@ -677,11 +694,16 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
         }
 
         ui.label(format!("{:.2}s", state.timeline_playhead_secs));
+
+        ui.separator();
+        if ui.button("+ Video Track").clicked() {
+            state.timeline.add_video_track();
+        }
     });
 
-    // ── Clip Properties panel (V1/V2 only; shown when a clip is selected) ────
+    // ── Clip Properties panel (video tracks only; shown when a clip is selected) ────
     if let Some((ti, ci)) = state.timeline_selected
-        && ti < 2
+        && ti < state.timeline.audio_track_start()
     {
         let src_name = state
             .timeline
@@ -717,6 +739,42 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         }
                     });
                     ui.horizontal(|ui| {
+                        ui.label("Opacity");
+                        let mut opacity_pct = clip.opacity * 100.0;
+                        if ui
+                            .add(
+                                egui::Slider::new(&mut opacity_pct, 0.0..=100.0)
+                                    .suffix(" %")
+                                    .fixed_decimals(0),
+                            )
+                            .changed()
+                        {
+                            clip.opacity = (opacity_pct / 100.0).clamp(0.0, 1.0);
+                        }
+                    });
+                    // Blend mode is only meaningful for overlay (V2+) clips.
+                    if ti >= 1 {
+                        ui.horizontal(|ui| {
+                            ui.label("Blend");
+                            egui::ComboBox::from_id_salt("clip_blend_mode")
+                                .selected_text(blend_mode_label(clip.blend_mode))
+                                .show_ui(ui, |ui| {
+                                    for mode in [
+                                        avio::BlendMode::Normal,
+                                        avio::BlendMode::Multiply,
+                                        avio::BlendMode::Screen,
+                                        avio::BlendMode::Overlay,
+                                    ] {
+                                        ui.selectable_value(
+                                            &mut clip.blend_mode,
+                                            mode,
+                                            blend_mode_label(mode),
+                                        );
+                                    }
+                                });
+                        });
+                    }
+                    ui.horizontal(|ui| {
                         ui.label("Brightness");
                         ui.add(
                             egui::Slider::new(&mut clip.brightness, -1.0..=1.0)
@@ -746,7 +804,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             clip.saturation = 1.0;
                         }
                     });
-                    ui.weak("Color correction applied on Export only (ff-preview limitation — docs/issue40.md). Speed applies to preview and export; audio pitch changes proportionally in preview (no pitch correction — docs/issue42.md).");
+                    ui.weak("Color correction applied on Export only (ff-preview limitation — docs/issue40.md). Speed applies to preview and export; audio pitch changes proportionally in preview (no pitch correction — docs/issue42.md). Opacity applies to preview (V1 fades to black; V2 fades over V1). Blend mode applies to export only (docs/issue43.md).");
                 });
         }
     }
@@ -932,11 +990,20 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         egui::vec2(LABEL_WIDTH, TRACK_HEIGHT),
                         egui::Layout::top_down(egui::Align::Center),
                         |ui| {
-                            ui.label(match track.kind {
-                                state::TrackKind::Video1 => "V1",
-                                state::TrackKind::Video2 => "V2",
-                                state::TrackKind::Audio1 => "A1",
-                            });
+                            let label = if track.kind == state::TrackKind::Video {
+                                let vn = state.timeline.tracks[..=track_idx]
+                                    .iter()
+                                    .filter(|t| t.kind == state::TrackKind::Video)
+                                    .count();
+                                format!("V{vn}")
+                            } else {
+                                let an = state.timeline.tracks[..=track_idx]
+                                    .iter()
+                                    .filter(|t| t.kind == state::TrackKind::Audio)
+                                    .count();
+                                format!("A{an}")
+                            };
+                            ui.label(label);
                             ui.horizontal(|ui| {
                                 let m_col = if track.muted {
                                     egui::Color32::from_rgb(240, 160, 40)
@@ -1000,10 +1067,10 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
 
                     // Clip rectangles
                     let clip_color = match track.kind {
-                        state::TrackKind::Video1 | state::TrackKind::Video2 => {
+                        state::TrackKind::Video => {
                             egui::Color32::from_rgb(70, 130, 180) // steel blue
                         }
-                        state::TrackKind::Audio1 => {
+                        state::TrackKind::Audio => {
                             egui::Color32::from_rgb(70, 150, 120) // teal
                         }
                     };
@@ -1090,8 +1157,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                     handle_color,
                                 );
 
-                                // Filmstrip thumbnails — V1/V2 only
-                                if track.kind != state::TrackKind::Audio1
+                                // Filmstrip thumbnails — video tracks only
+                                if track.kind != state::TrackKind::Audio
                                     && let Some(ss) = &source.sprite_sheet
                                 {
                                     let tile_w = TRACK_HEIGHT * (16.0 / 9.0);
@@ -1137,8 +1204,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                     );
                                 }
 
-                                // Waveform — A1 track only
-                                if track.kind == state::TrackKind::Audio1
+                                // Waveform — audio tracks only
+                                if track.kind == state::TrackKind::Audio
                                     && !source.waveform.is_empty()
                                 {
                                     let n = source.waveform.len();
@@ -1178,8 +1245,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                     egui::Color32::WHITE,
                                 );
 
-                                // Silence region overlays — A1 track only
-                                if track.kind == state::TrackKind::Audio1 {
+                                // Silence region overlays — audio tracks only
+                                if track.kind == state::TrackKind::Audio {
                                     for &(start, end) in &source.silence_regions {
                                         let sx0 = lane_rect.left()
                                             + (tc.start_on_track + start).as_secs_f32() * pps;
@@ -1202,10 +1269,10 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                     }
                                 }
 
-                                // Fade ramps — A1 track only. Painted before interaction widgets
+                                // Fade ramps — audio tracks only. Painted before interaction widgets
                                 // so the triangular overlays appear under any interactive chrome.
                                 // avio gap: per-clip fade-in/out not applied during render
-                                if track.kind == state::TrackKind::Audio1 {
+                                if track.kind == state::TrackKind::Audio {
                                     let clipped = ui.painter().with_clip_rect(cr);
                                     let fade_color =
                                         egui::Color32::from_rgba_unmultiplied(0, 0, 0, 140);
@@ -1271,11 +1338,11 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                     ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeHorizontal);
                                 }
 
-                                // Gain line — A1 track only. Registered AFTER clip_resp so it
+                                // Gain line — audio tracks only. Registered AFTER clip_resp so it
                                 // wins hover/drag priority when the pointer is over the line.
                                 // Range: −40 dB (bottom) to +12 dB (top); 0 dB at mid-height.
                                 // avio gap: per-clip gain not applied (no audio_filter() on TimelineBuilder)
-                                let gain_resp_for_clip = if track.kind == state::TrackKind::Audio1 {
+                                let gain_resp_for_clip = if track.kind == state::TrackKind::Audio {
                                     const GAIN_DB_MAX: f32 = 12.0;
                                     const GAIN_DB_MIN: f32 = -40.0;
                                     let y_frac = if tc.gain_db >= 0.0 {
@@ -1335,10 +1402,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                     None
                                 };
 
-                                // Fade handles — A1 track only. Registered AFTER gain_resp for
+                                // Fade handles — audio tracks only. Registered AFTER gain_resp for
                                 // the highest interaction priority on the clip rect.
-                                let fade_consuming_drag = if track.kind == state::TrackKind::Audio1
-                                {
+                                let fade_consuming_drag = if track.kind == state::TrackKind::Audio {
                                     const FADE_HANDLE_PX: f32 = 10.0;
                                     let half = cr.height() / 2.0;
                                     let eff_dur_secs = {
@@ -1699,7 +1765,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                         tc.transition_duration.as_millis() as f64;
                                     clip_resp.context_menu(|ui| {
                                         // Transition options — V1 only
-                                        if track.kind == state::TrackKind::Video1 {
+                                        if track_idx == 0 {
                                             ui.label("Transition to previous clip:");
                                             for &variant in &[
                                                 avio::XfadeTransition::Fade,
@@ -2000,9 +2066,13 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
         pending_inserts.push((ti, new_clip));
     }
 
-    // Snapshot all 3 tracks before applying any pending ops.
-    let tracks_before: [Vec<state::TimelineClip>; 3] =
-        std::array::from_fn(|i| state.timeline.tracks[i].clips.clone());
+    // Snapshot all tracks before applying any pending ops.
+    let tracks_before: Vec<Vec<state::TimelineClip>> = state
+        .timeline
+        .tracks
+        .iter()
+        .map(|t| t.clips.clone())
+        .collect();
     // Flags captured before pending vecs are consumed by for-loops.
     let had_trims = !pending_trims.is_empty();
     let had_moves = !pending_moves.is_empty();
@@ -2091,20 +2161,22 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 contrast: tc.contrast,
                 saturation: tc.saturation,
                 speed: tc.speed,
+                opacity: tc.opacity,
+                blend_mode: tc.blend_mode,
             };
             let tracks = &state.timeline.tracks;
-            let v1: Vec<_> = if track_is_active(tracks, 0) {
-                tracks[0].clips.iter().map(make_tcd).collect()
-            } else {
-                vec![]
-            };
-            let v2: Vec<_> = if track_is_active(tracks, 1) {
-                tracks[1].clips.iter().map(make_tcd).collect()
-            } else {
-                vec![]
-            };
-            let a1: Vec<_> = if track_is_active(tracks, 2) {
-                tracks[2].clips.iter().map(make_tcd).collect()
+            let audio_start = state.timeline.audio_track_start();
+            let video_tracks: Vec<Vec<_>> = (0..audio_start)
+                .map(|ti| {
+                    if track_is_active(tracks, ti) {
+                        tracks[ti].clips.iter().map(make_tcd).collect()
+                    } else {
+                        vec![]
+                    }
+                })
+                .collect();
+            let a1: Vec<_> = if audio_start < tracks.len() && track_is_active(tracks, audio_start) {
+                tracks[audio_start].clips.iter().map(make_tcd).collect()
             } else {
                 vec![]
             };
@@ -2112,8 +2184,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 .cpal_rate
                 .store(1.0f64.to_bits(), std::sync::atomic::Ordering::Relaxed);
             let (thread, handle_rx) = player::spawn_timeline_player(
-                v1,
-                v2,
+                video_tracks,
                 a1,
                 Arc::clone(&state.frame_handle),
                 ctx,
@@ -2175,6 +2246,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             contrast: 1.0,
             saturation: 1.0,
             speed: 1.0,
+            opacity: 1.0,
+            blend_mode: avio::BlendMode::Normal,
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -2301,6 +2374,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 contrast: state.timeline.tracks[ti].clips[ci].contrast,
                 saturation: state.timeline.tracks[ti].clips[ci].saturation,
                 speed: state.timeline.tracks[ti].clips[ci].speed,
+                opacity: state.timeline.tracks[ti].clips[ci].opacity,
+                blend_mode: state.timeline.tracks[ti].clips[ci].blend_mode,
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }
@@ -2333,7 +2408,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             ""
         };
         if !label.is_empty() {
-            let snapshots: Vec<_> = (0..3_usize)
+            let snapshots: Vec<_> = (0..state.timeline.tracks.len())
                 .filter(|&i| state.timeline.tracks[i].clips != tracks_before[i])
                 .map(|i| {
                     (


### PR DESCRIPTION
## Summary

Implements per-clip opacity control for all video tracks (V1 fades to black; V2+ fades over V1) and adds a dynamic '+ Video Track' button so users can add V2, V3, … on demand instead of having a fixed 3-track array. Also fixes a silent RGB/RGBA format mismatch in `drain_frame` that caused a panic when the timeline player returned non-RGBA frames.

## Changes

- **`state.rs`**: Refactor `TrackKind` from `{Video1, Video2, Audio1}` to `{Video, Audio}`; replace `[Track; 3]` with `Vec<Track>`; add `TimelineState::add_video_track()`, `video_track_count()`, `audio_track_start()`; add `opacity: f32` and `blend_mode` fields to `TimelineClip`
- **`ui/timeline.rs`**: Opacity slider shown for all video tracks (not just V2); blend mode row kept V2+ only; `+ Video Track` button added to transport bar; track labels generated dynamically (V1/V2/V3…/A1/A2…); all hardcoded `tracks[0..2]` replaced with index-driven iteration
- **`player.rs`**: `spawn_timeline_player` now takes `video_tracks: Vec<Vec<TrackClipData>>`; loops over all video tracks to build the avio `Timeline`
- **`export.rs`**: `ExportSnapshot` now carries `video_clips: Vec<Vec<ExportClip>>`; export path loops over all tracks
- **`main.rs`**: Filter tracks by `TrackKind::Video` instead of fixed indices
- **`ui/drain.rs`**: `drain_frame` handles both RGB and RGBA frame data; color correction guarded by RGBA format check to avoid applying byte math to packed-RGB buffers

## Related Issues

Closes #102

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes