### PR TITLE
feat(filter): per-clip white balance (temperature/tint)

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1,0 +1,73 @@
+//! Software colour operations for the timeline preview.
+//!
+//! These mirror the avio `FilterStep` formulas exactly so the monitor preview
+//! matches the rendered (exported) output.
+
+/// Tanner-Helland kelvin→RGB multipliers, identical to avio's `kelvin_to_rgb`
+/// (`ff-filter`'s `WhiteBalance` uses this for `colorchannelmixer`). Each
+/// component is in `0..=1`.
+pub fn kelvin_to_rgb(temp_k: u32) -> (f32, f32, f32) {
+    let t = (f64::from(temp_k) / 100.0).clamp(10.0, 400.0);
+    let r = if t <= 66.0 {
+        1.0
+    } else {
+        (329.698_727_446_4 * (t - 60.0).powf(-0.133_204_759_2) / 255.0).clamp(0.0, 1.0)
+    };
+    let g = if t <= 66.0 {
+        ((99.470_802_586_1 * t.ln() - 161.119_568_166_1) / 255.0).clamp(0.0, 1.0)
+    } else {
+        ((288.122_169_528_3 * (t - 60.0).powf(-0.075_514_849_2)) / 255.0).clamp(0.0, 1.0)
+    };
+    let b = if t >= 66.0 {
+        1.0
+    } else if t <= 19.0 {
+        0.0
+    } else {
+        ((138.517_731_223_1 * (t - 10.0).ln() - 305.044_792_730_7) / 255.0).clamp(0.0, 1.0)
+    };
+    (r as f32, g as f32, b as f32)
+}
+
+/// Applies white balance to packed RGBA pixel data in place (alpha untouched).
+///
+/// Matches avio's `WhiteBalance` → `colorchannelmixer`:
+/// `R' = r·R`, `G' = (g + tint)·G`, `B' = b·B`, where `(r, g, b) = kelvin_to_rgb(temp)`.
+pub fn apply_white_balance_rgba(data: &mut [u8], temperature_k: u32, tint: f32) {
+    let (r, g, b) = kelvin_to_rgb(temperature_k);
+    let g_adj = (g + tint).clamp(0.0, 2.0);
+    for px in data.chunks_exact_mut(4) {
+        px[0] = (f32::from(px[0]) * r).clamp(0.0, 255.0) as u8;
+        px[1] = (f32::from(px[1]) * g_adj).clamp(0.0, 255.0) as u8;
+        px[2] = (f32::from(px[2]) * b).clamp(0.0, 255.0) as u8;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kelvin_to_rgb_warm_should_keep_red_drop_blue() {
+        // Below the 6600 K boundary: red is full, blue is reduced (warm cast).
+        let (r, _g, b) = kelvin_to_rgb(3000);
+        assert!((r - 1.0).abs() < 1e-6, "warm red should be full, got {r}");
+        assert!(b < 1.0, "warm blue should be reduced, got {b}");
+    }
+
+    #[test]
+    fn kelvin_to_rgb_cool_should_keep_blue_drop_red() {
+        // Above the 6600 K boundary: blue is full, red is reduced (cool cast).
+        let (r, _g, b) = kelvin_to_rgb(9000);
+        assert!((b - 1.0).abs() < 1e-6, "cool blue should be full, got {b}");
+        assert!(r < 1.0, "cool red should be reduced, got {r}");
+    }
+
+    #[test]
+    fn apply_white_balance_neutral_tint_warm_should_reduce_blue_channel() {
+        let mut px = [128u8, 128, 128, 255];
+        apply_white_balance_rgba(&mut px, 3000, 0.0);
+        assert_eq!(px[0], 128, "red unchanged at warm temp");
+        assert!(px[2] < 128, "blue reduced at warm temp, got {}", px[2]);
+        assert_eq!(px[3], 255, "alpha untouched");
+    }
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -39,6 +39,10 @@ pub struct ExportClip {
     /// Optional 3D LUT (.cube) path. When `Some`, attached via
     /// `Clip::with_video_effect(FilterStep::Lut3d)`.
     pub lut_path: Option<PathBuf>,
+    /// White-balance colour temperature (Kelvin). `WB_NEUTRAL_TEMP` + tint 0 = off.
+    pub wb_temperature: u32,
+    /// White-balance tint (added to the green multiplier).
+    pub wb_tint: f32,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -164,6 +168,16 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
             #[allow(clippy::float_cmp)]
             let clip = if c.brightness != 0.0 || c.contrast != 1.0 || c.saturation != 1.0 {
                 clip.with_color_correction(c.brightness, c.contrast, c.saturation)
+            } else {
+                clip
+            };
+            // White balance after exposure/contrast, before the LUT look.
+            #[allow(clippy::float_cmp)]
+            let clip = if c.wb_temperature != crate::state::WB_NEUTRAL_TEMP || c.wb_tint != 0.0 {
+                clip.with_video_effect(avio::FilterStep::WhiteBalance {
+                    temperature_k: c.wb_temperature,
+                    tint: c.wb_tint,
+                })
             } else {
                 clip
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod analysis;
+mod color;
 mod export;
 mod gif;
 mod lut;

--- a/src/project.rs
+++ b/src/project.rs
@@ -53,6 +53,14 @@ pub struct ProjectTimelineClip {
     pub blend_mode: String,
     #[serde(default)]
     pub lut_path: Option<String>,
+    #[serde(default = "default_wb_temperature")]
+    pub wb_temperature: u32,
+    #[serde(default)]
+    pub wb_tint: f32,
+}
+
+fn default_wb_temperature() -> u32 {
+    crate::state::WB_NEUTRAL_TEMP
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -193,6 +201,8 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
             .lut_path
             .as_ref()
             .map(|p| p.to_string_lossy().into_owned()),
+        wb_temperature: tc.wb_temperature,
+        wb_tint: tc.wb_tint,
     }
 }
 
@@ -225,6 +235,8 @@ fn project_to_timeline_clip(
         opacity: ptc.opacity,
         blend_mode: blend_mode_from_str(&ptc.blend_mode),
         lut_path: ptc.lut_path.as_ref().map(PathBuf::from),
+        wb_temperature: ptc.wb_temperature,
+        wb_tint: ptc.wb_tint,
     })
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,6 +4,10 @@ use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
 
+/// Neutral white-balance temperature (Kelvin). At this value (with tint 0) the
+/// white-balance filter is treated as "off" and skipped, so output is unchanged.
+pub const WB_NEUTRAL_TEMP: u32 = 6500;
+
 /// Which edge of a clip is being trimmed.
 #[derive(Clone, Debug, PartialEq)]
 pub enum TrimEdge {
@@ -534,6 +538,11 @@ pub struct TimelineClip {
     /// Applied on export via `avio::Clip::with_video_effect(FilterStep::Lut3d)`.
     /// Export-only: not shown in the monitor preview (v1).
     pub lut_path: Option<PathBuf>,
+    /// White-balance colour temperature in Kelvin. Default 6500 (off).
+    /// Applied via `FilterStep::WhiteBalance` on export and in software preview.
+    pub wb_temperature: u32,
+    /// White-balance tint, added to the green channel multiplier. Default 0.0 (off).
+    pub wb_tint: f32,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -655,6 +655,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 opacity: 1.0,
                 blend_mode: avio::BlendMode::Normal,
                 lut_path: None,
+                wb_temperature: state::WB_NEUTRAL_TEMP,
+                wb_tint: 0.0,
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/drain.rs
+++ b/src/ui/drain.rs
@@ -210,6 +210,7 @@ fn drain_frame(state: &mut AppState, ctx: &egui::Context) {
                 })
             });
             let correction = active.map(|tc| (tc.brightness, tc.contrast, tc.saturation));
+            let white_balance = active.map(|tc| (tc.wb_temperature, tc.wb_tint));
             let lut_path = active.and_then(|tc| tc.lut_path.clone());
 
             let is_rgba = frame.data.len() == frame.width as usize * frame.height as usize * 4;
@@ -219,6 +220,14 @@ fn drain_frame(state: &mut AppState, ctx: &egui::Context) {
                 && (b != 0.0 || c != 1.0 || s != 1.0)
             {
                 apply_eq_rgba(&mut frame.data, b, c, s);
+            }
+            // White balance after exposure/contrast, before the LUT (export order).
+            #[allow(clippy::float_cmp)]
+            if is_rgba
+                && let Some((temp, tint)) = white_balance
+                && (temp != crate::state::WB_NEUTRAL_TEMP || tint != 0.0)
+            {
+                crate::color::apply_white_balance_rgba(&mut frame.data, temp, tint);
             }
             // LUT applied after colour correction (matches the export order).
             if is_rgba && let Some(path) = lut_path {

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -238,6 +238,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             None
                         },
                         lut_path: tc.lut_path.clone(),
+                        wb_temperature: tc.wb_temperature,
+                        wb_tint: tc.wb_tint,
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -931,6 +933,29 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             clip.brightness = 0.0;
                             clip.contrast = 1.0;
                             clip.saturation = 1.0;
+                        }
+                    });
+                    // White balance — temperature (Kelvin) + tint, via avio WhiteBalance.
+                    // Labels precede their sliders (matches the brightness row above).
+                    ui.horizontal(|ui| {
+                        ui.label("White Balance — Temp K");
+                        ui.add(egui::Slider::new(&mut clip.wb_temperature, 2000..=12000));
+                        ui.separator();
+                        ui.label("Tint");
+                        ui.add(
+                            egui::Slider::new(&mut clip.wb_tint, -0.5..=0.5).fixed_decimals(2),
+                        );
+                        ui.separator();
+                        #[allow(clippy::float_cmp)]
+                        let wb_off =
+                            clip.wb_temperature == state::WB_NEUTRAL_TEMP && clip.wb_tint == 0.0;
+                        if ui
+                            .add_enabled(!wb_off, egui::Button::new("Reset"))
+                            .on_hover_text("Reset white balance to neutral")
+                            .clicked()
+                        {
+                            clip.wb_temperature = state::WB_NEUTRAL_TEMP;
+                            clip.wb_tint = 0.0;
                         }
                     });
                     // 3D LUT (.cube) — export-only via avio Clip effect chain.
@@ -2855,6 +2880,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             opacity: 1.0,
             blend_mode: avio::BlendMode::Normal,
             lut_path: None,
+            wb_temperature: state::WB_NEUTRAL_TEMP,
+            wb_tint: 0.0,
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -2984,6 +3011,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 opacity: state.timeline.tracks[ti].clips[ci].opacity,
                 blend_mode: state.timeline.tracks[ti].clips[ci].blend_mode,
                 lut_path: state.timeline.tracks[ti].clips[ci].lut_path.clone(),
+                wb_temperature: state.timeline.tracks[ti].clips[ci].wb_temperature,
+                wb_tint: state.timeline.tracks[ti].clips[ci].wb_tint,
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }


### PR DESCRIPTION
## Summary

Adds per-clip white balance (colour temperature + tint), applied in the timeline preview and on export. Second colour tool under #132; demo-only — it reuses the avio `Clip` effect chain from #148 (`FilterStep::WhiteBalance`), so no avio change is required.

## Changes

- **`src/color.rs`** (new): `kelvin_to_rgb` (mirrors avio's Tanner-Helland formula exactly) + `apply_white_balance_rgba` for the software preview, with unit tests.
- **`src/state.rs`**: `TimelineClip.wb_temperature` / `wb_tint`; `WB_NEUTRAL_TEMP` (6500 K) constant. 6500 K + tint 0 is treated as "off" (the avio formula has no exact identity point), so an untouched clip is bit-identical.
- **`src/export.rs`**: `ExportClip` WB fields; `clips_to_avio` attaches `FilterStep::WhiteBalance` before the LUT (order: Eq → WB → LUT).
- **`src/ui/drain.rs`**: applies WB to preview frames between colour correction and the LUT (matching export order).
- **`src/ui/timeline.rs`**: Clip Properties WB row (Temp K + Tint sliders + Reset), labels placed before sliders for clarity.
- **`src/project.rs`**: WB persisted in the project file (`#[serde(default)]` keeps older files loadable).

## Related Issues

Closes #149

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes