### PR TITLE
feat(export): use clip proxies for export via avio Clip::proxy

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -33,6 +33,9 @@ pub struct ExportClip {
     pub opacity: f32,
     /// Per-clip blend mode. Forwarded to `Clip::with_blend_mode`.
     pub blend_mode: avio::BlendMode,
+    /// Optional proxy file to decode from. When `Some`, forwarded to `Clip::proxy`
+    /// so avio renders from the proxy and scales up to the original resolution.
+    pub proxy_path: Option<PathBuf>,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -122,6 +125,10 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
         .into_iter()
         .map(|c| {
             let clip = avio::Clip::new(&c.path).offset(c.start_on_track);
+            let clip = match &c.proxy_path {
+                Some(p) => clip.proxy(p),
+                None => clip,
+            };
             let clip = match (c.in_point, c.out_point) {
                 (Some(in_pt), Some(out_pt)) => clip.trim(in_pt, out_pt),
                 _ => clip,

--- a/src/state.rs
+++ b/src/state.rs
@@ -150,6 +150,9 @@ pub struct AppState {
     pub export_out: Option<std::time::Duration>,
     /// When true, only the [export_in, export_out) range is rendered on export.
     pub export_range_enabled: bool,
+    /// When true, export decodes from each clip's proxy (when available) and
+    /// scales up to the original resolution — faster test renders via `Clip::proxy`.
+    pub export_use_proxies: bool,
     /// Index into `TimelineState::title_clips` of the currently selected title clip.
     pub selected_title_clip: Option<usize>,
     /// Active tab in the clip browser left panel.
@@ -235,6 +238,7 @@ impl Default for AppState {
             export_in: None,
             export_out: None,
             export_range_enabled: false,
+            export_use_proxies: false,
             selected_title_clip: None,
             browser_tab: BrowserTab::Media,
             text_presets: Vec::new(),

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -211,6 +211,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     .save_file()
             {
                 let clips = &state.clips;
+                let use_proxies = state.export_use_proxies;
                 let make_clip = |tc: &state::TimelineClip| {
                     let src = &clips[tc.source_index];
                     export::ExportClip {
@@ -231,6 +232,11 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         speed: tc.speed,
                         opacity: tc.opacity,
                         blend_mode: tc.blend_mode,
+                        proxy_path: if use_proxies {
+                            src.proxy_path.clone()
+                        } else {
+                            None
+                        },
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -410,6 +416,15 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     }
                 });
             }
+
+            ui.checkbox(
+                &mut state.export_use_proxies,
+                "Use proxies for export (faster, lower quality)",
+            )
+            .on_hover_text(
+                "Decode from each clip's proxy (when generated) and scale up to the \
+                 original resolution. Uses avio's Clip::proxy API.",
+            );
 
             ui.separator();
 


### PR DESCRIPTION
## Summary

Adds an option to export from each clip's low-resolution proxy instead of the original source, producing full-resolution output via avio's new `Clip::proxy` API. This enables fast test renders without sacrificing the output resolution. Closes the long-standing proxy-aware-path gap (#11), which required a new avio API.

## Changes

- **`src/export.rs`**: `ExportClip` gains a `proxy_path: Option<PathBuf>`; `clips_to_avio` calls `Clip::proxy()` when it is set, so avio decodes from the proxy and scales up to the original resolution.
- **`src/state.rs`**: added an `export_use_proxies` toggle on `AppState`.
- **`src/ui/timeline.rs`**: "Use proxies for export" checkbox in Export Settings; when enabled, each clip's `ImportedClip::proxy_path` is forwarded into its `ExportClip`.

Depends on avio changes (filed as gap reports in `docs/`): the new `Clip::proxy()` / `VideoLayer::proxy` / `ProxySource` API, plus two proxy-generation bug fixes surfaced during verification (video-only filter steps leaking into the audio graph, and an audio-graph use-after-free crash).

## Related Issues

Closes #11

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes