### PR TITLE
fix(timeline): drop dragged clip onto the correct track

### DIFF
--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -1465,7 +1465,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     let is_tl_drag_hover = active_drag.is_some()
                         && ui.input(|i| {
                             i.pointer.latest_pos().is_some_and(|ptr| {
-                                let y_off = ptr.y - ruler_rect.bottom();
+                                let y_off = ptr.y - t1_lane_rect.bottom();
                                 ((y_off / TRACK_HEIGHT).floor() as isize) == track_idx as isize
                             })
                         });
@@ -2103,7 +2103,10 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                         && drag.src_clip == clip_i
                                     {
                                         if let Some(ptr) = ui.input(|i| i.pointer.latest_pos()) {
-                                            let y_off = ptr.y - ruler_rect.bottom();
+                                            // Track lanes start below the T1 title lane, not at
+                                            // the ruler — offset by the T1 lane so the drop maps
+                                            // to the correct track.
+                                            let y_off = ptr.y - t1_lane_rect.bottom();
                                             let dst_track = ((y_off / TRACK_HEIGHT).floor()
                                                 as isize)
                                                 .clamp(0, tracks_count as isize - 1)
@@ -2327,7 +2330,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         })
                         .unwrap_or(1.0);
 
-                    let tracks_top = ruler_rect.bottom();
+                    // Track lanes start below the T1 title lane (see drop handler).
+                    let tracks_top = t1_lane_rect.bottom();
                     let y_off = ptr.y - tracks_top;
                     let dst_ti = ((y_off / TRACK_HEIGHT).floor() as isize)
                         .clamp(0, tracks_count as isize - 1)
@@ -2434,8 +2438,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
 
             // ── Playhead ────────────────────────────────────────────────────────
             let playhead_x = timeline_left + state.timeline_playhead_secs as f32 * pps;
+            // Span the ruler, the T1 title lane, and every track lane below it.
             let tracks_bottom =
-                ruler_rect.bottom() + TRACK_HEIGHT * state.timeline.tracks.len() as f32;
+                t1_lane_rect.bottom() + TRACK_HEIGHT * state.timeline.tracks.len() as f32;
             let playhead_color = egui::Color32::from_rgb(220, 60, 60);
             ui.painter().vline(
                 playhead_x,


### PR DESCRIPTION
## Summary

Fixes a regression where dragging an existing clip within the timeline dropped it one track lower than the pointer (e.g. a clip on V1 released in place landed on A1). The track-index math did not account for the T1 title lane inserted between the ruler and the track lanes.

## Changes

- **Root cause**: the T1 title lane (height `TRACK_HEIGHT`, added in #103) sits between the ruler and the track lanes, but the timeline-internal drag computed the destination track from `ruler_rect.bottom()`, ignoring the T1 lane — offsetting the pointer-Y → track-index mapping by one lane. Browser-to-timeline drops were unaffected because they use egui's per-lane DnD hit-testing.
- **Fix** (`src/ui/timeline.rs`): use `t1_lane_rect.bottom()` instead of `ruler_rect.bottom()` as the track-lane origin in:
  - the drop handler (`dst_track`),
  - the drag-hover lane highlight,
  - the ghost-clip rendering position,
  - the playhead line extent (which was also one lane short at the bottom).

## Related Issues

Fixes #129

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes