### PR TITLE
feat(filter): per-clip tone curves (luma + RGB)

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -62,6 +62,8 @@ pub struct ExportClip {
     /// source has no video stream.
     pub width: u32,
     pub height: u32,
+    /// Per-clip tone curves (Luma + R/G/B). Attached via `FilterStep::Curves`.
+    pub curves: crate::state::ToneCurves,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -147,7 +149,7 @@ pub fn spawn_queue_job(job: &mut QueueJob) -> bool {
 }
 
 /// Attaches a clip's colour grade to `clip` in canonical order
-/// (`Eq → WhiteBalance → Hue → Gamma → Lut3d`), skipping neutral steps.
+/// (`Eq → WhiteBalance → Hue → Gamma → Curves → Lut3d → Vignette`), skipping neutral steps.
 ///
 /// Brightness/contrast/saturation go through `Clip::with_color_correction` (the
 /// native `eq` path that `Clip::video_effect_chain` emits); the rest are attached
@@ -166,6 +168,7 @@ pub fn apply_color_grade(
     gamma_r: f32,
     gamma_g: f32,
     gamma_b: f32,
+    curves: &crate::state::ToneCurves,
     lut_path: Option<&std::path::Path>,
     vignette: f32,
     vignette_x: f32,
@@ -201,6 +204,16 @@ pub fn apply_color_grade(
         })
     } else {
         clip
+    };
+    let clip = if curves.is_neutral() {
+        clip
+    } else {
+        clip.with_video_effect(avio::FilterStep::Curves {
+            master: curves.master.clone(),
+            r: curves.r.clone(),
+            g: curves.g.clone(),
+            b: curves.b.clone(),
+        })
     };
     let clip = match lut_path {
         Some(p) => clip.with_video_effect(avio::FilterStep::Lut3d {
@@ -260,7 +273,7 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
                 Some(kind) => clip.with_transition(kind, c.transition_duration),
                 None => clip,
             };
-            // Colour grading chain (Eq → WB → Hue → Gamma → LUT → Vignette). Built from the
+            // Colour grading chain (Eq → WB → Hue → Gamma → Curves → LUT → Vignette). Built from the
             // shared `apply_color_grade` so export and the preview
             // (`Clip::apply_video_effects`) apply the identical chain.
             let clip = apply_color_grade(
@@ -274,6 +287,7 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
                 c.gamma_r,
                 c.gamma_g,
                 c.gamma_b,
+                &c.curves,
                 c.lut_path.as_deref(),
                 c.vignette,
                 c.vignette_x,
@@ -602,6 +616,7 @@ mod tests {
             gamma_r,
             gamma_g,
             gamma_b,
+            &crate::state::ToneCurves::default(), // curves (neutral)
             lut_path,
             0.0,  // vignette (neutral)
             50.0, // vignette_x
@@ -808,6 +823,7 @@ mod tests {
             1.0,
             1.0,
             1.0,
+            &crate::state::ToneCurves::default(),
             None,
             50.0, // strength %
             25.0, // centre X %
@@ -841,6 +857,7 @@ mod tests {
             1.0,
             1.0,
             1.0,
+            &crate::state::ToneCurves::default(),
             None,
             0.0,
             50.0,
@@ -850,5 +867,47 @@ mod tests {
         )
         .video_effect_chain();
         assert!(steps.is_empty());
+    }
+
+    /// Non-empty tone curves append a `Curves` step carrying the per-channel
+    /// control points; empty channels are omitted.
+    #[test]
+    fn curves_step_carries_control_points() {
+        let curves = crate::state::ToneCurves {
+            master: vec![(0.0, 0.0), (0.5, 0.6), (1.0, 1.0)],
+            r: vec![(0.0, 0.1), (1.0, 1.0)],
+            g: Vec::new(),
+            b: Vec::new(),
+        };
+        let steps = apply_color_grade(
+            avio::Clip::new("test.mp4"),
+            0.0,
+            1.0,
+            1.0,
+            WB_NEUTRAL_TEMP,
+            0.0,
+            0.0,
+            1.0,
+            1.0,
+            1.0,
+            &curves,
+            None,
+            0.0,
+            50.0,
+            50.0,
+            1920,
+            1080,
+        )
+        .video_effect_chain();
+        assert_eq!(steps.len(), 1);
+        match &steps[0] {
+            avio::FilterStep::Curves { master, r, g, b } => {
+                assert_eq!(master.len(), 3);
+                assert_eq!(r.len(), 2);
+                assert!(g.is_empty());
+                assert!(b.is_empty());
+            }
+            other => panic!("expected Curves, got {other:?}"),
+        }
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -53,6 +53,8 @@ pub struct TrackClipData {
     /// to pixel `x0`/`y0`. `0` when the source has no video stream.
     pub width: u32,
     pub height: u32,
+    /// Per-clip tone curves (Luma + R/G/B).
+    pub curves: crate::state::ToneCurves,
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -429,7 +431,7 @@ pub fn spawn_timeline_player(
             if let Some(kind) = tc.transition {
                 c = c.with_transition(kind, tc.transition_duration);
             }
-            // Full colour grade (Eq → WB → Hue → Gamma → LUT → Vignette), shared with export.
+            // Full colour grade (Eq → WB → Hue → Gamma → Curves → LUT → Vignette), shared with export.
             // The preview player applies these via avio's RealtimeComposer, so the
             // monitor matches the rendered output without any host-side re-grading.
             c = crate::export::apply_color_grade(
@@ -443,6 +445,7 @@ pub fn spawn_timeline_player(
                 tc.gamma_r,
                 tc.gamma_g,
                 tc.gamma_b,
+                &tc.curves,
                 tc.lut_path.as_deref(),
                 tc.vignette,
                 tc.vignette_x,

--- a/src/project.rs
+++ b/src/project.rs
@@ -71,6 +71,8 @@ pub struct ProjectTimelineClip {
     pub vignette_x: f32,
     #[serde(default = "default_vignette_centre")]
     pub vignette_y: f32,
+    #[serde(default)]
+    pub curves: crate::state::ToneCurves,
 }
 
 fn default_wb_temperature() -> u32 {
@@ -232,6 +234,7 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         vignette: tc.vignette,
         vignette_x: tc.vignette_x,
         vignette_y: tc.vignette_y,
+        curves: tc.curves.clone(),
     }
 }
 
@@ -273,6 +276,7 @@ fn project_to_timeline_clip(
         vignette: ptc.vignette,
         vignette_x: ptc.vignette_x,
         vignette_y: ptc.vignette_y,
+        curves: ptc.curves.clone(),
     })
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -487,6 +487,34 @@ pub struct Track {
     pub soloed: bool,
 }
 
+/// Per-clip tone curves — one control-point list per channel. Each list is a set
+/// of `(x, y)` points in `0.0..=1.0`. An empty list means that channel is
+/// identity (it is omitted from the `curves` filter). `master` is the Luma curve.
+#[derive(Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ToneCurves {
+    pub master: Vec<(f32, f32)>,
+    pub r: Vec<(f32, f32)>,
+    pub g: Vec<(f32, f32)>,
+    pub b: Vec<(f32, f32)>,
+}
+
+impl ToneCurves {
+    /// `true` when every channel is identity (empty) — the `Curves` step is then
+    /// skipped so an untouched clip renders bit-identical.
+    pub fn is_neutral(&self) -> bool {
+        self.master.is_empty() && self.r.is_empty() && self.g.is_empty() && self.b.is_empty()
+    }
+}
+
+/// Which tone-curve channel the editor is currently editing.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum CurveChannel {
+    Luma,
+    R,
+    G,
+    B,
+}
+
 #[derive(Clone, PartialEq)]
 pub struct TimelineClip {
     pub source_index: usize,
@@ -553,6 +581,8 @@ pub struct TimelineClip {
     pub vignette_x: f32,
     /// Vignette centre Y as a percentage of height (0.0–100.0). Default 50.0 (centre).
     pub vignette_y: f32,
+    /// Per-clip tone curves (Luma + R/G/B). Default: all identity (empty).
+    pub curves: ToneCurves,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -664,6 +664,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 vignette: 0.0,
                 vignette_x: 50.0,
                 vignette_y: 50.0,
+                curves: state::ToneCurves::default(),
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/curve_editor.rs
+++ b/src/ui/curve_editor.rs
@@ -1,0 +1,186 @@
+//! Draggable tone-curve editor for the Clip Properties panel.
+//!
+//! Edits one [`ToneCurves`] channel at a time (Luma / R / G / B). Each channel is
+//! a list of `(x, y)` control points in `0.0..=1.0`; an empty list is identity
+//! (that channel is omitted from the `curves` filter). The drawn line is a linear
+//! interpolation of the control points — FFmpeg's `curves` applies a cubic spline,
+//! so the preview/export is a smooth approximation of the editor's polyline.
+
+use crate::state::{CurveChannel, ToneCurves};
+
+const CANVAS: f32 = 200.0;
+/// Squared pixel radius within which a click counts as "on an existing point".
+const HANDLE_HIT: f32 = 9.0;
+
+fn channel_vec(curves: &ToneCurves, ch: CurveChannel) -> &Vec<(f32, f32)> {
+    match ch {
+        CurveChannel::Luma => &curves.master,
+        CurveChannel::R => &curves.r,
+        CurveChannel::G => &curves.g,
+        CurveChannel::B => &curves.b,
+    }
+}
+
+fn channel_vec_mut(curves: &mut ToneCurves, ch: CurveChannel) -> &mut Vec<(f32, f32)> {
+    match ch {
+        CurveChannel::Luma => &mut curves.master,
+        CurveChannel::R => &mut curves.r,
+        CurveChannel::G => &mut curves.g,
+        CurveChannel::B => &mut curves.b,
+    }
+}
+
+fn channel_color(ch: CurveChannel) -> egui::Color32 {
+    match ch {
+        CurveChannel::Luma => egui::Color32::from_gray(230),
+        CurveChannel::R => egui::Color32::from_rgb(230, 90, 90),
+        CurveChannel::G => egui::Color32::from_rgb(90, 210, 90),
+        CurveChannel::B => egui::Color32::from_rgb(100, 140, 240),
+    }
+}
+
+/// Renders the tone-curve editor for `curves`. The active channel is kept in egui
+/// temp memory so it persists across frames.
+pub fn tone_curve_editor(ui: &mut egui::Ui, curves: &mut ToneCurves) {
+    let chan_id = ui.id().with("tone_curve_active_channel");
+    let mut active = ui
+        .data_mut(|d| d.get_temp::<CurveChannel>(chan_id))
+        .unwrap_or(CurveChannel::Luma);
+
+    // ── Channel selector + per-channel reset ──────────────────────────────────
+    ui.horizontal(|ui| {
+        for (label, ch) in [
+            ("Luma", CurveChannel::Luma),
+            ("R", CurveChannel::R),
+            ("G", CurveChannel::G),
+            ("B", CurveChannel::B),
+        ] {
+            if ui.selectable_label(active == ch, label).clicked() {
+                active = ch;
+            }
+        }
+        ui.separator();
+        let non_empty = !channel_vec(curves, active).is_empty();
+        if ui
+            .add_enabled(non_empty, egui::Button::new("Reset"))
+            .on_hover_text("Reset this channel to identity")
+            .clicked()
+        {
+            channel_vec_mut(curves, active).clear();
+        }
+    });
+    ui.data_mut(|d| d.insert_temp(chan_id, active));
+
+    // ── Canvas ────────────────────────────────────────────────────────────────
+    let (rect, bg_resp) = ui.allocate_exact_size(egui::vec2(CANVAS, CANVAS), egui::Sense::click());
+
+    let to_screen = |p: (f32, f32)| {
+        egui::pos2(
+            rect.left() + p.0.clamp(0.0, 1.0) * rect.width(),
+            rect.bottom() - p.1.clamp(0.0, 1.0) * rect.height(),
+        )
+    };
+    let to_data = |pos: egui::Pos2| {
+        (
+            ((pos.x - rect.left()) / rect.width()).clamp(0.0, 1.0),
+            ((rect.bottom() - pos.y) / rect.height()).clamp(0.0, 1.0),
+        )
+    };
+
+    // Materialize the active channel's points (empty ⇒ identity for display/edit).
+    let stored = channel_vec(curves, active);
+    let mut pts: Vec<(f32, f32)> = if stored.is_empty() {
+        vec![(0.0, 0.0), (1.0, 1.0)]
+    } else {
+        stored.clone()
+    };
+    pts.sort_by(|a, b| a.0.total_cmp(&b.0));
+
+    // ── Interaction (no painter held here) ────────────────────────────────────
+    let mut changed = false;
+    let mut remove_idx: Option<usize> = None;
+    let mut hovered = vec![false; pts.len()];
+    let n = pts.len();
+    for i in 0..n {
+        let center = to_screen(pts[i]);
+        let handle_rect = egui::Rect::from_center_size(center, egui::vec2(12.0, 12.0));
+        let resp = ui.interact(
+            handle_rect,
+            bg_resp.id.with(i),
+            egui::Sense::click_and_drag(),
+        );
+        hovered[i] = resp.hovered();
+        let is_endpoint = i == 0 || i == n - 1;
+        if resp.dragged() {
+            let d = resp.drag_delta();
+            let ny = (pts[i].1 + (-d.y) / rect.height()).clamp(0.0, 1.0);
+            let nx = if is_endpoint {
+                pts[i].0 // endpoints locked in x
+            } else {
+                (pts[i].0 + d.x / rect.width()).clamp(pts[i - 1].0 + 0.001, pts[i + 1].0 - 0.001)
+            };
+            pts[i] = (nx, ny);
+            changed = true;
+        }
+        if resp.double_clicked() && !is_endpoint {
+            remove_idx = Some(i);
+        }
+    }
+    if let Some(i) = remove_idx {
+        pts.remove(i);
+        changed = true;
+    }
+
+    // Add a point on a background click that is not on an existing handle.
+    if bg_resp.clicked()
+        && let Some(pos) = bg_resp.interact_pointer_pos()
+    {
+        let on_handle = pts
+            .iter()
+            .any(|&p| to_screen(p).distance_sq(pos) < HANDLE_HIT);
+        if !on_handle {
+            pts.push(to_data(pos));
+            pts.sort_by(|a, b| a.0.total_cmp(&b.0));
+            changed = true;
+        }
+    }
+
+    if changed {
+        *channel_vec_mut(curves, active) = pts.clone();
+    }
+
+    // ── Paint ─────────────────────────────────────────────────────────────────
+    let painter = ui.painter_at(rect);
+    painter.rect_filled(rect, 2.0, egui::Color32::from_gray(24));
+    painter.rect_stroke(
+        rect,
+        2.0,
+        egui::Stroke::new(1.0, egui::Color32::from_gray(80)),
+        egui::StrokeKind::Inside,
+    );
+    // Quarter grid + identity diagonal.
+    let grid = egui::Stroke::new(1.0, egui::Color32::from_gray(45));
+    for k in 1..4 {
+        let f = k as f32 / 4.0;
+        painter.line_segment([to_screen((f, 0.0)), to_screen((f, 1.0))], grid);
+        painter.line_segment([to_screen((0.0, f)), to_screen((1.0, f))], grid);
+    }
+    painter.line_segment(
+        [to_screen((0.0, 0.0)), to_screen((1.0, 1.0))],
+        egui::Stroke::new(1.0, egui::Color32::from_gray(60)),
+    );
+    // Curve polyline.
+    let curve_stroke = egui::Stroke::new(1.6, channel_color(active));
+    for w in pts.windows(2) {
+        painter.line_segment([to_screen(w[0]), to_screen(w[1])], curve_stroke);
+    }
+    // Control-point handles.
+    for (i, p) in pts.iter().enumerate() {
+        let r = if hovered.get(i).copied().unwrap_or(false) {
+            5.0
+        } else {
+            3.5
+        };
+        painter.circle_filled(to_screen(*p), r, egui::Color32::WHITE);
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,4 +1,5 @@
 pub mod clip_browser;
+pub mod curve_editor;
 pub mod drain;
 pub mod monitor;
 pub mod theme;

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -250,6 +250,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         vignette_y: tc.vignette_y,
                         width: src.info.primary_video().map(|v| v.width()).unwrap_or(0),
                         height: src.info.primary_video().map(|v| v.height()).unwrap_or(0),
+                        curves: tc.curves.clone(),
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -723,6 +724,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     .primary_video()
                     .map(|v| v.height())
                     .unwrap_or(0),
+                curves: tc.curves.clone(),
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -808,6 +810,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                 .primary_video()
                                 .map(|v| v.height())
                                 .unwrap_or(0),
+                            curves: tc.curves.clone(),
                         };
                         let tracks = &state.timeline.tracks;
                         let audio_start = state.timeline.audio_track_start();
@@ -1075,6 +1078,12 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             clip.vignette_y = 50.0;
                         }
                     });
+                    // Tone curves (Luma + R/G/B) via avio Curves — draggable editor.
+                    egui::CollapsingHeader::new("Tone Curves")
+                        .id_salt("tone_curves")
+                        .show(ui, |ui| {
+                            super::curve_editor::tone_curve_editor(ui, &mut clip.curves);
+                        });
                     // 3D LUT (.cube) — export-only via avio Clip effect chain.
                     ui.horizontal(|ui| {
                         ui.label("LUT (.cube)");
@@ -2931,6 +2940,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     .primary_video()
                     .map(|v| v.height())
                     .unwrap_or(0),
+                curves: tc.curves.clone(),
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -3026,6 +3036,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             vignette: 0.0,
             vignette_x: 50.0,
             vignette_y: 50.0,
+            curves: state::ToneCurves::default(),
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -3164,6 +3175,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 vignette: state.timeline.tracks[ti].clips[ci].vignette,
                 vignette_x: state.timeline.tracks[ti].clips[ci].vignette_x,
                 vignette_y: state.timeline.tracks[ti].clips[ci].vignette_y,
+                curves: state.timeline.tracks[ti].clips[ci].curves.clone(),
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }


### PR DESCRIPTION
## Summary

Adds per-clip tone curves to the colour grading panel (part of #132; after LUT
#148, white balance #149, HSL #150, vignette #151). A draggable curve editor
(Luma + per-channel R/G/B) lets you add, move, and remove control points; the
curves are applied in both the timeline preview and export through avio's
`FilterStep::Curves` via the shared `apply_color_grade` chain, so the preview
matches the rendered output.

## Changes

- **`state.rs`**: `ToneCurves { master, r, g, b: Vec<(f32,f32)> }` (serde-derived,
  empty channel = identity) and a `CurveChannel` enum; `TimelineClip` gains
  `curves`.
- **`export.rs`**: `ExportClip.curves`; `apply_color_grade` attaches
  `FilterStep::Curves` after Gamma and before LUT
  (`Eq → WB → Hue → Gamma → Curves → LUT → Vignette`), skipped when all channels
  are empty. Unit test for the curves step.
- **`player.rs`**: `TrackClipData.curves`; `make_clip` forwards it so the preview
  grade matches export.
- **`ui/curve_editor.rs`** (new): a draggable tone-curve widget — channel
  selector, 200×200 canvas with grid + identity reference, click-to-add,
  drag-to-move (endpoints x-locked), double-click-to-remove, per-channel reset.
- **`ui/timeline.rs`**: a "Tone Curves" `CollapsingHeader` in Clip Properties;
  `curves` added at all construction sites. **`ui/mod.rs`**: module registered.
- **`clip_browser.rs` / `project.rs`**: defaults and save/load (serde default).

Tone curves are per-pixel (resolution-independent), so no resolution plumbing is
needed. The editor draws linear segments while FFmpeg applies a cubic spline, so
the drawn line is a smooth approximation of the rendered result (noted in the UI).

## Related Issues

Closes #152.

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes