### PR TITLE
feat(filter): per-clip 3D LUT (.cube) with preview and export

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -36,6 +36,9 @@ pub struct ExportClip {
     /// Optional proxy file to decode from. When `Some`, forwarded to `Clip::proxy`
     /// so avio renders from the proxy and scales up to the original resolution.
     pub proxy_path: Option<PathBuf>,
+    /// Optional 3D LUT (.cube) path. When `Some`, attached via
+    /// `Clip::with_video_effect(FilterStep::Lut3d)`.
+    pub lut_path: Option<PathBuf>,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -163,6 +166,13 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
                 clip.with_color_correction(c.brightness, c.contrast, c.saturation)
             } else {
                 clip
+            };
+            // 3D LUT applied after colour correction (correct exposure, then look).
+            let clip = match &c.lut_path {
+                Some(p) => clip.with_video_effect(avio::FilterStep::Lut3d {
+                    path: p.to_string_lossy().into_owned(),
+                }),
+                None => clip,
             };
             #[allow(clippy::float_cmp)]
             let clip = if c.opacity != 1.0 {

--- a/src/lut.rs
+++ b/src/lut.rs
@@ -1,0 +1,114 @@
+//! Minimal `.cube` 3D LUT parser and software application for the timeline preview.
+//!
+//! Export applies the LUT via avio (`FilterStep::Lut3d`); this module mirrors that
+//! look in the software preview path so the monitor matches the rendered output.
+
+use std::path::Path;
+
+/// A parsed 3D LUT. `data` holds `size³` RGB entries with red varying fastest,
+/// then green, then blue (the `.cube` ordering): `idx = r + g*size + b*size*size`.
+pub struct Lut3d {
+    size: usize,
+    data: Vec<[f32; 3]>,
+}
+
+impl Lut3d {
+    /// Parses a `.cube` file. Only 3D LUTs with the default `0..1` domain are
+    /// supported; `LUT_1D_SIZE`, `TITLE`, `DOMAIN_*`, and comments are tolerated.
+    pub fn parse(path: &Path) -> Result<Self, String> {
+        let text = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+        let mut size = 0usize;
+        let mut data: Vec<[f32; 3]> = Vec::new();
+
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            if let Some(rest) = line.strip_prefix("LUT_3D_SIZE") {
+                size = rest
+                    .trim()
+                    .parse()
+                    .map_err(|_| "invalid LUT_3D_SIZE".to_string())?;
+                continue;
+            }
+            if line.starts_with("LUT_1D_SIZE") {
+                return Err("1D LUTs are not supported".to_string());
+            }
+            if line.starts_with("TITLE") || line.starts_with("DOMAIN_") {
+                continue;
+            }
+            // Data line: three floats.
+            let mut it = line.split_whitespace();
+            if let (Some(r), Some(g), Some(b)) = (it.next(), it.next(), it.next())
+                && let (Ok(r), Ok(g), Ok(b)) =
+                    (r.parse::<f32>(), g.parse::<f32>(), b.parse::<f32>())
+            {
+                data.push([r, g, b]);
+            }
+        }
+
+        if size < 2 {
+            return Err("missing or too-small LUT_3D_SIZE".to_string());
+        }
+        let expected = size * size * size;
+        if data.len() != expected {
+            return Err(format!(
+                "LUT entry count {} does not match LUT_3D_SIZE {size} (expected {expected})",
+                data.len()
+            ));
+        }
+        Ok(Self { size, data })
+    }
+
+    /// Trilinearly samples the LUT for a normalised RGB input in `0..1`.
+    fn sample(&self, r: f32, g: f32, b: f32) -> [f32; 3] {
+        let n = self.size;
+        let max = (n - 1) as f32;
+        let fr = r.clamp(0.0, 1.0) * max;
+        let fg = g.clamp(0.0, 1.0) * max;
+        let fb = b.clamp(0.0, 1.0) * max;
+        let (r0, g0, b0) = (
+            fr.floor() as usize,
+            fg.floor() as usize,
+            fb.floor() as usize,
+        );
+        let (r1, g1, b1) = (
+            (r0 + 1).min(n - 1),
+            (g0 + 1).min(n - 1),
+            (b0 + 1).min(n - 1),
+        );
+        let (dr, dg, db) = (fr - r0 as f32, fg - g0 as f32, fb - b0 as f32);
+
+        let at = |ri: usize, gi: usize, bi: usize| self.data[ri + gi * n + bi * n * n];
+        let lerp = |a: [f32; 3], c: [f32; 3], t: f32| {
+            [
+                a[0] + (c[0] - a[0]) * t,
+                a[1] + (c[1] - a[1]) * t,
+                a[2] + (c[2] - a[2]) * t,
+            ]
+        };
+
+        // Interpolate along red, then green, then blue.
+        let c00 = lerp(at(r0, g0, b0), at(r1, g0, b0), dr);
+        let c10 = lerp(at(r0, g1, b0), at(r1, g1, b0), dr);
+        let c01 = lerp(at(r0, g0, b1), at(r1, g0, b1), dr);
+        let c11 = lerp(at(r0, g1, b1), at(r1, g1, b1), dr);
+        let c0 = lerp(c00, c10, dg);
+        let c1 = lerp(c01, c11, dg);
+        lerp(c0, c1, db)
+    }
+
+    /// Applies the LUT in place to packed RGBA pixel data (alpha untouched).
+    pub fn apply_rgba(&self, data: &mut [u8]) {
+        for chunk in data.chunks_exact_mut(4) {
+            let r = chunk[0] as f32 / 255.0;
+            let g = chunk[1] as f32 / 255.0;
+            let b = chunk[2] as f32 / 255.0;
+            let [or, og, ob] = self.sample(r, g, b);
+            chunk[0] = (or.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            chunk[1] = (og.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            chunk[2] = (ob.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod analysis;
 mod export;
 mod gif;
+mod lut;
 mod player;
 mod presets;
 mod project;

--- a/src/project.rs
+++ b/src/project.rs
@@ -51,6 +51,8 @@ pub struct ProjectTimelineClip {
     pub speed: f32,
     pub opacity: f32,
     pub blend_mode: String,
+    #[serde(default)]
+    pub lut_path: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -187,6 +189,10 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         speed: tc.speed,
         opacity: tc.opacity,
         blend_mode: blend_mode_to_str(tc.blend_mode).to_string(),
+        lut_path: tc
+            .lut_path
+            .as_ref()
+            .map(|p| p.to_string_lossy().into_owned()),
     }
 }
 
@@ -218,6 +224,7 @@ fn project_to_timeline_clip(
         speed: ptc.speed,
         opacity: ptc.opacity,
         blend_mode: blend_mode_from_str(&ptc.blend_mode),
+        lut_path: ptc.lut_path.as_ref().map(PathBuf::from),
     })
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex, mpsc};
@@ -161,6 +162,9 @@ pub struct AppState {
     pub text_presets: Vec<TextClipPreset>,
     /// Index into `text_presets` of the currently selected preset in the browser.
     pub selected_text_preset: Option<usize>,
+    /// Parsed-LUT cache for the software preview, keyed by `.cube` path.
+    /// `None` = parse failed (cached so it is not retried every frame).
+    pub lut_cache: HashMap<PathBuf, Option<crate::lut::Lut3d>>,
 }
 
 impl Default for AppState {
@@ -243,6 +247,7 @@ impl Default for AppState {
             browser_tab: BrowserTab::Media,
             text_presets: Vec::new(),
             selected_text_preset: None,
+            lut_cache: HashMap::new(),
         }
     }
 }
@@ -525,6 +530,10 @@ pub struct TimelineClip {
     /// overlay tracks — `FilterGraphBuilder::blend()` is not wired into the `Clip` pipeline
     /// (docs/issue43.md).
     pub blend_mode: avio::BlendMode,
+    /// Per-clip 3D LUT (.cube) file path. `None` = no LUT.
+    /// Applied on export via `avio::Clip::with_video_effect(FilterStep::Lut3d)`.
+    /// Export-only: not shown in the monitor preview (v1).
+    pub lut_path: Option<PathBuf>,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -654,6 +654,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 speed: 1.0,
                 opacity: 1.0,
                 blend_mode: avio::BlendMode::Normal,
+                lut_path: None,
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/drain.rs
+++ b/src/ui/drain.rs
@@ -193,27 +193,24 @@ fn drain_frame(state: &mut AppState, ctx: &egui::Context) {
 
             // Apply per-clip color correction for preview.
             // Find the active V1 clip at the current frame PTS and apply its
-            // brightness/contrast/saturation as a software RGBA transform.
+            // brightness/contrast/saturation (and LUT) as software RGBA transforms.
             let pts = frame.pts;
-            let correction = state
-                .timeline
-                .tracks
-                .first()
-                .and_then(|track| {
-                    track.clips.iter().find(|tc| {
-                        let start = tc.start_on_track;
-                        let eff_dur = match (tc.in_point, tc.out_point) {
-                            (Some(i), Some(o)) if o > i => o - i,
-                            _ => state
-                                .clips
-                                .get(tc.source_index)
-                                .map(|c| c.info.duration())
-                                .unwrap_or(std::time::Duration::ZERO),
-                        };
-                        pts >= start && pts < start + eff_dur
-                    })
+            let active = state.timeline.tracks.first().and_then(|track| {
+                track.clips.iter().find(|tc| {
+                    let start = tc.start_on_track;
+                    let eff_dur = match (tc.in_point, tc.out_point) {
+                        (Some(i), Some(o)) if o > i => o - i,
+                        _ => state
+                            .clips
+                            .get(tc.source_index)
+                            .map(|c| c.info.duration())
+                            .unwrap_or(std::time::Duration::ZERO),
+                    };
+                    pts >= start && pts < start + eff_dur
                 })
-                .map(|tc| (tc.brightness, tc.contrast, tc.saturation));
+            });
+            let correction = active.map(|tc| (tc.brightness, tc.contrast, tc.saturation));
+            let lut_path = active.and_then(|tc| tc.lut_path.clone());
 
             let is_rgba = frame.data.len() == frame.width as usize * frame.height as usize * 4;
             #[allow(clippy::float_cmp)]
@@ -222,6 +219,21 @@ fn drain_frame(state: &mut AppState, ctx: &egui::Context) {
                 && (b != 0.0 || c != 1.0 || s != 1.0)
             {
                 apply_eq_rgba(&mut frame.data, b, c, s);
+            }
+            // LUT applied after colour correction (matches the export order).
+            if is_rgba && let Some(path) = lut_path {
+                let lut = state.lut_cache.entry(path.clone()).or_insert_with(|| {
+                    match crate::lut::Lut3d::parse(&path) {
+                        Ok(l) => Some(l),
+                        Err(e) => {
+                            log::warn!("LUT preview parse failed for {}: {e}", path.display());
+                            None
+                        }
+                    }
+                });
+                if let Some(lut) = lut {
+                    lut.apply_rgba(&mut frame.data);
+                }
             }
         } else {
             state.current_pts = Some(frame.pts);

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -237,6 +237,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         } else {
                             None
                         },
+                        lut_path: tc.lut_path.clone(),
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -932,7 +933,28 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             clip.saturation = 1.0;
                         }
                     });
-                    ui.weak("Color correction applied on Export only (ff-preview limitation — docs/issue40.md). Speed applies to preview and export; audio pitch changes proportionally in preview (no pitch correction — docs/issue42.md). Opacity applies to preview (V1 fades to black; V2 fades over V1). Blend mode applies to export only (docs/issue43.md).");
+                    // 3D LUT (.cube) — export-only via avio Clip effect chain.
+                    ui.horizontal(|ui| {
+                        ui.label("LUT (.cube)");
+                        if ui.button("Load…").clicked()
+                            && let Some(path) = rfd::FileDialog::new()
+                                .add_filter("Cube LUT", &["cube"])
+                                .pick_file()
+                        {
+                            clip.lut_path = Some(path);
+                        }
+                        if clip.lut_path.is_some() && ui.button("Clear").clicked() {
+                            clip.lut_path = None;
+                        }
+                        if let Some(p) = &clip.lut_path {
+                            let name = p
+                                .file_name()
+                                .map(|n| n.to_string_lossy().into_owned())
+                                .unwrap_or_default();
+                            ui.weak(name);
+                        }
+                    });
+                    ui.weak("Color correction applied on Export only (ff-preview limitation — docs/issue40.md). Speed applies to preview and export; audio pitch changes proportionally in preview (no pitch correction — docs/issue42.md). Opacity applies to preview (V1 fades to black; V2 fades over V1). Blend mode applies to export only (docs/issue43.md). LUT applies to preview and export.");
                 });
         }
     }
@@ -2832,6 +2854,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             speed: 1.0,
             opacity: 1.0,
             blend_mode: avio::BlendMode::Normal,
+            lut_path: None,
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -2960,6 +2983,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 speed: state.timeline.tracks[ti].clips[ci].speed,
                 opacity: state.timeline.tracks[ti].clips[ci].opacity,
                 blend_mode: state.timeline.tracks[ti].clips[ci].blend_mode,
+                lut_path: state.timeline.tracks[ti].clips[ci].lut_path.clone(),
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }


### PR DESCRIPTION
## Summary

Adds per-clip 3D LUT (.cube) colour grading, applied both in the timeline preview and on export. This is the first colour-grading tool under #132 and it delivers the avio `Clip` effect chain (avio gap #52) that the sibling tools (#149–#153) build on — once this lands they need no further avio changes.

## Changes

- **avio dependency (gap #52, separate avio PR)**: `Clip::with_video_effect()` / `with_audio_effect()` attach any `FilterStep` to a clip; `Timeline::render()` forwards them to the layer/track effect chains. Also fixes `FilterStep::Lut3d` to escape Windows file paths for the FFmpeg filter-arg parser.
- **`src/export.rs`**: `ExportClip.lut_path`; `clips_to_avio` attaches `FilterStep::Lut3d` after colour correction.
- **`src/state.rs`**: `TimelineClip.lut_path`; `lut_cache` for parsed LUTs.
- **`src/lut.rs`** (new): `.cube` parser + trilinear interpolation for the software preview, so the monitor matches the export.
- **`src/ui/drain.rs`**: applies the LUT to preview frames (after brightness/contrast/saturation, matching export order), with per-path caching.
- **`src/ui/timeline.rs`**: Clip Properties LUT Load/Clear UI.
- **`src/project.rs`**: LUT path persisted in the project file (`#[serde(default)]` keeps older files loadable).

## Related Issues

Closes #148

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes