### PR TITLE
feat(timeline): add T1 title track with text overlay

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -49,6 +49,8 @@ pub struct ExportSnapshot {
     pub loudness_normalize: bool,
     #[allow(dead_code)]
     pub loudness_target: f64,
+    /// Title clips from the T1 track — converted to a lavfi drawtext overlay.
+    pub title_clips: Vec<crate::state::TitleClip>,
 }
 
 /// Spawns a background task that builds an `avio::Timeline` from the snapshot
@@ -129,6 +131,59 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
         .collect()
 }
 
+/// Builds an FFmpeg `lavfi` filtergraph string from T1 title clips.
+///
+/// Returns `None` when there are no non-empty title clips.  The string is
+/// passed to [`avio::TimelineBuilder::lavfi_overlay`] and interpreted by the
+/// `movie` filter's `format_name=lavfi` path in `ff-filter`.
+fn build_lavfi_overlay_filter(
+    title_clips: &[crate::state::TitleClip],
+    w: u32,
+    h: u32,
+    timeline_dur_secs: f64,
+) -> Option<String> {
+    let non_empty: Vec<_> = title_clips
+        .iter()
+        .filter(|tc| !tc.text.is_empty())
+        .collect();
+    if non_empty.is_empty() {
+        return None;
+    }
+
+    // Transparent canvas lasting exactly as long as the video content.
+    let mut chain = format!("color=s={w}x{h}:c=black@0.0:d={timeline_dur_secs:.3}");
+
+    for tc in non_empty {
+        let start_t = tc.start_on_track.as_secs_f64();
+        let end_t = start_t + tc.duration.as_secs_f64();
+        let [r, g, b, _] = tc.color;
+        let fontcolor = format!("#{r:02x}{g:02x}{b:02x}");
+
+        // Escape user text for the lavfi drawtext `text=` option.
+        // Within single-quotes the lavfi parser treats `'` as end-of-quote,
+        // so we close-quote, insert an escaped apostrophe, then re-open.
+        let text = tc.text.replace('\\', "\\\\").replace('\'', "'\\''");
+
+        let x_expr = match tc.h_align {
+            crate::state::HAlign::Left => "10",
+            crate::state::HAlign::Centre => "(w-text_w)/2",
+            crate::state::HAlign::Right => "w-text_w-10",
+        };
+        let y_expr = match tc.v_align {
+            crate::state::VAlign::Top => "10",
+            crate::state::VAlign::Middle => "(h-text_h)/2",
+            crate::state::VAlign::Bottom => "h-text_h-10",
+        };
+
+        chain = format!(
+            "{chain},drawtext=text='{text}':fontsize={fs}:fontcolor={fontcolor}\
+             :x={x_expr}:y={y_expr}:enable='between(t,{start_t:.3},{end_t:.3})'",
+            fs = tc.font_size,
+        );
+    }
+    Some(chain)
+}
+
 fn build_and_render(
     snapshot: ExportSnapshot,
     output: &std::path::Path,
@@ -158,6 +213,34 @@ fn build_and_render(
             .unwrap_or(Duration::ZERO);
         let frames = (total_dur.as_secs_f64() * fps).round() as u64;
         if frames > 0 { Some(frames) } else { None }
+    };
+
+    // Total timeline duration: the latest end-time of any clip across all video tracks.
+    // Used to bound the lavfi overlay duration so the composition terminates correctly.
+    let timeline_dur_secs: f64 = snapshot
+        .video_clips
+        .iter()
+        .flat_map(|track| track.iter())
+        .map(|c| {
+            let dur = c
+                .out_point
+                .zip(c.in_point)
+                .map(|(op, ip)| op.saturating_sub(ip))
+                .or(c.out_point)
+                .unwrap_or(c.source_duration);
+            c.start_on_track.as_secs_f64() + dur.as_secs_f64()
+        })
+        .fold(0.0_f64, f64::max);
+
+    let lavfi_overlay = if timeline_dur_secs > 0.0 {
+        build_lavfi_overlay_filter(
+            &snapshot.title_clips,
+            snapshot.export_filters.output_width,
+            snapshot.export_filters.output_height,
+            timeline_dur_secs,
+        )
+    } else {
+        None
     };
 
     let avio_video: Vec<Vec<avio::Clip>> = snapshot
@@ -201,6 +284,9 @@ fn build_and_render(
     }
     if !effective_a1.is_empty() {
         builder = builder.audio_track(effective_a1);
+    }
+    if let Some(lavfi_str) = lavfi_overlay {
+        builder = builder.lavfi_overlay(lavfi_str);
     }
 
     let timeline = builder.build().map_err(|e| e.to_string())?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -27,6 +27,21 @@ pub struct TimelineClipDrag {
     pub grab_offset_secs: f32,
 }
 
+/// Tracks an in-progress T1 title clip drag-to-reposition operation.
+#[derive(Clone)]
+pub struct TitleClipDrag {
+    pub clip_idx: usize,
+    /// Seconds from the clip's left edge to where the user grabbed it.
+    pub grab_offset_secs: f32,
+}
+
+/// Tracks an in-progress T1 title clip edge-trim operation.
+#[derive(Clone)]
+pub struct TitleClipTrimDrag {
+    pub clip_idx: usize,
+    pub edge: TrimEdge,
+}
+
 /// A reversible timeline edit stored as per-track clip-vec snapshots.
 /// Undo = restore `before`; redo = restore `after`.
 #[derive(Clone)]
@@ -36,12 +51,18 @@ pub enum EditCommand {
         snapshots: Vec<(usize, Vec<TimelineClip>, Vec<TimelineClip>)>,
         label: &'static str,
     },
+    TitleSnapshot {
+        before: Vec<TitleClip>,
+        after: Vec<TitleClip>,
+        label: &'static str,
+    },
 }
 
 impl EditCommand {
     pub fn label(&self) -> &'static str {
         match self {
             Self::TrackSnapshot { label, .. } => label,
+            Self::TitleSnapshot { label, .. } => label,
         }
     }
 }
@@ -104,6 +125,8 @@ pub struct AppState {
     pub loudness_rx: mpsc::Receiver<Option<LoudnessResult>>,
     pub clip_drag: Option<TimelineClipDrag>,
     pub clip_trim: Option<TimelineClipTrimDrag>,
+    pub title_clip_drag: Option<TitleClipDrag>,
+    pub title_clip_trim: Option<TitleClipTrimDrag>,
     pub show_export_settings: bool,
     pub theme_preference: egui::ThemePreference,
     pub undo_stack: Vec<EditCommand>,
@@ -121,6 +144,14 @@ pub struct AppState {
     pub timeline_loop_in: Option<std::time::Duration>,
     pub timeline_loop_out: Option<std::time::Duration>,
     pub timeline_loop_enabled: bool,
+    /// Index into `TimelineState::title_clips` of the currently selected title clip.
+    pub selected_title_clip: Option<usize>,
+    /// Active tab in the clip browser left panel.
+    pub browser_tab: BrowserTab,
+    /// Text clip presets stored in the browser's Text tab.
+    pub text_presets: Vec<TextClipPreset>,
+    /// Index into `text_presets` of the currently selected preset in the browser.
+    pub selected_text_preset: Option<usize>,
 }
 
 impl Default for AppState {
@@ -183,6 +214,8 @@ impl Default for AppState {
             loudness_rx,
             clip_drag: None,
             clip_trim: None,
+            title_clip_drag: None,
+            title_clip_trim: None,
             show_export_settings: false,
             theme_preference: egui::ThemePreference::System,
             undo_stack: Vec::new(),
@@ -194,6 +227,10 @@ impl Default for AppState {
             timeline_loop_in: None,
             timeline_loop_out: None,
             timeline_loop_enabled: false,
+            selected_title_clip: None,
+            browser_tab: BrowserTab::Media,
+            text_presets: Vec::new(),
+            selected_text_preset: None,
         }
     }
 }
@@ -354,10 +391,81 @@ impl EncoderConfigDraft {
     }
 }
 
+/// Which tab is active in the clip browser left panel.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum BrowserTab {
+    Media,
+    Text,
+}
+
+/// A text clip template stored in the browser's Text tab.
+///
+/// When dragged onto the T1 lane a [`TitleClip`] is created from this preset.
+#[derive(Clone)]
+pub struct TextClipPreset {
+    pub name: String,
+    pub text: String,
+    pub font_size: u32,
+    /// RGBA colour, 0–255 per channel.
+    pub color: [u8; 4],
+    pub h_align: HAlign,
+    pub v_align: VAlign,
+    /// Default duration applied when the preset is dropped onto the timeline.
+    pub default_duration_secs: f32,
+}
+
+impl Default for TextClipPreset {
+    fn default() -> Self {
+        Self {
+            name: "New Title".to_string(),
+            text: String::new(),
+            font_size: 48,
+            color: [255, 255, 255, 255],
+            h_align: HAlign::Centre,
+            v_align: VAlign::Middle,
+            default_duration_secs: 3.0,
+        }
+    }
+}
+
+/// Drag-and-drop payload for text clip presets dragged from the browser to the T1 lane.
+#[derive(Clone, Copy)]
+pub struct TextClipDragIdx(pub usize);
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum TrackKind {
     Video,
     Audio,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum HAlign {
+    Left,
+    Centre,
+    Right,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum VAlign {
+    Top,
+    Middle,
+    Bottom,
+}
+
+/// A text title clip on the T1 track.
+///
+/// Title clips are UI-only; `TimelineBuilder` has no drawtext or graphics overlay API
+/// (docs/issue47.md). Stored in `TimelineState::title_clips` (not in the video `Track` vec).
+#[derive(Clone, PartialEq)]
+pub struct TitleClip {
+    pub start_on_track: Duration,
+    pub duration: Duration,
+    pub text: String,
+    pub font_size: u32,
+    /// RGBA colour, 0–255 per channel.
+    pub color: [u8; 4],
+    pub h_align: HAlign,
+    pub v_align: VAlign,
 }
 
 pub struct Track {
@@ -414,6 +522,10 @@ pub struct TimelineClip {
 pub struct TimelineState {
     pub tracks: Vec<Track>,
     pub pixels_per_second: f32,
+    /// Title clips on the T1 track (displayed above V1 in the UI).
+    ///
+    /// avio gap: these are UI-only; `TimelineBuilder` has no text overlay API (docs/issue47.md).
+    pub title_clips: Vec<TitleClip>,
 }
 
 impl TimelineState {
@@ -461,6 +573,7 @@ impl Default for TimelineState {
                 },
             ],
             pixels_per_second: 60.0,
+            title_clips: Vec::new(),
         }
     }
 }
@@ -518,6 +631,9 @@ impl AppState {
                         self.timeline.tracks[*ti].clips = before.clone();
                     }
                 }
+                EditCommand::TitleSnapshot { before, .. } => {
+                    self.timeline.title_clips = before.clone();
+                }
             }
             self.redo_stack.push(cmd);
             self.clips_moved_while_paused = true;
@@ -532,6 +648,9 @@ impl AppState {
                     for (ti, _, after) in snapshots {
                         self.timeline.tracks[*ti].clips = after.clone();
                     }
+                }
+                EditCommand::TitleSnapshot { after, .. } => {
+                    self.timeline.title_clips = after.clone();
                 }
             }
             self.undo_stack.push(cmd);

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -3,10 +3,241 @@ use std::time::Duration;
 
 use crate::{analysis, gif, player, proxy, sprite, state, thumbnail, trim};
 
+fn show_text_tab(state: &mut state::AppState, ui: &mut egui::Ui) {
+    // ── "+" button to create a new preset ────────────────────────────────────
+    ui.horizontal(|ui| {
+        ui.label("Text Clips");
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            if ui
+                .button("+")
+                .on_hover_text("Create new text clip")
+                .clicked()
+            {
+                let n = state.text_presets.len() + 1;
+                state.text_presets.push(state::TextClipPreset {
+                    name: format!("Title {n}"),
+                    ..Default::default()
+                });
+                state.selected_text_preset = Some(state.text_presets.len() - 1);
+            }
+        });
+    });
+    ui.separator();
+
+    // ── Preset list with drag sources ────────────────────────────────────────
+    let mut clicked_preset: Option<usize> = None;
+    let mut delete_preset: Option<usize> = None;
+
+    egui::ScrollArea::vertical()
+        .id_salt("text_preset_scroll")
+        .max_height(200.0)
+        .show(ui, |ui| {
+            for (idx, preset) in state.text_presets.iter().enumerate() {
+                let selected = state.selected_text_preset == Some(idx);
+                let dnd_id = egui::Id::new(("text_preset_dnd", idx));
+                let is_dragging = ui.ctx().is_being_dragged(dnd_id);
+
+                let card_bg = if selected {
+                    egui::Color32::from_rgba_premultiplied(80, 60, 160, 120)
+                } else {
+                    egui::Color32::from_rgb(45, 40, 60)
+                };
+
+                let dnd = ui.dnd_drag_source(dnd_id, state::TextClipDragIdx(idx), |ui| {
+                    egui::Frame::new()
+                        .fill(card_bg)
+                        .corner_radius(egui::CornerRadius::same(4))
+                        .inner_margin(egui::Margin::same(6))
+                        .show(ui, |ui| {
+                            ui.set_min_width(ui.available_width());
+                            // Colour swatch + name
+                            ui.horizontal(|ui| {
+                                let [r, g, b, _] = preset.color;
+                                let swatch_color = egui::Color32::from_rgb(r, g, b);
+                                let (swatch_rect, _) = ui.allocate_exact_size(
+                                    egui::vec2(12.0, 12.0),
+                                    egui::Sense::hover(),
+                                );
+                                ui.painter().rect_filled(swatch_rect, 2.0, swatch_color);
+                                ui.add(
+                                    egui::Label::new(egui::RichText::new(&preset.name).small())
+                                        .truncate(),
+                                );
+                            });
+                            // Preview text (dimmed)
+                            if !preset.text.is_empty() {
+                                ui.add(
+                                    egui::Label::new(
+                                        egui::RichText::new(&preset.text)
+                                            .small()
+                                            .color(egui::Color32::from_gray(160))
+                                            .italics(),
+                                    )
+                                    .truncate(),
+                                );
+                            }
+                            ui.add(
+                                egui::Label::new(
+                                    egui::RichText::new(format!(
+                                        "{} pt · {}s",
+                                        preset.font_size, preset.default_duration_secs
+                                    ))
+                                    .small()
+                                    .color(egui::Color32::from_gray(130)),
+                                )
+                                .truncate(),
+                            );
+                        });
+                });
+
+                if is_dragging {
+                    ui.ctx().set_cursor_icon(egui::CursorIcon::Grabbing);
+                }
+
+                let card_resp = ui.interact(
+                    dnd.response.rect,
+                    egui::Id::new(("text_preset_click", idx)),
+                    egui::Sense::click(),
+                );
+                if card_resp.clicked() {
+                    clicked_preset = Some(idx);
+                }
+                card_resp.context_menu(|ui| {
+                    if ui.button("Delete").clicked() {
+                        delete_preset = Some(idx);
+                        ui.close();
+                    }
+                });
+            }
+        });
+
+    if let Some(idx) = clicked_preset {
+        state.selected_text_preset = Some(idx);
+    }
+    if let Some(idx) = delete_preset {
+        state.text_presets.remove(idx);
+        state.selected_text_preset = state.selected_text_preset.and_then(|sel| {
+            if sel == idx {
+                None
+            } else if sel > idx {
+                Some(sel - 1)
+            } else {
+                Some(sel)
+            }
+        });
+    }
+
+    // ── Selected preset properties ────────────────────────────────────────────
+    if let Some(idx) = state.selected_text_preset
+        && let Some(preset) = state.text_presets.get_mut(idx)
+    {
+        ui.separator();
+        egui::CollapsingHeader::new("Preset Properties")
+            .default_open(true)
+            .show(ui, |ui| {
+                egui::Grid::new("text_preset_props")
+                    .num_columns(2)
+                    .spacing([8.0, 4.0])
+                    .show(ui, |ui| {
+                        ui.label("Name");
+                        ui.text_edit_singleline(&mut preset.name);
+                        ui.end_row();
+
+                        ui.label("Text");
+                        ui.text_edit_multiline(&mut preset.text);
+                        ui.end_row();
+
+                        ui.label("Font size");
+                        let mut fs = preset.font_size as f32;
+                        if ui
+                            .add(
+                                egui::Slider::new(&mut fs, 12.0..=120.0)
+                                    .suffix(" pt")
+                                    .fixed_decimals(0),
+                            )
+                            .changed()
+                        {
+                            preset.font_size = fs as u32;
+                        }
+                        ui.end_row();
+
+                        ui.label("Color");
+                        let mut color = egui::Color32::from_rgba_unmultiplied(
+                            preset.color[0],
+                            preset.color[1],
+                            preset.color[2],
+                            preset.color[3],
+                        );
+                        if egui::color_picker::color_edit_button_srgba(
+                            ui,
+                            &mut color,
+                            egui::color_picker::Alpha::OnlyBlend,
+                        )
+                        .changed()
+                        {
+                            preset.color = color.to_array();
+                        }
+                        ui.end_row();
+
+                        ui.label("H-Align");
+                        ui.horizontal(|ui| {
+                            ui.selectable_value(&mut preset.h_align, state::HAlign::Left, "Left");
+                            ui.selectable_value(
+                                &mut preset.h_align,
+                                state::HAlign::Centre,
+                                "Centre",
+                            );
+                            ui.selectable_value(&mut preset.h_align, state::HAlign::Right, "Right");
+                        });
+                        ui.end_row();
+
+                        ui.label("V-Align");
+                        ui.horizontal(|ui| {
+                            ui.selectable_value(&mut preset.v_align, state::VAlign::Top, "Top");
+                            ui.selectable_value(
+                                &mut preset.v_align,
+                                state::VAlign::Middle,
+                                "Middle",
+                            );
+                            ui.selectable_value(
+                                &mut preset.v_align,
+                                state::VAlign::Bottom,
+                                "Bottom",
+                            );
+                        });
+                        ui.end_row();
+
+                        ui.label("Duration");
+                        ui.add(
+                            egui::DragValue::new(&mut preset.default_duration_secs)
+                                .suffix(" s")
+                                .range(0.1..=600.0)
+                                .speed(0.1),
+                        );
+                        ui.end_row();
+                    });
+                ui.weak("Drag this preset onto the T1 track to place a title clip.");
+            });
+    }
+}
+
 pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context) {
     ui.heading("Clip Browser");
     ui.separator();
 
+    // ── Tab bar ──────────────────────────────────────────────────────────────
+    ui.horizontal(|ui| {
+        ui.selectable_value(&mut state.browser_tab, state::BrowserTab::Media, "Media");
+        ui.selectable_value(&mut state.browser_tab, state::BrowserTab::Text, "Text");
+    });
+    ui.separator();
+
+    if state.browser_tab == state::BrowserTab::Text {
+        show_text_tab(state, ui);
+        return;
+    }
+
+    // ── Media tab ────────────────────────────────────────────────────────────
     if ui.button("Import").clicked()
         && let Some(paths) = rfd::FileDialog::new()
             .add_filter(

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -38,7 +38,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
 
     if timeline_is_active {
         if let Some(tex) = &state.preview_texture {
-            ui.image(egui::load::SizedTexture::new(tex.id(), video_size));
+            let img_resp = ui.image(egui::load::SizedTexture::new(tex.id(), video_size));
+            draw_title_overlays(state, ui, img_resp.rect);
         } else {
             ui.allocate_ui(video_size, |ui| {
                 ui.centered_and_justified(|ui| {
@@ -403,6 +404,78 @@ fn spawn_and_store(
     state.pending_proxy_rx = Some(proxy_rx);
     state.proxy_active = false;
     state.is_paused = false;
+}
+
+/// Draws active T1 title clips as egui text on top of the preview image rect.
+fn draw_title_overlays(state: &state::AppState, ui: &egui::Ui, img_rect: egui::Rect) {
+    let t = state.timeline_playhead_secs;
+    let painter = ui.painter();
+
+    for tc in &state.timeline.title_clips {
+        if tc.text.is_empty() {
+            continue;
+        }
+        let start = tc.start_on_track.as_secs_f64();
+        let end = start + tc.duration.as_secs_f64();
+        if t < start || t >= end {
+            continue;
+        }
+
+        let [r, g, b, a] = tc.color;
+        let color = egui::Color32::from_rgba_unmultiplied(r, g, b, a);
+
+        // Scale font proportionally to preview width (assumes 1920-wide reference).
+        let font_size = (tc.font_size as f32 * img_rect.width() / 1920.0).max(8.0);
+
+        let pos = match (tc.h_align, tc.v_align) {
+            (state::HAlign::Left, state::VAlign::Top) => {
+                egui::pos2(img_rect.left() + 10.0, img_rect.top() + 10.0)
+            }
+            (state::HAlign::Left, state::VAlign::Middle) => {
+                egui::pos2(img_rect.left() + 10.0, img_rect.center().y)
+            }
+            (state::HAlign::Left, state::VAlign::Bottom) => {
+                egui::pos2(img_rect.left() + 10.0, img_rect.bottom() - 10.0)
+            }
+            (state::HAlign::Centre, state::VAlign::Top) => {
+                egui::pos2(img_rect.center().x, img_rect.top() + 10.0)
+            }
+            (state::HAlign::Centre, state::VAlign::Middle) => img_rect.center(),
+            (state::HAlign::Centre, state::VAlign::Bottom) => {
+                egui::pos2(img_rect.center().x, img_rect.bottom() - 10.0)
+            }
+            (state::HAlign::Right, state::VAlign::Top) => {
+                egui::pos2(img_rect.right() - 10.0, img_rect.top() + 10.0)
+            }
+            (state::HAlign::Right, state::VAlign::Middle) => {
+                egui::pos2(img_rect.right() - 10.0, img_rect.center().y)
+            }
+            (state::HAlign::Right, state::VAlign::Bottom) => {
+                egui::pos2(img_rect.right() - 10.0, img_rect.bottom() - 10.0)
+            }
+        };
+
+        let halign = match tc.h_align {
+            state::HAlign::Left => egui::Align2::LEFT_CENTER,
+            state::HAlign::Centre => egui::Align2::CENTER_CENTER,
+            state::HAlign::Right => egui::Align2::RIGHT_CENTER,
+        };
+        let valign = match tc.v_align {
+            state::VAlign::Top => egui::Align2::CENTER_TOP,
+            state::VAlign::Middle => egui::Align2::CENTER_CENTER,
+            state::VAlign::Bottom => egui::Align2::CENTER_BOTTOM,
+        };
+        // Combine h and v alignment into a single Align2.
+        let align = egui::Align2([halign.x(), valign.y()]);
+
+        painter.text(
+            pos,
+            align,
+            &tc.text,
+            egui::FontId::proportional(font_size),
+            color,
+        );
+    }
 }
 
 fn snap_to_nearest_keyframe(

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -239,6 +239,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     export_filters: state.export_filters.clone(),
                     loudness_normalize: state.loudness_normalize,
                     loudness_target: state.loudness_target,
+                    title_clips: state.timeline.title_clips.clone(),
                 };
                 state.export = Some(export::spawn_export(snapshot, output_path));
             }
@@ -809,6 +810,91 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
         }
     }
 
+    // ── Title Editor ──────────────────────────────────────────────────────────
+    if let Some(tci) = state.selected_title_clip
+        && let Some(tc) = state.timeline.title_clips.get_mut(tci)
+    {
+        egui::CollapsingHeader::new("Title Properties")
+            .default_open(true)
+            .show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("Text");
+                    ui.text_edit_multiline(&mut tc.text);
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Font size");
+                    let mut fs = tc.font_size as f32;
+                    if ui
+                        .add(
+                            egui::Slider::new(&mut fs, 12.0..=120.0)
+                                .suffix(" pt")
+                                .fixed_decimals(0),
+                        )
+                        .changed()
+                    {
+                        tc.font_size = fs as u32;
+                    }
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Color");
+                    let mut color = egui::Color32::from_rgba_unmultiplied(
+                        tc.color[0],
+                        tc.color[1],
+                        tc.color[2],
+                        tc.color[3],
+                    );
+                    if egui::color_picker::color_edit_button_srgba(
+                        ui,
+                        &mut color,
+                        egui::color_picker::Alpha::OnlyBlend,
+                    )
+                    .changed()
+                    {
+                        tc.color = color.to_array();
+                    }
+                });
+                ui.horizontal(|ui| {
+                    ui.label("H-Align");
+                    ui.selectable_value(&mut tc.h_align, state::HAlign::Left, "Left");
+                    ui.selectable_value(&mut tc.h_align, state::HAlign::Centre, "Centre");
+                    ui.selectable_value(&mut tc.h_align, state::HAlign::Right, "Right");
+                });
+                ui.horizontal(|ui| {
+                    ui.label("V-Align");
+                    ui.selectable_value(&mut tc.v_align, state::VAlign::Top, "Top");
+                    ui.selectable_value(&mut tc.v_align, state::VAlign::Middle, "Middle");
+                    ui.selectable_value(&mut tc.v_align, state::VAlign::Bottom, "Bottom");
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Start");
+                    let mut start_secs = tc.start_on_track.as_secs_f32();
+                    if ui
+                        .add(
+                            egui::DragValue::new(&mut start_secs)
+                                .suffix(" s")
+                                .speed(0.1),
+                        )
+                        .changed()
+                    {
+                        tc.start_on_track = Duration::from_secs_f32(start_secs.max(0.0));
+                    }
+                    ui.label("Duration");
+                    let mut dur_secs = tc.duration.as_secs_f32();
+                    if ui
+                        .add(egui::DragValue::new(&mut dur_secs).suffix(" s").speed(0.1))
+                        .changed()
+                    {
+                        tc.duration = Duration::from_secs_f32(dur_secs.max(0.1));
+                    }
+                });
+                // avio gap: title clips are UI-only; TimelineBuilder has no drawtext API (docs/issue47.md).
+                ui.weak(
+                    "Title clips render in the UI only and are not exported \
+                         (avio gap — docs/issue47.md).",
+                );
+            });
+    }
+
     ui.separator();
 
     const TRACK_HEIGHT: f32 = 40.0;
@@ -835,6 +921,13 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             })
         })
         .fold(0.0f32, f32::max);
+    // Also account for title clip extents.
+    let max_end_secs = state
+        .timeline
+        .title_clips
+        .iter()
+        .map(|tc| tc.start_on_track.as_secs_f32() + tc.duration.as_secs_f32())
+        .fold(max_end_secs, f32::max);
     let content_width = (max_end_secs * pps + 200.0).max(1200.0);
 
     let mut pending_clips: Vec<(usize, usize, f32)> = Vec::new();
@@ -859,6 +952,21 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
     // track_idx — M or S button clicked this frame
     let mut pending_mute_toggle: Option<usize> = None;
     let mut pending_solo_toggle: Option<usize> = None;
+    // T1 title clip actions
+    let mut new_title_selection: Option<usize> = None;
+    let mut delete_title_clip: Option<usize> = None;
+    // Text preset drops from the browser: (preset_idx, start_secs_on_track)
+    let mut pending_title_drops: Vec<(usize, f32)> = Vec::new();
+    // Title clip drag-to-reposition: (clip_idx, new_start_secs)
+    let mut pending_title_moves: Vec<(usize, f32)> = Vec::new();
+    // Title clip edge-trim: (clip_idx, new_start, new_duration)
+    let mut pending_title_trims: Vec<(usize, Duration, Duration)> = Vec::new();
+    let active_title_drag = state.title_clip_drag.clone();
+    let active_title_trim = state.title_clip_trim.clone();
+    let mut new_title_drag: Option<state::TitleClipDrag> = None;
+    let mut new_title_trim: Option<state::TitleClipTrimDrag> = None;
+    let mut clear_title_drag = false;
+    let mut clear_title_trim = false;
     // Set on clip left-click; applied after the ScrollArea.
     let mut new_selection: Option<(usize, usize)> = None;
     let active_drag = state.clip_drag.clone();
@@ -981,6 +1089,189 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     );
                 }
             }
+
+            // ── Title track (T1) — rendered above all video tracks ─────────────
+            let mut t1_lane_rect = egui::Rect::NOTHING;
+            ui.horizontal(|ui| {
+                ui.allocate_ui_with_layout(
+                    egui::vec2(LABEL_WIDTH, TRACK_HEIGHT),
+                    egui::Layout::top_down(egui::Align::Center),
+                    |ui| {
+                        ui.label("T1");
+                    },
+                );
+
+                let is_text_dnd_hover = ui.input(|i| i.pointer.is_decidedly_dragging())
+                    && ui.rect_contains_pointer(egui::Rect::from_min_size(
+                        ui.cursor().min,
+                        egui::vec2(content_width - LABEL_WIDTH, TRACK_HEIGHT),
+                    ));
+                let t1_bg = if is_text_dnd_hover {
+                    egui::Color32::from_rgb(70, 55, 100)
+                } else {
+                    egui::Color32::from_gray(35)
+                };
+
+                let (t1_rect, t1_resp) = ui.allocate_exact_size(
+                    egui::vec2(content_width - LABEL_WIDTH, TRACK_HEIGHT),
+                    egui::Sense::click(),
+                );
+                t1_lane_rect = t1_rect;
+                ui.painter().rect_filled(t1_rect, 0.0, t1_bg);
+                ui.painter().rect_stroke(
+                    t1_rect,
+                    0.0,
+                    egui::Stroke::new(1.0, egui::Color32::from_gray(60)),
+                    egui::StrokeKind::Inside,
+                );
+
+                for (tci, tc) in state.timeline.title_clips.iter().enumerate() {
+                    let x = t1_rect.left() + tc.start_on_track.as_secs_f32() * pps;
+                    let w = (tc.duration.as_secs_f32() * pps).max(2.0);
+                    let cr = egui::Rect::from_min_size(
+                        egui::pos2(x, t1_rect.top()),
+                        egui::vec2(w, TRACK_HEIGHT),
+                    );
+                    if cr.max.x < t1_rect.left() || cr.min.x > t1_rect.right() {
+                        continue;
+                    }
+                    let is_selected = state.selected_title_clip == Some(tci);
+                    ui.painter()
+                        .rect_filled(cr, 4.0, egui::Color32::from_rgb(200, 150, 50));
+                    let label = if tc.text.is_empty() {
+                        "(title)"
+                    } else {
+                        tc.text.as_str()
+                    };
+                    let clipped_painter = ui.painter().with_clip_rect(cr);
+                    clipped_painter.text(
+                        cr.left_center() + egui::vec2(4.0, 0.0),
+                        egui::Align2::LEFT_CENTER,
+                        label,
+                        egui::FontId::proportional(11.0),
+                        egui::Color32::WHITE,
+                    );
+                    if is_selected {
+                        ui.painter().rect_stroke(
+                            cr,
+                            4.0,
+                            egui::Stroke::new(2.0, egui::Color32::WHITE),
+                            egui::StrokeKind::Outside,
+                        );
+                    }
+                    let clip_id = egui::Id::new(("t1_clip", tci));
+                    let clip_resp = ui.interact(cr, clip_id, egui::Sense::click_and_drag());
+                    if clip_resp.clicked() {
+                        new_title_selection = Some(tci);
+                    }
+
+                    // Resize cursor near trim edges
+                    let near_trim_edge = clip_resp.hovered()
+                        && ui.input(|i| i.pointer.latest_pos()).is_some_and(|ptr| {
+                            ptr.x <= x + TRIM_HANDLE_PX || ptr.x >= x + w - TRIM_HANDLE_PX
+                        });
+                    if near_trim_edge
+                        || active_title_trim
+                            .as_ref()
+                            .is_some_and(|t| t.clip_idx == tci)
+                    {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeHorizontal);
+                    }
+
+                    if clip_resp.drag_started() {
+                        // Auto-pause so the user can resize while the playhead stays.
+                        let is_timeline_playing = state
+                            .timeline_player_thread
+                            .as_ref()
+                            .map(|h| !h.is_finished())
+                            .unwrap_or(false);
+                        if is_timeline_playing && !state.timeline_is_paused {
+                            if let Some(h) = &state.timeline_player_handle {
+                                h.pause();
+                            }
+                            state.timeline_is_paused = true;
+                        }
+                        let ptr_x = ui
+                            .input(|i| i.pointer.press_origin())
+                            .map(|p| p.x)
+                            .unwrap_or(x);
+                        if ptr_x <= x + TRIM_HANDLE_PX {
+                            new_title_trim = Some(state::TitleClipTrimDrag {
+                                clip_idx: tci,
+                                edge: state::TrimEdge::Left,
+                            });
+                        } else if ptr_x >= x + w - TRIM_HANDLE_PX {
+                            new_title_trim = Some(state::TitleClipTrimDrag {
+                                clip_idx: tci,
+                                edge: state::TrimEdge::Right,
+                            });
+                        } else {
+                            let grab = ((ptr_x - t1_rect.left()) / pps
+                                - tc.start_on_track.as_secs_f32())
+                            .max(0.0);
+                            new_title_drag = Some(state::TitleClipDrag {
+                                clip_idx: tci,
+                                grab_offset_secs: grab,
+                            });
+                        }
+                    }
+                    if clip_resp.drag_stopped()
+                        && let Some(ref trim) = active_title_trim
+                        && trim.clip_idx == tci
+                    {
+                        if let Some(ptr) = ui.input(|i| i.pointer.latest_pos()) {
+                            const MIN_DUR_SECS: f32 = 0.1;
+                            match trim.edge {
+                                state::TrimEdge::Right => {
+                                    let new_w = (ptr.x - x).max(MIN_DUR_SECS * pps);
+                                    let new_dur =
+                                        Duration::from_secs_f32((new_w / pps).max(MIN_DUR_SECS));
+                                    pending_title_trims.push((tci, tc.start_on_track, new_dur));
+                                }
+                                state::TrimEdge::Left => {
+                                    let max_start_x = x + w - MIN_DUR_SECS * pps;
+                                    let new_x = ptr.x.min(max_start_x).max(t1_rect.left());
+                                    let new_start = Duration::from_secs_f32(
+                                        ((new_x - t1_rect.left()) / pps).max(0.0),
+                                    );
+                                    let old_end = tc.start_on_track + tc.duration;
+                                    let new_dur = old_end
+                                        .saturating_sub(new_start)
+                                        .max(Duration::from_secs_f32(MIN_DUR_SECS));
+                                    pending_title_trims.push((tci, new_start, new_dur));
+                                }
+                            }
+                        }
+                        clear_title_trim = true;
+                    }
+                    if clip_resp.drag_stopped()
+                        && let Some(ref drag) = active_title_drag
+                        && drag.clip_idx == tci
+                    {
+                        if let Some(ptr) = ui.input(|i| i.pointer.latest_pos()) {
+                            let raw_start =
+                                ((ptr.x - t1_rect.left()) / pps - drag.grab_offset_secs).max(0.0);
+                            pending_title_moves.push((tci, raw_start));
+                        }
+                        clear_title_drag = true;
+                    }
+                    clip_resp.context_menu(|ui| {
+                        if ui.button("Delete").clicked() {
+                            delete_title_clip = Some(tci);
+                            ui.close();
+                        }
+                    });
+                }
+
+                // Receive text preset drops from the browser.
+                if let Some(payload) = t1_resp.dnd_release_payload::<state::TextClipDragIdx>() {
+                    let ptr_x = ui
+                        .input(|i| i.pointer.latest_pos().map(|p| p.x))
+                        .unwrap_or(t1_rect.left());
+                    let start_secs = ((ptr_x - t1_rect.left()) / pps).max(0.0);
+                    pending_title_drops.push((payload.0, start_secs));
+                }
+            });
 
             // ── Track lanes ────────────────────────────────────────────────────
             for (track_idx, track) in state.timeline.tracks.iter().enumerate() {
@@ -1954,6 +2245,66 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 }
             }
 
+            // ── T1 ghost clip while dragging title ──────────────────────────────
+            if let Some(ref drag) = active_title_drag
+                && let Some(ptr) = ui.input(|i| i.pointer.latest_pos())
+                && let Some(tc) = state.timeline.title_clips.get(drag.clip_idx)
+            {
+                let ghost_dur = tc.duration.as_secs_f32();
+                let ghost_start =
+                    ((ptr.x - t1_lane_rect.left()) / pps - drag.grab_offset_secs).max(0.0);
+                let ghost_rect = egui::Rect::from_min_size(
+                    egui::pos2(t1_lane_rect.left() + ghost_start * pps, t1_lane_rect.top()),
+                    egui::vec2((ghost_dur * pps).max(2.0), TRACK_HEIGHT),
+                );
+                ui.painter().rect_filled(
+                    ghost_rect,
+                    4.0,
+                    egui::Color32::from_rgba_premultiplied(200, 150, 50, 120),
+                );
+                ui.painter().rect_stroke(
+                    ghost_rect,
+                    4.0,
+                    egui::Stroke::new(1.5, egui::Color32::WHITE),
+                    egui::StrokeKind::Outside,
+                );
+            }
+            // ── T1 trim ghost ────────────────────────────────────────────────────
+            if let Some(ref trim) = active_title_trim
+                && let Some(ptr) = ui.input(|i| i.pointer.latest_pos())
+                && let Some(tc) = state.timeline.title_clips.get(trim.clip_idx)
+            {
+                const MIN_DUR_SECS: f32 = 0.1;
+                let orig_x = t1_lane_rect.left() + tc.start_on_track.as_secs_f32() * pps;
+                let orig_w = tc.duration.as_secs_f32() * pps;
+                let (ghost_left, ghost_w) = match trim.edge {
+                    state::TrimEdge::Right => {
+                        let new_w = (ptr.x - orig_x).max(MIN_DUR_SECS * pps);
+                        (orig_x, new_w)
+                    }
+                    state::TrimEdge::Left => {
+                        let max_start_x = orig_x + orig_w - MIN_DUR_SECS * pps;
+                        let new_x = ptr.x.min(max_start_x).max(t1_lane_rect.left());
+                        (new_x, orig_x + orig_w - new_x)
+                    }
+                };
+                let ghost_rect = egui::Rect::from_min_size(
+                    egui::pos2(ghost_left, t1_lane_rect.top()),
+                    egui::vec2(ghost_w.max(2.0), TRACK_HEIGHT),
+                );
+                ui.painter().rect_filled(
+                    ghost_rect,
+                    4.0,
+                    egui::Color32::from_rgba_premultiplied(200, 150, 50, 120),
+                );
+                ui.painter().rect_stroke(
+                    ghost_rect,
+                    4.0,
+                    egui::Stroke::new(1.5, egui::Color32::from_rgb(255, 200, 0)),
+                    egui::StrokeKind::Outside,
+                );
+            }
+
             // ── Playhead ────────────────────────────────────────────────────────
             let playhead_x = timeline_left + state.timeline_playhead_secs as f32 * pps;
             let tracks_bottom =
@@ -2004,6 +2355,95 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
     // Apply timeline selection change.
     if let Some(sel) = new_selection {
         state.timeline_selected = Some(sel);
+        state.selected_title_clip = None;
+    }
+
+    // Apply T1 title clip actions.
+    if let Some(idx) = new_title_selection {
+        state.selected_title_clip = Some(idx);
+        state.timeline_selected = None;
+    }
+    for (preset_idx, start_secs) in pending_title_drops {
+        if let Some(preset) = state.text_presets.get(preset_idx) {
+            let start = Duration::from_secs_f32(start_secs);
+            let new_tc = state::TitleClip {
+                start_on_track: start,
+                duration: Duration::from_secs_f32(preset.default_duration_secs),
+                text: preset.text.clone(),
+                font_size: preset.font_size,
+                color: preset.color,
+                h_align: preset.h_align,
+                v_align: preset.v_align,
+            };
+            state.timeline.title_clips.push(new_tc);
+            state.timeline.title_clips.sort_by_key(|c| c.start_on_track);
+            if let Some(idx) = state
+                .timeline
+                .title_clips
+                .iter()
+                .position(|c| c.start_on_track == start)
+            {
+                state.selected_title_clip = Some(idx);
+                state.timeline_selected = None;
+            }
+        }
+    }
+    if let Some(idx) = delete_title_clip
+        && idx < state.timeline.title_clips.len()
+    {
+        state.timeline.title_clips.remove(idx);
+        match state.selected_title_clip {
+            Some(sel) if sel == idx => state.selected_title_clip = None,
+            Some(sel) if sel > idx => state.selected_title_clip = Some(sel - 1),
+            _ => {}
+        }
+    }
+
+    // Apply title clip moves.
+    let had_title_moves = !pending_title_moves.is_empty();
+    let title_clips_before = state.timeline.title_clips.clone();
+    for (clip_idx, new_start_secs) in pending_title_moves {
+        if let Some(tc) = state.timeline.title_clips.get_mut(clip_idx) {
+            tc.start_on_track = Duration::from_secs_f32(new_start_secs);
+        }
+        state.timeline.title_clips.sort_by_key(|c| c.start_on_track);
+        // Keep selection pointing at the same clip after sort.
+        if let Some(tc) = state.timeline.title_clips.get(clip_idx) {
+            let start = tc.start_on_track;
+            if let Some(new_idx) = state
+                .timeline
+                .title_clips
+                .iter()
+                .position(|c| c.start_on_track == start)
+            {
+                state.selected_title_clip = Some(new_idx);
+            }
+        }
+    }
+    if had_title_moves && title_clips_before != state.timeline.title_clips {
+        state.push_edit(state::EditCommand::TitleSnapshot {
+            before: title_clips_before,
+            after: state.timeline.title_clips.clone(),
+            label: "Move Title Clip",
+        });
+    }
+
+    // Apply title clip trims.
+    let had_title_trims = !pending_title_trims.is_empty();
+    let title_clips_before_trim = state.timeline.title_clips.clone();
+    for (clip_idx, new_start, new_dur) in pending_title_trims {
+        if let Some(tc) = state.timeline.title_clips.get_mut(clip_idx) {
+            tc.start_on_track = new_start;
+            tc.duration = new_dur;
+        }
+        state.timeline.title_clips.sort_by_key(|c| c.start_on_track);
+    }
+    if had_title_trims && title_clips_before_trim != state.timeline.title_clips {
+        state.push_edit(state::EditCommand::TitleSnapshot {
+            before: title_clips_before_trim,
+            after: state.timeline.title_clips.clone(),
+            label: "Trim Title Clip",
+        });
     }
 
     // Copy selected clip to clipboard (Ctrl+C).
@@ -2095,6 +2535,18 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
     }
     if let Some(nt) = new_trim {
         state.clip_trim = Some(nt);
+    }
+    if clear_title_drag {
+        state.title_clip_drag = None;
+    }
+    if let Some(ntd) = new_title_drag {
+        state.title_clip_drag = Some(ntd);
+    }
+    if clear_title_trim {
+        state.title_clip_trim = None;
+    }
+    if let Some(ntt) = new_title_trim {
+        state.title_clip_trim = Some(ntt);
     }
     if moved_while_paused {
         state.clips_moved_while_paused = true;


### PR DESCRIPTION
## Summary

Adds a dedicated T1 title track to the timeline where users can create, edit, reposition, and resize text clips. Title text is rendered as an overlay on the preview monitor during playback and composited via FFmpeg `lavfi drawtext` during export.

## Changes

- **`src/state.rs`**: Added `TitleClip`, `TitleClipDrag`, `TitleClipTrimDrag`, `TextClipPreset`, `BrowserTab`, `TextClipDragIdx` types; added `title_clips` to `TimelineState`; added `EditCommand::TitleSnapshot` for undo/redo; wired `apply_undo`/`apply_redo` to restore title clip state
- **`src/ui/clip_browser.rs`**: Added "Text" tab with preset list; "+" button creates `TextClipPreset` items; each preset is a `dnd_drag_source` draggable onto the T1 lane; preset properties (name, text, font size, colour, alignment, duration) editable via collapsing header
- **`src/ui/timeline.rs`**: T1 lane rendered above V1; accepts `TextClipDragIdx` drops to place title clips; clips support click-to-select, drag-to-reposition, edge-trim (left/right), context-menu delete, and undo/redo via `TitleSnapshot`; loop-region and playhead render above T1
- **`src/ui/monitor.rs`**: `draw_title_overlays()` renders active title clips as text on the preview image using `egui::Painter`, scaled to the monitor viewport
- **`src/export.rs`**: `build_lavfi_overlay_filter()` builds a `color=…,drawtext=…` filtergraph string from T1 clips; `ExportSnapshot` carries `title_clips`; `TimelineBuilder::lavfi_overlay()` is called when title clips are present

## Related Issues

Closes #103

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes