### PR TITLE
feat(filter): per-clip vignette (strength + centre)

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -52,6 +52,16 @@ pub struct ExportClip {
     pub gamma_r: f32,
     pub gamma_g: f32,
     pub gamma_b: f32,
+    /// Vignette strength percentage (0.0 = off). Mapped to `FilterStep::Vignette` angle.
+    pub vignette: f32,
+    /// Vignette centre X / Y percentage (50.0 = centre).
+    pub vignette_x: f32,
+    pub vignette_y: f32,
+    /// Source video dimensions — used to convert the normalized vignette centre
+    /// to the pixel `x0`/`y0` that `FilterStep::Vignette` requires. `0` when the
+    /// source has no video stream.
+    pub width: u32,
+    pub height: u32,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -157,6 +167,11 @@ pub fn apply_color_grade(
     gamma_g: f32,
     gamma_b: f32,
     lut_path: Option<&std::path::Path>,
+    vignette: f32,
+    vignette_x: f32,
+    vignette_y: f32,
+    width: u32,
+    height: u32,
 ) -> avio::Clip {
     let clip = if brightness != 0.0 || contrast != 1.0 || saturation != 1.0 {
         clip.with_color_correction(brightness, contrast, saturation)
@@ -187,11 +202,23 @@ pub fn apply_color_grade(
     } else {
         clip
     };
-    match lut_path {
+    let clip = match lut_path {
         Some(p) => clip.with_video_effect(avio::FilterStep::Lut3d {
             path: p.to_string_lossy().into_owned(),
         }),
         None => clip,
+    };
+    // Vignette last (final creative step). Strength 0..100 maps to angle 0..π/2;
+    // the normalized centre maps to pixels via the source dimensions. `.max(1.0)`
+    // keeps x0/y0 non-zero so avio's `x0 == 0.0 ⇒ centre` special-case is never
+    // triggered accidentally at 0%.
+    if vignette > 0.0 && width > 0 && height > 0 {
+        let angle = (vignette / 100.0) * std::f32::consts::FRAC_PI_2;
+        let x0 = ((vignette_x / 100.0) * width as f32).max(1.0);
+        let y0 = ((vignette_y / 100.0) * height as f32).max(1.0);
+        clip.with_video_effect(avio::FilterStep::Vignette { angle, x0, y0 })
+    } else {
+        clip
     }
 }
 
@@ -233,7 +260,7 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
                 Some(kind) => clip.with_transition(kind, c.transition_duration),
                 None => clip,
             };
-            // Colour grading chain (Eq → WB → Hue → Gamma → LUT). Built from the
+            // Colour grading chain (Eq → WB → Hue → Gamma → LUT → Vignette). Built from the
             // shared `apply_color_grade` so export and the preview
             // (`Clip::apply_video_effects`) apply the identical chain.
             let clip = apply_color_grade(
@@ -248,6 +275,11 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
                 c.gamma_g,
                 c.gamma_b,
                 c.lut_path.as_deref(),
+                c.vignette,
+                c.vignette_x,
+                c.vignette_y,
+                c.width,
+                c.height,
             );
             #[allow(clippy::float_cmp)]
             let clip = if c.opacity != 1.0 {
@@ -571,6 +603,11 @@ mod tests {
             gamma_g,
             gamma_b,
             lut_path,
+            0.0,  // vignette (neutral)
+            50.0, // vignette_x
+            50.0, // vignette_y
+            1920, // width (unused while vignette is neutral)
+            1080, // height
         )
         .video_effect_chain()
     }
@@ -754,5 +791,64 @@ mod tests {
         assert!(matches!(steps[2], avio::FilterStep::Hue { .. }));
         assert!(matches!(steps[3], avio::FilterStep::Gamma { .. }));
         assert!(matches!(steps[4], avio::FilterStep::Lut3d { .. }));
+    }
+
+    /// A non-zero vignette appends a `Vignette` step, mapping strength to the
+    /// `angle` (0..π/2) and the normalized centre to pixel `x0`/`y0`.
+    #[test]
+    fn vignette_step_maps_strength_and_centre() {
+        let steps = apply_color_grade(
+            avio::Clip::new("test.mp4"),
+            0.0,
+            1.0,
+            1.0,
+            WB_NEUTRAL_TEMP,
+            0.0,
+            0.0,
+            1.0,
+            1.0,
+            1.0,
+            None,
+            50.0, // strength %
+            25.0, // centre X %
+            75.0, // centre Y %
+            1920,
+            1080,
+        )
+        .video_effect_chain();
+        assert_eq!(steps.len(), 1);
+        match &steps[0] {
+            avio::FilterStep::Vignette { angle, x0, y0 } => {
+                assert!((*angle - std::f32::consts::FRAC_PI_2 * 0.5).abs() < 1e-4);
+                assert!((*x0 - 480.0).abs() < 1e-3); // 0.25 * 1920
+                assert!((*y0 - 810.0).abs() < 1e-3); // 0.75 * 1080
+            }
+            other => panic!("expected Vignette, got {other:?}"),
+        }
+    }
+
+    /// Strength 0 (the default) skips the vignette step entirely.
+    #[test]
+    fn vignette_neutral_produces_no_step() {
+        let steps = apply_color_grade(
+            avio::Clip::new("test.mp4"),
+            0.0,
+            1.0,
+            1.0,
+            WB_NEUTRAL_TEMP,
+            0.0,
+            0.0,
+            1.0,
+            1.0,
+            1.0,
+            None,
+            0.0,
+            50.0,
+            50.0,
+            1920,
+            1080,
+        )
+        .video_effect_chain();
+        assert!(steps.is_empty());
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -45,6 +45,14 @@ pub struct TrackClipData {
     pub opacity: f32,
     /// Per-clip blend mode. Forwarded to `Clip::with_blend_mode`.
     pub blend_mode: avio::BlendMode,
+    /// Vignette strength percentage (`0.0` = off) and normalized centre X/Y (%).
+    pub vignette: f32,
+    pub vignette_x: f32,
+    pub vignette_y: f32,
+    /// Source video dimensions — used to convert the normalized vignette centre
+    /// to pixel `x0`/`y0`. `0` when the source has no video stream.
+    pub width: u32,
+    pub height: u32,
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -421,7 +429,7 @@ pub fn spawn_timeline_player(
             if let Some(kind) = tc.transition {
                 c = c.with_transition(kind, tc.transition_duration);
             }
-            // Full colour grade (Eq → WB → Hue → Gamma → LUT), shared with export.
+            // Full colour grade (Eq → WB → Hue → Gamma → LUT → Vignette), shared with export.
             // The preview player applies these via avio's RealtimeComposer, so the
             // monitor matches the rendered output without any host-side re-grading.
             c = crate::export::apply_color_grade(
@@ -436,6 +444,11 @@ pub fn spawn_timeline_player(
                 tc.gamma_g,
                 tc.gamma_b,
                 tc.lut_path.as_deref(),
+                tc.vignette,
+                tc.vignette_x,
+                tc.vignette_y,
+                tc.width,
+                tc.height,
             );
             #[allow(clippy::float_cmp)]
             if tc.opacity != 1.0 {

--- a/src/project.rs
+++ b/src/project.rs
@@ -65,10 +65,20 @@ pub struct ProjectTimelineClip {
     pub gamma_g: f32,
     #[serde(default = "default_gamma")]
     pub gamma_b: f32,
+    #[serde(default)]
+    pub vignette: f32,
+    #[serde(default = "default_vignette_centre")]
+    pub vignette_x: f32,
+    #[serde(default = "default_vignette_centre")]
+    pub vignette_y: f32,
 }
 
 fn default_wb_temperature() -> u32 {
     crate::state::WB_NEUTRAL_TEMP
+}
+
+fn default_vignette_centre() -> f32 {
+    50.0
 }
 
 fn default_gamma() -> f32 {
@@ -219,6 +229,9 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         gamma_r: tc.gamma_r,
         gamma_g: tc.gamma_g,
         gamma_b: tc.gamma_b,
+        vignette: tc.vignette,
+        vignette_x: tc.vignette_x,
+        vignette_y: tc.vignette_y,
     }
 }
 
@@ -257,6 +270,9 @@ fn project_to_timeline_clip(
         gamma_r: ptc.gamma_r,
         gamma_g: ptc.gamma_g,
         gamma_b: ptc.gamma_b,
+        vignette: ptc.vignette,
+        vignette_x: ptc.vignette_x,
+        vignette_y: ptc.vignette_y,
     })
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -546,6 +546,13 @@ pub struct TimelineClip {
     pub gamma_g: f32,
     /// Per-channel gamma (blue). Default 1.0 (off).
     pub gamma_b: f32,
+    /// Vignette strength as a percentage (0.0–100.0). Default 0.0 (off).
+    /// Mapped to the `FilterStep::Vignette` `angle` (0..π/2) in `apply_color_grade`.
+    pub vignette: f32,
+    /// Vignette centre X as a percentage of width (0.0–100.0). Default 50.0 (centre).
+    pub vignette_x: f32,
+    /// Vignette centre Y as a percentage of height (0.0–100.0). Default 50.0 (centre).
+    pub vignette_y: f32,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -661,6 +661,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 gamma_r: 1.0,
                 gamma_g: 1.0,
                 gamma_b: 1.0,
+                vignette: 0.0,
+                vignette_x: 50.0,
+                vignette_y: 50.0,
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -245,6 +245,11 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         gamma_r: tc.gamma_r,
                         gamma_g: tc.gamma_g,
                         gamma_b: tc.gamma_b,
+                        vignette: tc.vignette,
+                        vignette_x: tc.vignette_x,
+                        vignette_y: tc.vignette_y,
+                        width: src.info.primary_video().map(|v| v.width()).unwrap_or(0),
+                        height: src.info.primary_video().map(|v| v.height()).unwrap_or(0),
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -705,6 +710,19 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 speed: tc.speed,
                 opacity: tc.opacity,
                 blend_mode: tc.blend_mode,
+                vignette: tc.vignette,
+                vignette_x: tc.vignette_x,
+                vignette_y: tc.vignette_y,
+                width: clips[tc.source_index]
+                    .info
+                    .primary_video()
+                    .map(|v| v.width())
+                    .unwrap_or(0),
+                height: clips[tc.source_index]
+                    .info
+                    .primary_video()
+                    .map(|v| v.height())
+                    .unwrap_or(0),
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -777,6 +795,19 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             speed: tc.speed,
                             opacity: tc.opacity,
                             blend_mode: tc.blend_mode,
+                            vignette: tc.vignette,
+                            vignette_x: tc.vignette_x,
+                            vignette_y: tc.vignette_y,
+                            width: clips[tc.source_index]
+                                .info
+                                .primary_video()
+                                .map(|v| v.width())
+                                .unwrap_or(0),
+                            height: clips[tc.source_index]
+                                .info
+                                .primary_video()
+                                .map(|v| v.height())
+                                .unwrap_or(0),
                         };
                         let tracks = &state.timeline.tracks;
                         let audio_start = state.timeline.audio_track_start();
@@ -1006,6 +1037,42 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             clip.gamma_r = 1.0;
                             clip.gamma_g = 1.0;
                             clip.gamma_b = 1.0;
+                        }
+                    });
+                    // Vignette (darkened edges) via avio Vignette. Strength 0 = off;
+                    // centre X/Y are percentages of the frame (50 = centre).
+                    ui.horizontal(|ui| {
+                        ui.label("Vignette");
+                        ui.add(
+                            egui::Slider::new(&mut clip.vignette, 0.0..=100.0).fixed_decimals(0),
+                        );
+                        ui.separator();
+                        let has_vig = clip.vignette > 0.0;
+                        ui.add_enabled(
+                            has_vig,
+                            egui::Slider::new(&mut clip.vignette_x, 0.0..=100.0)
+                                .fixed_decimals(0)
+                                .text("CX"),
+                        );
+                        ui.add_enabled(
+                            has_vig,
+                            egui::Slider::new(&mut clip.vignette_y, 0.0..=100.0)
+                                .fixed_decimals(0)
+                                .text("CY"),
+                        );
+                        ui.separator();
+                        #[allow(clippy::float_cmp)]
+                        let vig_off = clip.vignette == 0.0
+                            && clip.vignette_x == 50.0
+                            && clip.vignette_y == 50.0;
+                        if ui
+                            .add_enabled(!vig_off, egui::Button::new("Reset"))
+                            .on_hover_text("Reset vignette to neutral")
+                            .clicked()
+                        {
+                            clip.vignette = 0.0;
+                            clip.vignette_x = 50.0;
+                            clip.vignette_y = 50.0;
                         }
                     });
                     // 3D LUT (.cube) — export-only via avio Clip effect chain.
@@ -2851,6 +2918,19 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 speed: tc.speed,
                 opacity: tc.opacity,
                 blend_mode: tc.blend_mode,
+                vignette: tc.vignette,
+                vignette_x: tc.vignette_x,
+                vignette_y: tc.vignette_y,
+                width: clips[tc.source_index]
+                    .info
+                    .primary_video()
+                    .map(|v| v.width())
+                    .unwrap_or(0),
+                height: clips[tc.source_index]
+                    .info
+                    .primary_video()
+                    .map(|v| v.height())
+                    .unwrap_or(0),
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -2943,6 +3023,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             gamma_r: 1.0,
             gamma_g: 1.0,
             gamma_b: 1.0,
+            vignette: 0.0,
+            vignette_x: 50.0,
+            vignette_y: 50.0,
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -3078,6 +3161,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 gamma_r: state.timeline.tracks[ti].clips[ci].gamma_r,
                 gamma_g: state.timeline.tracks[ti].clips[ci].gamma_g,
                 gamma_b: state.timeline.tracks[ti].clips[ci].gamma_b,
+                vignette: state.timeline.tracks[ti].clips[ci].vignette,
+                vignette_x: state.timeline.tracks[ti].clips[ci].vignette_x,
+                vignette_y: state.timeline.tracks[ti].clips[ci].vignette_y,
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }


### PR DESCRIPTION
## Summary

Adds a per-clip vignette (darkened edges) to the colour grading panel (part of
#132; after LUT #148, white balance #149, HSL #150). Strength and centre X/Y are
exposed in Clip Properties and applied in both the timeline preview and export
through avio's `FilterStep::Vignette`, using the shared `apply_color_grade` chain
so the preview matches the rendered output.

## Changes

- **`state.rs`**: `TimelineClip` gains `vignette` (strength %, default 0 = off),
  `vignette_x` / `vignette_y` (centre %, default 50 = centre).
- **`export.rs`**: `ExportClip` gains the three fields plus `width`/`height`
  (source dimensions). `apply_color_grade` appends `FilterStep::Vignette` last
  (`Eq → WB → Hue → Gamma → LUT → Vignette`), mapping strength → `angle`
  (`0..π/2`) and the normalized centre → pixel `x0`/`y0`
  (`.max(1.0)` avoids avio's `x0 == 0.0 ⇒ centre` special-case). Two unit tests.
- **`player.rs`**: `TrackClipData` gains the same fields; `make_clip` forwards
  them so the preview grade matches export.
- **`ui/timeline.rs`**: Clip Properties gets a Vignette row (strength / CX / CY /
  Reset); CX/CY enabled only when strength > 0. All construction sites updated.
- **`clip_browser.rs` / `project.rs`**: defaults and save/load (serde defaults).

Preview and export both route through avio's compositor, so no host-side software
preview is needed. Vignette strength is resolution-independent; the centre is
computed from the source resolution (correct for the base/V1 clip; a scaled V2
overlay may differ in preview — see the avio gap below).

## Related Issues

Closes #151. Surfaced an avio gap (`FilterStep::Vignette` centre is pixel-based,
not normalized/expression) — documented in `docs/issue64.md` for filing against avio.

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes