### PR TITLE
feat(project): save and load project state as JSON

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod export;
 mod gif;
 mod player;
 mod presets;
+mod project;
 mod proxy;
 mod sprite;
 mod state;
@@ -202,6 +203,7 @@ fn main() -> eframe::Result<()> {
 #[derive(Default)]
 struct AvioEditorApp {
     state: state::AppState,
+    project_warnings: Vec<String>,
 }
 
 impl eframe::App for AvioEditorApp {
@@ -216,10 +218,78 @@ impl eframe::App for AvioEditorApp {
         // Arrow key frame stepping (while paused).
         handle_frame_step(&self.state, ctx);
 
+        // Project keyboard shortcuts (Ctrl+S = save, Ctrl+O = open).
+        if !ctx.wants_keyboard_input() {
+            if ctx.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::S))
+                && let Some(path) = rfd::FileDialog::new()
+                    .add_filter("Avio Project", &["avioedit"])
+                    .set_file_name("project.avioedit")
+                    .save_file()
+            {
+                if let Err(e) = project::save_project(&self.state, &path) {
+                    self.project_warnings = vec![format!("Save failed: {e}")];
+                } else {
+                    self.project_warnings.clear();
+                }
+            }
+            if ctx.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::O))
+                && let Some(path) = rfd::FileDialog::new()
+                    .add_filter("Avio Project", &["avioedit"])
+                    .pick_file()
+            {
+                match project::load_project(&mut self.state, &path) {
+                    Ok(w) => self.project_warnings = w,
+                    Err(e) => self.project_warnings = vec![format!("Load failed: {e}")],
+                }
+            }
+        }
+
         // 1. Top menu bar (must come before all other panels)
         egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
             egui::MenuBar::new().ui(ui, |ui| {
-                ui.menu_button("File", |_ui| {});
+                ui.menu_button("File", |ui| {
+                    if ui.button("New Project").clicked() {
+                        if rfd::MessageDialog::new()
+                            .set_title("New Project")
+                            .set_description("Discard the current project and start fresh?")
+                            .set_buttons(rfd::MessageButtons::OkCancel)
+                            .show()
+                            == rfd::MessageDialogResult::Ok
+                        {
+                            self.state = state::AppState::default();
+                            self.project_warnings.clear();
+                        }
+                        ui.close();
+                    }
+                    if ui.button("Open Project…").on_hover_text("Ctrl+O").clicked() {
+                        if let Some(path) = rfd::FileDialog::new()
+                            .add_filter("Avio Project", &["avioedit"])
+                            .pick_file()
+                        {
+                            match project::load_project(&mut self.state, &path) {
+                                Ok(w) => self.project_warnings = w,
+                                Err(e) => {
+                                    self.project_warnings = vec![format!("Load failed: {e}")];
+                                }
+                            }
+                        }
+                        ui.close();
+                    }
+                    if ui.button("Save Project…").on_hover_text("Ctrl+S").clicked() {
+                        if let Some(path) = rfd::FileDialog::new()
+                            .add_filter("Avio Project", &["avioedit"])
+                            .set_file_name("project.avioedit")
+                            .save_file()
+                        {
+                            if let Err(e) = project::save_project(&self.state, &path) {
+                                self.project_warnings = vec![format!("Save failed: {e}")];
+                            } else {
+                                self.project_warnings.clear();
+                            }
+                        }
+                        ui.close();
+                    }
+                });
                 ui.menu_button("Edit", |ui| {
                     let can_undo = !self.state.undo_stack.is_empty();
                     let can_redo = !self.state.redo_stack.is_empty();
@@ -275,6 +345,21 @@ impl eframe::App for AvioEditorApp {
                 });
             });
         });
+
+        // Project load warnings banner (shown when one or more source files were missing).
+        if !self.project_warnings.is_empty() {
+            egui::TopBottomPanel::top("project_warnings").show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.colored_label(egui::Color32::YELLOW, "⚠");
+                    for w in &self.project_warnings {
+                        ui.label(w);
+                    }
+                    if ui.small_button("✕").clicked() {
+                        self.project_warnings.clear();
+                    }
+                });
+            });
+        }
 
         // 2. Bottom: Timeline (must come before SidePanel and CentralPanel)
         egui::TopBottomPanel::bottom("timeline")

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,0 +1,440 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::state::{
+    AppState, ExportFilterDraft, HAlign, ImportedClip, TimelineClip, TitleClip, Track, TrackKind,
+    VAlign,
+};
+
+// ── Serializable project structs ─────────────────────────────────────────────
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ProjectFile {
+    pub version: u32,
+    pub clips: Vec<ProjectClip>,
+    pub video_tracks: Vec<Vec<ProjectTimelineClip>>,
+    pub audio_clips: Vec<ProjectTimelineClip>,
+    pub title_clips: Vec<ProjectTitleClip>,
+    pub encoder_config: crate::presets::PresetFile,
+    pub export_filters: ProjectExportFilters,
+    pub loudness_normalize: bool,
+    pub loudness_target: f64,
+    pub export_in_secs: Option<f64>,
+    pub export_out_secs: Option<f64>,
+    pub export_range_enabled: bool,
+    pub timeline_loop_enabled: bool,
+    pub pixels_per_second: f32,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ProjectClip {
+    pub path: String,
+    pub in_point_secs: Option<f64>,
+    pub out_point_secs: Option<f64>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ProjectTimelineClip {
+    pub source_path: String,
+    pub start_on_track_secs: f64,
+    pub in_point_secs: Option<f64>,
+    pub out_point_secs: Option<f64>,
+    pub transition: Option<String>,
+    pub transition_duration_secs: f64,
+    pub gain_db: f32,
+    pub fade_in_secs: f64,
+    pub fade_out_secs: f64,
+    pub brightness: f32,
+    pub contrast: f32,
+    pub saturation: f32,
+    pub speed: f32,
+    pub opacity: f32,
+    pub blend_mode: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ProjectTitleClip {
+    pub start_on_track_secs: f64,
+    pub duration_secs: f64,
+    pub text: String,
+    pub font_size: u32,
+    pub color: [u8; 4],
+    pub h_align: String,
+    pub v_align: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ProjectExportFilters {
+    pub scale_enabled: bool,
+    pub output_width: u32,
+    pub output_height: u32,
+    pub colorbalance_enabled: bool,
+    pub brightness: f32,
+    pub contrast: f32,
+    pub saturation: f32,
+}
+
+// ── Enum conversion helpers ───────────────────────────────────────────────────
+
+fn blend_mode_to_str(m: avio::BlendMode) -> &'static str {
+    match m {
+        avio::BlendMode::Normal => "Normal",
+        avio::BlendMode::Multiply => "Multiply",
+        avio::BlendMode::Screen => "Screen",
+        avio::BlendMode::Overlay => "Overlay",
+        avio::BlendMode::SoftLight => "SoftLight",
+        avio::BlendMode::HardLight => "HardLight",
+        avio::BlendMode::ColorDodge => "ColorDodge",
+        avio::BlendMode::ColorBurn => "ColorBurn",
+        avio::BlendMode::Darken => "Darken",
+        avio::BlendMode::Lighten => "Lighten",
+        avio::BlendMode::Difference => "Difference",
+        avio::BlendMode::Exclusion => "Exclusion",
+        _ => "Normal",
+    }
+}
+
+fn blend_mode_from_str(s: &str) -> avio::BlendMode {
+    match s {
+        "Multiply" => avio::BlendMode::Multiply,
+        "Screen" => avio::BlendMode::Screen,
+        "Overlay" => avio::BlendMode::Overlay,
+        "SoftLight" => avio::BlendMode::SoftLight,
+        "HardLight" => avio::BlendMode::HardLight,
+        "ColorDodge" => avio::BlendMode::ColorDodge,
+        "ColorBurn" => avio::BlendMode::ColorBurn,
+        "Darken" => avio::BlendMode::Darken,
+        "Lighten" => avio::BlendMode::Lighten,
+        "Difference" => avio::BlendMode::Difference,
+        "Exclusion" => avio::BlendMode::Exclusion,
+        _ => avio::BlendMode::Normal,
+    }
+}
+
+fn xfade_from_str(s: &str) -> Option<avio::XfadeTransition> {
+    match s {
+        "dissolve" => Some(avio::XfadeTransition::Dissolve),
+        "fade" => Some(avio::XfadeTransition::Fade),
+        "wipeleft" => Some(avio::XfadeTransition::WipeLeft),
+        "wiperight" => Some(avio::XfadeTransition::WipeRight),
+        "wipeup" => Some(avio::XfadeTransition::WipeUp),
+        "wipedown" => Some(avio::XfadeTransition::WipeDown),
+        "slideleft" => Some(avio::XfadeTransition::SlideLeft),
+        "slideright" => Some(avio::XfadeTransition::SlideRight),
+        "slideup" => Some(avio::XfadeTransition::SlideUp),
+        "slidedown" => Some(avio::XfadeTransition::SlideDown),
+        "circleopen" => Some(avio::XfadeTransition::CircleOpen),
+        "circleclose" => Some(avio::XfadeTransition::CircleClose),
+        "fadegrays" => Some(avio::XfadeTransition::FadeGrays),
+        "pixelize" => Some(avio::XfadeTransition::Pixelize),
+        _ => None,
+    }
+}
+
+fn halign_to_str(a: HAlign) -> &'static str {
+    match a {
+        HAlign::Left => "Left",
+        HAlign::Centre => "Centre",
+        HAlign::Right => "Right",
+    }
+}
+
+fn halign_from_str(s: &str) -> HAlign {
+    match s {
+        "Left" => HAlign::Left,
+        "Right" => HAlign::Right,
+        _ => HAlign::Centre,
+    }
+}
+
+fn valign_to_str(a: VAlign) -> &'static str {
+    match a {
+        VAlign::Top => "Top",
+        VAlign::Middle => "Middle",
+        VAlign::Bottom => "Bottom",
+    }
+}
+
+fn valign_from_str(s: &str) -> VAlign {
+    match s {
+        "Top" => VAlign::Top,
+        "Bottom" => VAlign::Bottom,
+        _ => VAlign::Middle,
+    }
+}
+
+// ── TimelineClip conversion ───────────────────────────────────────────────────
+
+fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> ProjectTimelineClip {
+    let source_path = clips
+        .get(tc.source_index)
+        .map(|c| c.path.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    ProjectTimelineClip {
+        source_path,
+        start_on_track_secs: tc.start_on_track.as_secs_f64(),
+        in_point_secs: tc.in_point.map(|d| d.as_secs_f64()),
+        out_point_secs: tc.out_point.map(|d| d.as_secs_f64()),
+        transition: tc.transition.map(|t| t.as_str().to_string()),
+        transition_duration_secs: tc.transition_duration.as_secs_f64(),
+        gain_db: tc.gain_db,
+        fade_in_secs: tc.fade_in.as_secs_f64(),
+        fade_out_secs: tc.fade_out.as_secs_f64(),
+        brightness: tc.brightness,
+        contrast: tc.contrast,
+        saturation: tc.saturation,
+        speed: tc.speed,
+        opacity: tc.opacity,
+        blend_mode: blend_mode_to_str(tc.blend_mode).to_string(),
+    }
+}
+
+fn project_to_timeline_clip(
+    ptc: &ProjectTimelineClip,
+    path_map: &HashMap<String, usize>,
+    warnings: &mut Vec<String>,
+) -> Option<TimelineClip> {
+    let source_index = match path_map.get(&ptc.source_path) {
+        Some(&idx) => idx,
+        None => {
+            warnings.push(format!("Missing source file: {}", ptc.source_path));
+            return None;
+        }
+    };
+    Some(TimelineClip {
+        source_index,
+        start_on_track: Duration::from_secs_f64(ptc.start_on_track_secs),
+        in_point: ptc.in_point_secs.map(Duration::from_secs_f64),
+        out_point: ptc.out_point_secs.map(Duration::from_secs_f64),
+        transition: ptc.transition.as_deref().and_then(xfade_from_str),
+        transition_duration: Duration::from_secs_f64(ptc.transition_duration_secs),
+        gain_db: ptc.gain_db,
+        fade_in: Duration::from_secs_f64(ptc.fade_in_secs),
+        fade_out: Duration::from_secs_f64(ptc.fade_out_secs),
+        brightness: ptc.brightness,
+        contrast: ptc.contrast,
+        saturation: ptc.saturation,
+        speed: ptc.speed,
+        opacity: ptc.opacity,
+        blend_mode: blend_mode_from_str(&ptc.blend_mode),
+    })
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Serializes the current editing session to a `.avioedit` JSON file.
+pub fn save_project(state: &AppState, path: &Path) -> Result<(), String> {
+    let audio_start = state.timeline.audio_track_start();
+
+    let clips: Vec<ProjectClip> = state
+        .clips
+        .iter()
+        .map(|c| ProjectClip {
+            path: c.path.to_string_lossy().into_owned(),
+            in_point_secs: c.in_point.map(|d| d.as_secs_f64()),
+            out_point_secs: c.out_point.map(|d| d.as_secs_f64()),
+        })
+        .collect();
+
+    let video_tracks: Vec<Vec<ProjectTimelineClip>> = (0..audio_start)
+        .map(|ti| {
+            state.timeline.tracks[ti]
+                .clips
+                .iter()
+                .map(|tc| timeline_clip_to_project(tc, &state.clips))
+                .collect()
+        })
+        .collect();
+
+    let audio_clips: Vec<ProjectTimelineClip> = if audio_start < state.timeline.tracks.len() {
+        state.timeline.tracks[audio_start]
+            .clips
+            .iter()
+            .map(|tc| timeline_clip_to_project(tc, &state.clips))
+            .collect()
+    } else {
+        vec![]
+    };
+
+    let title_clips: Vec<ProjectTitleClip> = state
+        .timeline
+        .title_clips
+        .iter()
+        .map(|tc| ProjectTitleClip {
+            start_on_track_secs: tc.start_on_track.as_secs_f64(),
+            duration_secs: tc.duration.as_secs_f64(),
+            text: tc.text.clone(),
+            font_size: tc.font_size,
+            color: tc.color,
+            h_align: halign_to_str(tc.h_align).to_string(),
+            v_align: valign_to_str(tc.v_align).to_string(),
+        })
+        .collect();
+
+    let ef = &state.export_filters;
+    let project = ProjectFile {
+        version: 1,
+        clips,
+        video_tracks,
+        audio_clips,
+        title_clips,
+        encoder_config: crate::presets::PresetFile::from_draft(&state.encoder_config),
+        export_filters: ProjectExportFilters {
+            scale_enabled: ef.scale_enabled,
+            output_width: ef.output_width,
+            output_height: ef.output_height,
+            colorbalance_enabled: ef.colorbalance_enabled,
+            brightness: ef.brightness,
+            contrast: ef.contrast,
+            saturation: ef.saturation,
+        },
+        loudness_normalize: state.loudness_normalize,
+        loudness_target: state.loudness_target,
+        export_in_secs: state.export_in.map(|d| d.as_secs_f64()),
+        export_out_secs: state.export_out.map(|d| d.as_secs_f64()),
+        export_range_enabled: state.export_range_enabled,
+        timeline_loop_enabled: state.timeline_loop_enabled,
+        pixels_per_second: state.timeline.pixels_per_second,
+    };
+
+    let file = std::fs::File::create(path).map_err(|e| e.to_string())?;
+    serde_json::to_writer_pretty(file, &project).map_err(|e| e.to_string())
+}
+
+/// Deserializes a `.avioedit` file and restores the editing session.
+///
+/// Returns `Ok(warnings)` where each warning describes a missing source file.
+/// Missing files are skipped; all other state is restored.
+pub fn load_project(state: &mut AppState, path: &Path) -> Result<Vec<String>, String> {
+    let file = std::fs::File::open(path).map_err(|e| e.to_string())?;
+    let project: ProjectFile =
+        serde_json::from_reader(file).map_err(|e| format!("Parse error: {e}"))?;
+
+    // Reset to a clean slate so channels, player handles, etc. are fresh.
+    *state = AppState::default();
+
+    let mut warnings: Vec<String> = Vec::new();
+
+    // Re-probe each source clip.
+    for pc in &project.clips {
+        let p = PathBuf::from(&pc.path);
+        match avio::open(&p) {
+            Ok(info) => {
+                state.clips.push(ImportedClip {
+                    path: p,
+                    info,
+                    thumbnail: None,
+                    proxy_path: None,
+                    scenes: Vec::new(),
+                    silence_regions: Vec::new(),
+                    waveform: Vec::new(),
+                    sprite_sheet: None,
+                    in_point: pc.in_point_secs.map(Duration::from_secs_f64),
+                    out_point: pc.out_point_secs.map(Duration::from_secs_f64),
+                });
+            }
+            Err(e) => {
+                warnings.push(format!("Cannot open \"{}\": {e} — clip skipped", pc.path));
+            }
+        }
+    }
+
+    // Build a path → clip_index map for resolving timeline clips.
+    let path_map: HashMap<String, usize> = state
+        .clips
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (c.path.to_string_lossy().into_owned(), i))
+        .collect();
+
+    // Reconstruct video tracks.
+    let mut video_tracks: Vec<Track> = project
+        .video_tracks
+        .iter()
+        .map(|track_clips| {
+            let clips = track_clips
+                .iter()
+                .filter_map(|ptc| project_to_timeline_clip(ptc, &path_map, &mut warnings))
+                .collect();
+            Track {
+                kind: TrackKind::Video,
+                clips,
+                muted: false,
+                soloed: false,
+            }
+        })
+        .collect();
+
+    // Ensure at least 2 video tracks (V1, V2) to match the default layout.
+    while video_tracks.len() < 2 {
+        video_tracks.push(Track {
+            kind: TrackKind::Video,
+            clips: Vec::new(),
+            muted: false,
+            soloed: false,
+        });
+    }
+
+    // Reconstruct A1 audio track.
+    let a1_clips = project
+        .audio_clips
+        .iter()
+        .filter_map(|ptc| project_to_timeline_clip(ptc, &path_map, &mut warnings))
+        .collect();
+    let a1_track = Track {
+        kind: TrackKind::Audio,
+        clips: a1_clips,
+        muted: false,
+        soloed: false,
+    };
+
+    state.timeline.tracks = {
+        let mut t = video_tracks;
+        t.push(a1_track);
+        t
+    };
+
+    // Restore title clips.
+    state.timeline.title_clips = project
+        .title_clips
+        .iter()
+        .map(|ptc| TitleClip {
+            start_on_track: Duration::from_secs_f64(ptc.start_on_track_secs),
+            duration: Duration::from_secs_f64(ptc.duration_secs),
+            text: ptc.text.clone(),
+            font_size: ptc.font_size,
+            color: ptc.color,
+            h_align: halign_from_str(&ptc.h_align),
+            v_align: valign_from_str(&ptc.v_align),
+        })
+        .collect();
+
+    // Restore export settings.
+    state.encoder_config = project.encoder_config.to_draft();
+    let ef = &project.export_filters;
+    state.export_filters = ExportFilterDraft {
+        scale_enabled: ef.scale_enabled,
+        output_width: ef.output_width,
+        output_height: ef.output_height,
+        colorbalance_enabled: ef.colorbalance_enabled,
+        brightness: ef.brightness,
+        contrast: ef.contrast,
+        saturation: ef.saturation,
+    };
+    state.loudness_normalize = project.loudness_normalize;
+    state.loudness_target = project.loudness_target;
+    state.export_in = project.export_in_secs.map(Duration::from_secs_f64);
+    state.export_out = project.export_out_secs.map(Duration::from_secs_f64);
+    state.export_range_enabled = project.export_range_enabled;
+    state.timeline_loop_enabled = project.timeline_loop_enabled;
+    state.timeline.pixels_per_second = project.pixels_per_second;
+
+    // Regenerate clip browser thumbnails, sprite sheets, scenes, waveforms, and
+    // silence regions — these are not serialized and must be rebuilt from source.
+    for i in 0..state.clips.len() {
+        crate::ui::clip_browser::spawn_clip_analysis(state, i);
+    }
+
+    Ok(warnings)
+}

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -3,6 +3,56 @@ use std::time::Duration;
 
 use crate::{analysis, gif, player, proxy, sprite, state, thumbnail, trim};
 
+/// Spawns the background analysis jobs (thumbnail, scene detection, sprite sheet,
+/// silence detection, waveform) for the clip at `clip_idx`. Used both when a clip
+/// is imported and when a project is loaded (so previews are regenerated).
+///
+/// The jobs send their results through the channels on `state`; the render loop's
+/// `drain_background_jobs` applies them by `clip_idx` (scenes/silence/waveform/sprite)
+/// or by `path` (thumbnail).
+pub fn spawn_clip_analysis(state: &state::AppState, clip_idx: usize) {
+    let Some(clip) = state.clips.get(clip_idx) else {
+        return;
+    };
+    let path = clip.path.clone();
+    let has_video = clip.info.primary_video().is_some();
+
+    if has_video {
+        let tx = state.thumbnail_tx.clone();
+        let path_for_task = path.clone();
+        tokio::task::spawn_blocking(move || {
+            if let Some((w, h, rgb)) = thumbnail::select_best_thumbnail(&path_for_task) {
+                let _ = tx.send((path_for_task, w, h, rgb));
+            }
+        });
+        let scene_tx = state.scene_tx.clone();
+        let path_for_scene = path.clone();
+        tokio::task::spawn_blocking(move || {
+            let scenes = analysis::detect_scenes(&path_for_scene);
+            let _ = scene_tx.send((clip_idx, scenes));
+        });
+        let sprite_tx = state.sprite_tx.clone();
+        let path_for_sprite = path.clone();
+        tokio::task::spawn_blocking(move || {
+            if let Some((w, h, rgba)) = sprite::generate_sprite_sheet(&path_for_sprite, 10, 5) {
+                let _ = sprite_tx.send((clip_idx, w, h, rgba));
+            }
+        });
+    }
+    let silence_tx = state.silence_tx.clone();
+    let path_for_silence = path.clone();
+    tokio::task::spawn_blocking(move || {
+        let regions = analysis::detect_silence(&path_for_silence);
+        let _ = silence_tx.send((clip_idx, regions));
+    });
+    let waveform_tx = state.waveform_tx.clone();
+    let path_for_waveform = path.clone();
+    tokio::task::spawn_blocking(move || {
+        let waveform = analysis::extract_waveform(&path_for_waveform, 512);
+        let _ = waveform_tx.send((clip_idx, waveform));
+    });
+}
+
 fn show_text_tab(state: &mut state::AppState, ui: &mut egui::Ui) {
     // ── "+" button to create a new preset ────────────────────────────────────
     ui.horizontal(|ui| {
@@ -249,7 +299,6 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
         for path in paths {
             match avio::open(&path) {
                 Ok(info) => {
-                    let has_video = info.primary_video().is_some();
                     state.clips.push(state::ImportedClip {
                         path: path.clone(),
                         info,
@@ -263,44 +312,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                         out_point: None,
                     });
                     let clip_idx = state.clips.len() - 1;
-                    if has_video {
-                        let tx = state.thumbnail_tx.clone();
-                        let path_for_task = path.clone();
-                        tokio::task::spawn_blocking(move || {
-                            if let Some((w, h, rgb)) =
-                                thumbnail::select_best_thumbnail(&path_for_task)
-                            {
-                                let _ = tx.send((path_for_task, w, h, rgb));
-                            }
-                        });
-                        let scene_tx = state.scene_tx.clone();
-                        let path_for_scene = path.clone();
-                        tokio::task::spawn_blocking(move || {
-                            let scenes = analysis::detect_scenes(&path_for_scene);
-                            let _ = scene_tx.send((clip_idx, scenes));
-                        });
-                        let sprite_tx = state.sprite_tx.clone();
-                        let path_for_sprite = path.clone();
-                        tokio::task::spawn_blocking(move || {
-                            if let Some((w, h, rgba)) =
-                                sprite::generate_sprite_sheet(&path_for_sprite, 10, 5)
-                            {
-                                let _ = sprite_tx.send((clip_idx, w, h, rgba));
-                            }
-                        });
-                    }
-                    let silence_tx = state.silence_tx.clone();
-                    let path_for_silence = path.clone();
-                    tokio::task::spawn_blocking(move || {
-                        let regions = analysis::detect_silence(&path_for_silence);
-                        let _ = silence_tx.send((clip_idx, regions));
-                    });
-                    let waveform_tx = state.waveform_tx.clone();
-                    let path_for_waveform = path.clone();
-                    tokio::task::spawn_blocking(move || {
-                        let waveform = analysis::extract_waveform(&path_for_waveform, 512);
-                        let _ = waveform_tx.send((clip_idx, waveform));
-                    });
+                    spawn_clip_analysis(state, clip_idx);
                 }
                 Err(e) => log::warn!("probe failed for {path:?}: {e}"),
             }


### PR DESCRIPTION
## Summary

Implements File → Save Project (Ctrl+S) and File → Open Project (Ctrl+O) so the full editing session can be persisted to and restored from a `.avioedit` JSON file. Captures source clips, timeline layout, title clips, export settings, and I/O markers. File → New Project clears the session after confirmation.

## Changes

- **`src/project.rs`** (new): `ProjectFile` and child structs with serde derives; `save_project` serializes `AppState` to pretty JSON; `load_project` re-probes each source via `avio::open`, rebuilds the timeline, and returns warnings for missing files (skipped, not fatal). avio enums without serde support (`XfadeTransition`, `BlendMode`, `HAlign`, `VAlign`) are converted to/from strings; `Duration` is stored as f64 seconds; encoder config reuses the existing `PresetFile`.
- **`src/main.rs`**: added `mod project`; `project_warnings` field on `AvioEditorApp`; Ctrl+S / Ctrl+O global shortcuts; populated File menu (New / Open / Save) with a confirmation dialog on New; yellow warning banner for missing-source-file reports.
- **`src/ui/clip_browser.rs`**: extracted import-time background jobs into a reusable `spawn_clip_analysis` function and call it after load so thumbnails, sprite sheets, scene markers, waveforms, and silence regions are regenerated (these are derived data, not serialized).

## Related Issues

Closes #106

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes