### PR TITLE
feat(export): replace single export with sequential batch queue

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -1,9 +1,7 @@
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-
-use crate::state::{ExportHandle, ExportStatus};
 
 /// Send-safe snapshot of a single clip on any track.
 pub struct ExportClip {
@@ -57,27 +55,66 @@ pub struct ExportSnapshot {
     pub export_out: Option<Duration>,
 }
 
-/// Spawns a background task that builds an `avio::Timeline` from the snapshot
-/// and calls `Timeline::render_with_progress()`. Returns an `ExportHandle`
-/// whose `status` and `progress` fields can be polled from the render loop.
-pub fn spawn_export(snapshot: ExportSnapshot, output_path: PathBuf) -> ExportHandle {
-    let status = Arc::new(Mutex::new(ExportStatus::Running));
-    let progress = Arc::new(AtomicU32::new(0));
-    let status_clone = Arc::clone(&status);
-    let progress_clone = Arc::clone(&progress);
-    let output_clone = output_path.clone();
+/// A single entry in the export queue.
+///
+/// The snapshot is stored as `Option` and consumed (via `.take()`) when
+/// rendering begins so it cannot be accidentally re-used.
+pub struct QueueJob {
+    pub output_path: PathBuf,
+    /// Snapshot captured at "Add to Queue" time. `None` after rendering starts.
+    pub snapshot: Option<ExportSnapshot>,
+    pub status: Arc<Mutex<crate::state::QueueJobStatus>>,
+    pub progress: Arc<AtomicU32>,
+    pub cancel: Arc<AtomicBool>,
+}
+
+impl QueueJob {
+    pub fn new(snapshot: ExportSnapshot, output_path: PathBuf) -> Self {
+        Self {
+            output_path,
+            snapshot: Some(snapshot),
+            status: Arc::new(Mutex::new(crate::state::QueueJobStatus::Pending)),
+            progress: Arc::new(AtomicU32::new(0)),
+            cancel: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+/// Starts rendering `job` in the background.
+///
+/// Takes the snapshot from `job.snapshot`, sets status to `Running`, and
+/// spawns a `tokio::task::spawn_blocking` call. Returns `false` if the job is
+/// not `Pending` or the snapshot was already consumed.
+pub fn spawn_queue_job(job: &mut QueueJob) -> bool {
+    let snapshot = match job.snapshot.take() {
+        Some(s) => s,
+        None => return false,
+    };
+    {
+        let mut s = job.status.lock().unwrap_or_else(|e| e.into_inner());
+        if *s != crate::state::QueueJobStatus::Pending {
+            return false;
+        }
+        *s = crate::state::QueueJobStatus::Running;
+    }
+    let status = Arc::clone(&job.status);
+    let progress = Arc::clone(&job.progress);
+    let cancel = Arc::clone(&job.cancel);
+    let output = job.output_path.clone();
 
     tokio::task::spawn_blocking(move || {
-        let result = build_and_render(snapshot, &output_clone, &progress_clone);
-        if let Ok(mut guard) = status_clone.lock() {
-            *guard = match result {
-                Ok(()) => ExportStatus::Done(output_clone),
-                Err(e) => ExportStatus::Failed(e),
-            };
-        }
+        let result = build_and_render(snapshot, &output, &progress, &cancel);
+        let mut guard = status.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = match result {
+            Ok(()) => crate::state::QueueJobStatus::Done(output),
+            Err(ref e) if e == "cancelled" => {
+                let _ = std::fs::remove_file(&output);
+                crate::state::QueueJobStatus::Cancelled
+            }
+            Err(e) => crate::state::QueueJobStatus::Failed(e),
+        };
     });
-
-    ExportHandle { status, progress }
+    true
 }
 
 fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
@@ -241,6 +278,7 @@ fn build_and_render(
     mut snapshot: ExportSnapshot,
     output: &std::path::Path,
     progress: &Arc<AtomicU32>,
+    cancel: &Arc<AtomicBool>,
 ) -> Result<(), String> {
     // Apply export range filter. Mutates the snapshot so all downstream logic
     // (total_frames_estimate, timeline_dur_secs, lavfi overlay) uses trimmed clips.
@@ -373,18 +411,20 @@ fn build_and_render(
     let timeline = builder.build().map_err(|e| e.to_string())?;
 
     let progress_ref = Arc::clone(progress);
-    timeline
-        .render_with_progress(output, config, move |p| {
-            let pct = p.percent().unwrap_or_else(|| {
-                total_frames_estimate
-                    .filter(|&total| total > 0)
-                    .map(|total| (p.frames_processed as f64 / total as f64 * 100.0).min(99.0))
-                    .unwrap_or(0.0)
-            });
-            progress_ref.store((pct as f32).to_bits(), Ordering::Relaxed);
-            true
-        })
-        .map_err(|e| e.to_string())?;
-
-    Ok(())
+    let cancel_ref = Arc::clone(cancel);
+    let render_result = timeline.render_with_progress(output, config, move |p| {
+        let pct = p.percent().unwrap_or_else(|| {
+            total_frames_estimate
+                .filter(|&total| total > 0)
+                .map(|total| (p.frames_processed as f64 / total as f64 * 100.0).min(99.0))
+                .unwrap_or(0.0)
+        });
+        progress_ref.store((pct as f32).to_bits(), Ordering::Relaxed);
+        !cancel_ref.load(Ordering::Relaxed)
+    });
+    match render_result {
+        Ok(()) => Ok(()),
+        Err(_) if cancel.load(Ordering::Relaxed) => Err("cancelled".to_string()),
+        Err(e) => Err(e.to_string()),
+    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU32, AtomicU64};
+use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
 
@@ -115,7 +115,8 @@ pub struct AppState {
     /// of calling h.play() on the stale runner.
     pub clips_moved_while_paused: bool,
     pub av_offset_ms: i32,
-    pub export: Option<ExportHandle>,
+    pub export_queue: Vec<crate::export::QueueJob>,
+    pub queue_rendering: bool,
     pub encoder_config: EncoderConfigDraft,
     pub export_filters: ExportFilterDraft,
     pub loudness_result: Option<LoudnessResult>,
@@ -209,7 +210,8 @@ impl Default for AppState {
             timeline_is_paused: false,
             clips_moved_while_paused: false,
             av_offset_ms: 0,
-            export: None,
+            export_queue: Vec::new(),
+            queue_rendering: false,
             encoder_config: EncoderConfigDraft::default(),
             export_filters: ExportFilterDraft::default(),
             loudness_result: None,
@@ -320,18 +322,14 @@ pub struct ProxyJobHandle {
     pub status: Arc<Mutex<ProxyStatus>>,
 }
 
+/// Status of a single queued export job.
 #[derive(Clone, PartialEq)]
-pub enum ExportStatus {
+pub enum QueueJobStatus {
+    Pending,
     Running,
     Done(PathBuf),
     Failed(String),
-}
-
-pub struct ExportHandle {
-    pub status: Arc<Mutex<ExportStatus>>,
-    /// Export progress `0.0..=1.0` stored as `f32::to_bits()`. `0.0` until the
-    /// first progress callback fires.
-    pub progress: Arc<AtomicU32>,
+    Cancelled,
 }
 
 /// EBU R128 loudness measurement result.

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -176,18 +176,34 @@ fn snap_clip_start(
 pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
     let ctx = ui.ctx().clone();
 
-    // Header: "Timeline" heading + ⚙ settings button + Export button (right-aligned)
-    let mut clear_export = false;
+    // Header: "Timeline" heading + ⚙ settings button + queue buttons (right-aligned)
     ui.horizontal(|ui| {
         ui.heading("Timeline");
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
             let v1_empty = state.timeline.tracks[0].clips.is_empty();
-            let is_running = state
-                .export
-                .as_ref()
-                .is_some_and(|h| matches!(*h.status.lock().unwrap(), state::ExportStatus::Running));
+            let any_running = state.export_queue.iter().any(|j| {
+                matches!(
+                    *j.status.lock().unwrap_or_else(|e| e.into_inner()),
+                    state::QueueJobStatus::Running
+                )
+            });
+            let has_pending = state.export_queue.iter().any(|j| {
+                matches!(
+                    *j.status.lock().unwrap_or_else(|e| e.into_inner()),
+                    state::QueueJobStatus::Pending
+                )
+            });
             if ui
-                .add_enabled(!v1_empty && !is_running, egui::Button::new("Export"))
+                .add_enabled(
+                    !state.export_queue.is_empty() && !any_running && has_pending,
+                    egui::Button::new("Render All"),
+                )
+                .clicked()
+            {
+                state.queue_rendering = true;
+            }
+            if ui
+                .add_enabled(!v1_empty, egui::Button::new("Add to Queue"))
                 .clicked()
                 && let Some(output_path) = rfd::FileDialog::new()
                     .add_filter("MP4", &["mp4"])
@@ -251,7 +267,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         None
                     },
                 };
-                state.export = Some(export::spawn_export(snapshot, output_path));
+                state
+                    .export_queue
+                    .push(export::QueueJob::new(snapshot, output_path));
             }
             ui.toggle_value(&mut state.show_export_settings, "⚙")
                 .on_hover_text("Export settings");
@@ -482,70 +500,104 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         .suffix(" LUFS"),
                 );
             });
+
+            // ── Queue list ─────────────────────────────────────────────────────
+            ui.separator();
+            ui.label("Queue");
+            let mut remove_idx: Option<usize> = None;
+            for (i, job) in state.export_queue.iter().enumerate() {
+                let status = job
+                    .status
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .clone();
+                let filename = job
+                    .output_path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_default();
+                ui.horizontal(|ui| {
+                    ui.label(
+                        egui::RichText::new(&filename)
+                            .text_style(egui::TextStyle::Monospace),
+                    );
+                    match &status {
+                        state::QueueJobStatus::Pending => {
+                            ui.weak("Pending");
+                            if ui.small_button("Remove").clicked() {
+                                remove_idx = Some(i);
+                            }
+                        }
+                        state::QueueJobStatus::Running => {
+                            let pct = f32::from_bits(
+                                job.progress
+                                    .load(std::sync::atomic::Ordering::Relaxed),
+                            );
+                            let fraction = (pct / 100.0).clamp(0.0, 1.0);
+                            let bar_text = if pct > 0.0 {
+                                format!("{:.0}%", pct)
+                            } else {
+                                "Encoding…".to_string()
+                            };
+                            ui.add(
+                                egui::ProgressBar::new(fraction)
+                                    .desired_width(120.0)
+                                    .text(bar_text),
+                            );
+                            if ui.small_button("Cancel").clicked() {
+                                job.cancel
+                                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                            }
+                        }
+                        state::QueueJobStatus::Done(_) => {
+                            ui.colored_label(egui::Color32::GREEN, "Done");
+                            if ui.small_button("✕").clicked() {
+                                remove_idx = Some(i);
+                            }
+                        }
+                        state::QueueJobStatus::Failed(msg) => {
+                            ui.colored_label(egui::Color32::RED, "Failed")
+                                .on_hover_text(msg.as_str());
+                            if ui.small_button("✕").clicked() {
+                                remove_idx = Some(i);
+                            }
+                        }
+                        state::QueueJobStatus::Cancelled => {
+                            ui.weak("Cancelled");
+                            if ui.small_button("✕").clicked() {
+                                remove_idx = Some(i);
+                            }
+                        }
+                    }
+                });
+            }
+            if let Some(i) = remove_idx {
+                state.export_queue.remove(i);
+            }
         });
 
-    // Export progress window (floating, centered) — shown while running.
-    // Done / Failed states remain as an inline status row below.
-    if let Some(handle) = &state.export {
-        let status = handle
-            .status
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone();
-        if matches!(status, state::ExportStatus::Running) {
-            let pct = f32::from_bits(handle.progress.load(std::sync::atomic::Ordering::Relaxed));
-            egui::Window::new("Exporting…")
-                .collapsible(false)
-                .resizable(false)
-                .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
-                .show(&ctx, |ui| {
-                    ui.set_min_width(300.0);
-                    let fraction = (pct / 100.0).clamp(0.0, 1.0);
-                    let bar = egui::ProgressBar::new(fraction).desired_width(300.0);
-                    let bar = if pct > 0.0 {
-                        bar.text(format!("{:.0}%", pct))
-                    } else {
-                        bar.text("Encoding…")
-                    };
-                    ui.add(bar);
-                });
-            // Keep the UI updating while the background task runs.
-            ctx.request_repaint_after(std::time::Duration::from_millis(200));
-        }
-    }
-
-    // Export completion / failure row
-    if let Some(handle) = &state.export {
-        let status = handle
-            .status
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone();
-        match status {
-            state::ExportStatus::Done(path) => {
-                ui.horizontal(|ui| {
-                    ui.colored_label(
-                        egui::Color32::GREEN,
-                        format!("Exported: {}", path.display()),
-                    );
-                    if ui.button("✕").clicked() {
-                        clear_export = true;
-                    }
-                });
+    // ── Export queue advancement ──────────────────────────────────────────────
+    // Each frame: when no job is running, start the next Pending one.
+    if state.queue_rendering {
+        let any_running = state.export_queue.iter().any(|j| {
+            matches!(
+                *j.status.lock().unwrap_or_else(|e| e.into_inner()),
+                state::QueueJobStatus::Running
+            )
+        });
+        if !any_running {
+            if let Some(job) = state.export_queue.iter_mut().find(|j| {
+                matches!(
+                    *j.status.lock().unwrap_or_else(|e| e.into_inner()),
+                    state::QueueJobStatus::Pending
+                )
+            }) {
+                export::spawn_queue_job(job);
+            } else {
+                state.queue_rendering = false;
             }
-            state::ExportStatus::Failed(msg) => {
-                ui.horizontal(|ui| {
-                    ui.colored_label(egui::Color32::RED, format!("Export failed: {msg}"));
-                    if ui.button("✕").clicked() {
-                        clear_export = true;
-                    }
-                });
-            }
-            state::ExportStatus::Running => {}
         }
-    }
-    if clear_export {
-        state.export = None;
+        ctx.request_repaint_after(std::time::Duration::from_millis(200));
     }
 
     // ── Timeline playback controls ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replaces the single-shot Export button with a queue-based system. Users add jobs to the queue (each capturing a snapshot of the current timeline and export settings), then trigger sequential rendering with Render All. Jobs run one at a time in the background; each shows individual progress and can be cancelled mid-render.

## Changes

- **`src/state.rs`**: Removed `ExportStatus`/`ExportHandle`; added `QueueJobStatus` (Pending / Running / Done / Failed / Cancelled) used by the queue
- **`src/export.rs`**: Replaced `spawn_export` with `QueueJob` struct and `spawn_queue_job`; added `cancel: Arc<AtomicBool>` to `build_and_render` — the render callback returns `false` to abort, cancellation is detected on error and the partial output file is deleted
- **`src/ui/timeline.rs`**: Timeline header now shows **Add to Queue** and **Render All** buttons; Export Settings (⚙) panel shows the queue list with per-job status, progress bar, and Cancel/Remove buttons; per-frame logic advances the queue automatically when a running job finishes

## Related Issues

Closes #105

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes