### PR TITLE
feat(export): add I/O markers and Export Range mode

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -51,6 +51,10 @@ pub struct ExportSnapshot {
     pub loudness_target: f64,
     /// Title clips from the T1 track — converted to a lavfi drawtext overlay.
     pub title_clips: Vec<crate::state::TitleClip>,
+    /// Export in-point. `Some` only when export range mode is active.
+    pub export_in: Option<Duration>,
+    /// Export out-point. `Some` only when export range mode is active.
+    pub export_out: Option<Duration>,
 }
 
 /// Spawns a background task that builds an `avio::Timeline` from the snapshot
@@ -131,6 +135,55 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
         .collect()
 }
 
+/// Filters and trims a track's clips to `[range_in, range_out)`.
+///
+/// Clips entirely outside the range are dropped. Clips that overlap are trimmed and their
+/// `start_on_track` values are shifted by `-range_in` so the output starts at t = 0.
+fn clip_range_filter(
+    clips: Vec<ExportClip>,
+    range_in: Duration,
+    range_out: Duration,
+) -> Vec<ExportClip> {
+    clips
+        .into_iter()
+        .filter_map(|mut c| {
+            let eff_in = c.in_point.unwrap_or(Duration::ZERO);
+            let eff_out = c.out_point.unwrap_or(c.source_duration);
+            let src_dur = eff_out.saturating_sub(eff_in);
+            let tl_dur = Duration::from_secs_f64(src_dur.as_secs_f64() / c.speed as f64);
+            let tl_end = c.start_on_track + tl_dur;
+
+            if tl_end <= range_in || c.start_on_track >= range_out {
+                return None;
+            }
+            // Trim start: skip source material that falls before the range.
+            if c.start_on_track < range_in {
+                let skip_src = Duration::from_secs_f64(
+                    (range_in - c.start_on_track).as_secs_f64() * c.speed as f64,
+                );
+                c.in_point = Some(eff_in + skip_src);
+                c.start_on_track = Duration::ZERO;
+            } else {
+                c.start_on_track -= range_in;
+            }
+            // Trim end: drop source material that falls past the range.
+            if tl_end > range_out {
+                let trim_src =
+                    Duration::from_secs_f64((tl_end - range_out).as_secs_f64() * c.speed as f64);
+                let new_out = eff_out.saturating_sub(trim_src);
+                c.out_point = Some(new_out.max(c.in_point.unwrap_or(Duration::ZERO)));
+            }
+            // clips_to_avio only calls .trim() when BOTH in_point and out_point are Some.
+            // If out_point was set above but in_point is still None, explicitly set it so
+            // the (Some, Some) branch is used and the end-trim actually takes effect.
+            if c.out_point.is_some() && c.in_point.is_none() {
+                c.in_point = Some(eff_in);
+            }
+            Some(c)
+        })
+        .collect()
+}
+
 /// Builds an FFmpeg `lavfi` filtergraph string from T1 title clips.
 ///
 /// Returns `None` when there are no non-empty title clips.  The string is
@@ -185,10 +238,38 @@ fn build_lavfi_overlay_filter(
 }
 
 fn build_and_render(
-    snapshot: ExportSnapshot,
+    mut snapshot: ExportSnapshot,
     output: &std::path::Path,
     progress: &Arc<AtomicU32>,
 ) -> Result<(), String> {
+    // Apply export range filter. Mutates the snapshot so all downstream logic
+    // (total_frames_estimate, timeline_dur_secs, lavfi overlay) uses trimmed clips.
+    if let (Some(range_in), Some(range_out)) = (snapshot.export_in, snapshot.export_out)
+        && range_in < range_out
+    {
+        snapshot.video_clips = std::mem::take(&mut snapshot.video_clips)
+            .into_iter()
+            .map(|track| clip_range_filter(track, range_in, range_out))
+            .collect();
+        let a1 = std::mem::take(&mut snapshot.a1_clips);
+        snapshot.a1_clips = clip_range_filter(a1, range_in, range_out);
+        snapshot.title_clips = std::mem::take(&mut snapshot.title_clips)
+            .into_iter()
+            .filter(|tc| {
+                tc.start_on_track < range_out && tc.start_on_track + tc.duration > range_in
+            })
+            .map(|mut tc| {
+                let tc_end = tc.start_on_track + tc.duration;
+                tc.start_on_track = tc.start_on_track.saturating_sub(range_in);
+                let new_end = tc_end.min(range_out).saturating_sub(range_in);
+                tc.duration = new_end
+                    .saturating_sub(tc.start_on_track)
+                    .max(Duration::from_millis(1));
+                tc
+            })
+            .collect();
+    }
+
     // Compute the estimate before snapshot fields are moved into clips_to_avio.
     // Used as a fallback when avio cannot determine total_frames (clips without out_point).
     let total_frames_estimate: Option<u64> = {

--- a/src/state.rs
+++ b/src/state.rs
@@ -141,9 +141,14 @@ pub struct AppState {
     /// Current J-key reverse rate. 0.0 = not reversing; positive = 1/2/4/8×.
     pub jkl_reverse_rate: f64,
     // ── Timeline loop region ─────────────────────────────────────────────────
-    pub timeline_loop_in: Option<std::time::Duration>,
-    pub timeline_loop_out: Option<std::time::Duration>,
     pub timeline_loop_enabled: bool,
+    // ── I/O markers (shared by loop playback and export range) ───────────────
+    /// Timeline in-point. Set by I key. Used for both loop playback and Export Range.
+    pub export_in: Option<std::time::Duration>,
+    /// Timeline out-point. Set by O key. Used for both loop playback and Export Range.
+    pub export_out: Option<std::time::Duration>,
+    /// When true, only the [export_in, export_out) range is rendered on export.
+    pub export_range_enabled: bool,
     /// Index into `TimelineState::title_clips` of the currently selected title clip.
     pub selected_title_clip: Option<usize>,
     /// Active tab in the clip browser left panel.
@@ -224,9 +229,10 @@ impl Default for AppState {
             timeline_clipboard: None,
             jkl_forward_rate: 0.0,
             jkl_reverse_rate: 0.0,
-            timeline_loop_in: None,
-            timeline_loop_out: None,
             timeline_loop_enabled: false,
+            export_in: None,
+            export_out: None,
+            export_range_enabled: false,
             selected_title_clip: None,
             browser_tab: BrowserTab::Media,
             text_presets: Vec::new(),

--- a/src/ui/drain.rs
+++ b/src/ui/drain.rs
@@ -181,8 +181,8 @@ fn drain_frame(state: &mut AppState, ctx: &egui::Context) {
             // out-point, seek back to the in-point.
             if state.timeline_loop_enabled
                 && !state.timeline_is_paused
-                && let Some(loop_out) = state.timeline_loop_out
-                && let Some(loop_in) = state.timeline_loop_in
+                && let Some(loop_out) = state.export_out
+                && let Some(loop_in) = state.export_in
                 && loop_in < loop_out
                 && frame.pts >= loop_out
                 && let Some(handle) = &state.timeline_player_handle

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -240,6 +240,16 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     loudness_normalize: state.loudness_normalize,
                     loudness_target: state.loudness_target,
                     title_clips: state.timeline.title_clips.clone(),
+                    export_in: if state.export_range_enabled {
+                        state.export_in
+                    } else {
+                        None
+                    },
+                    export_out: if state.export_range_enabled {
+                        state.export_out
+                    } else {
+                        None
+                    },
                 };
                 state.export = Some(export::spawn_export(snapshot, output_path));
             }
@@ -330,6 +340,58 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     }
                 }
             });
+
+            ui.separator();
+
+            // Export Range section
+            ui.horizontal(|ui| {
+                ui.checkbox(&mut state.export_range_enabled, "Export Range only");
+                if state.export_range_enabled {
+                    match (state.export_in, state.export_out) {
+                        (Some(ei), Some(eo)) if ei < eo => {
+                            let d = (eo - ei).as_secs_f64();
+                            ui.label(format!(
+                                "{:02}:{:02}.{:03}",
+                                (d / 60.0) as u64,
+                                (d % 60.0) as u64,
+                                ((d % 1.0) * 1000.0) as u64
+                            ));
+                        }
+                        _ => {
+                            ui.weak("Set I/O markers on ruler");
+                        }
+                    }
+                }
+            });
+            if state.export_range_enabled {
+                let fmt_tc = |d: Option<std::time::Duration>| {
+                    d.map(|d| {
+                        let s = d.as_secs_f64();
+                        format!(
+                            "{:02}:{:02}.{:03}",
+                            (s / 60.0) as u64,
+                            (s % 60.0) as u64,
+                            ((s % 1.0) * 1000.0) as u64
+                        )
+                    })
+                    .unwrap_or_else(|| "--:--.---".to_string())
+                };
+                ui.horizontal(|ui| {
+                    ui.label(format!("IN: {}", fmt_tc(state.export_in)));
+                    if ui.small_button("Set").clicked() {
+                        state.export_in = Some(std::time::Duration::from_secs_f64(
+                            state.timeline_playhead_secs,
+                        ));
+                    }
+                    ui.separator();
+                    ui.label(format!("OUT: {}", fmt_tc(state.export_out)));
+                    if ui.small_button("Set").clicked() {
+                        state.export_out = Some(std::time::Duration::from_secs_f64(
+                            state.timeline_playhead_secs,
+                        ));
+                    }
+                });
+            }
 
             ui.separator();
 
@@ -673,8 +735,6 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             if ui.button("⏹ Stop").clicked() {
                 state.stop_timeline_player();
                 state.timeline_playhead_secs = 0.0;
-                state.timeline_loop_in = None;
-                state.timeline_loop_out = None;
                 state.timeline_loop_enabled = false;
             }
             ui.separator();
@@ -1041,8 +1101,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 }
             }
 
-            // Loop region: shaded band + I/O marker lines
-            if let (Some(li), Some(lo)) = (state.timeline_loop_in, state.timeline_loop_out)
+            // I/O markers: shaded band + marker lines (shared by loop and export range)
+            if let (Some(li), Some(lo)) = (state.export_in, state.export_out)
                 && li < lo
             {
                 let x1 = (timeline_left + li.as_secs_f32() * pps).max(timeline_left);
@@ -1055,7 +1115,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     );
                 }
             }
-            if let Some(li) = state.timeline_loop_in {
+            if let Some(li) = state.export_in {
                 let x = timeline_left + li.as_secs_f32() * pps;
                 if x >= timeline_left && x <= ruler_rect.right() {
                     painter.vline(
@@ -1072,7 +1132,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     );
                 }
             }
-            if let Some(lo) = state.timeline_loop_out {
+            if let Some(lo) = state.export_out {
                 let x = timeline_left + lo.as_secs_f32() * pps;
                 if x >= timeline_left && x <= ruler_rect.right() {
                     painter.vline(
@@ -2877,12 +2937,12 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
     }
 
     if do_loop_in {
-        state.timeline_loop_in = Some(std::time::Duration::from_secs_f64(
+        state.export_in = Some(std::time::Duration::from_secs_f64(
             state.timeline_playhead_secs,
         ));
     }
     if do_loop_out {
-        state.timeline_loop_out = Some(std::time::Duration::from_secs_f64(
+        state.export_out = Some(std::time::Duration::from_secs_f64(
             state.timeline_playhead_secs,
         ));
     }


### PR DESCRIPTION
## Summary

Adds in/out point markers to the timeline ruler so users can export only a selected portion of the timeline. The I/O markers are shared between loop playback and export range, matching the design of professional NLEs. Also fixes a bug in avio where `AudioTrack` had no `in_point`/`out_point`, causing audio to run for the full source duration during range exports.

## Changes

- **`src/state.rs`**: Added `export_in`, `export_out`, `export_range_enabled` fields; unified loop/export markers by removing separate `timeline_loop_in`/`timeline_loop_out` fields — one set of I/O markers is now shared by loop playback and export range
- **`src/ui/timeline.rs`**: I/O keys unconditionally set shared markers; ruler draws blue I/O band and marker lines; Export Settings panel gains "Export Range only" checkbox with range duration display and Set In/Out buttons
- **`src/ui/drain.rs`**: Loop-back detection updated to read from unified `export_in`/`export_out`
- **`src/export.rs`**: `ExportSnapshot` carries `export_in`/`export_out`; new `clip_range_filter()` function trims clips to the range and shifts `start_on_track` by `-range_in`; applied at the top of `build_and_render` so `total_frames_estimate` and `timeline_dur_secs` reflect the range duration; title clips are also shifted and trimmed
- **`docs/issue48.md`**: Documented avio gap — `AudioTrack` lacked `in_point`/`out_point`; fixed in avio (`AudioTrack` now forwards trim to `atrim`+`asetpts` filters in the audio mix graph)

## Related Issues

Closes #104

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes