### PR TITLE
feat(filter): per-clip 3-way color wheels (lift/gamma/gain)

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -64,6 +64,8 @@ pub struct ExportClip {
     pub height: u32,
     /// Per-clip tone curves (Luma + R/G/B). Attached via `FilterStep::Curves`.
     pub curves: crate::state::ToneCurves,
+    /// Per-clip 3-way colour corrector. Attached via `FilterStep::ThreeWayCC`.
+    pub wheels: crate::state::ColorWheels,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -148,8 +150,30 @@ pub fn spawn_queue_job(job: &mut QueueJob) -> bool {
     true
 }
 
+/// Maps a [`ColorWheel`](crate::state::ColorWheel) to an avio per-channel `Rgb`
+/// (neutral `1.0`). The wheel's colour offset is projected onto R/G/B axes placed
+/// at 90° / 210° / 330° (R up); `luma` shifts all channels together. This is a
+/// demo approximation — avio's `ThreeWayCC` is itself a 3-point curves model.
+fn wheel_to_rgb(w: crate::state::ColorWheel, is_gamma: bool) -> avio::Rgb {
+    const COLOR_SCALE: f32 = 0.25;
+    const LUMA_SCALE: f32 = 0.25;
+    let contrib_r = w.y;
+    let contrib_g = -0.866 * w.x - 0.5 * w.y;
+    let contrib_b = 0.866 * w.x - 0.5 * w.y;
+    let base = 1.0 + w.luma * LUMA_SCALE;
+    let mk = |contrib: f32| {
+        let v = base + contrib * COLOR_SCALE;
+        if is_gamma { v.max(0.1) } else { v.max(0.0) }
+    };
+    avio::Rgb {
+        r: mk(contrib_r),
+        g: mk(contrib_g),
+        b: mk(contrib_b),
+    }
+}
+
 /// Attaches a clip's colour grade to `clip` in canonical order
-/// (`Eq → WhiteBalance → Hue → Gamma → Curves → Lut3d → Vignette`), skipping neutral steps.
+/// (`Eq → WhiteBalance → Hue → Gamma → ThreeWayCC → Curves → Lut3d → Vignette`), skipping neutral steps.
 ///
 /// Brightness/contrast/saturation go through `Clip::with_color_correction` (the
 /// native `eq` path that `Clip::video_effect_chain` emits); the rest are attached
@@ -168,6 +192,7 @@ pub fn apply_color_grade(
     gamma_r: f32,
     gamma_g: f32,
     gamma_b: f32,
+    wheels: &crate::state::ColorWheels,
     curves: &crate::state::ToneCurves,
     lut_path: Option<&std::path::Path>,
     vignette: f32,
@@ -204,6 +229,15 @@ pub fn apply_color_grade(
         })
     } else {
         clip
+    };
+    let clip = if wheels.is_neutral() {
+        clip
+    } else {
+        clip.with_video_effect(avio::FilterStep::ThreeWayCC {
+            lift: wheel_to_rgb(wheels.lift, false),
+            gamma: wheel_to_rgb(wheels.gamma, true),
+            gain: wheel_to_rgb(wheels.gain, false),
+        })
     };
     let clip = if curves.is_neutral() {
         clip
@@ -273,7 +307,7 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
                 Some(kind) => clip.with_transition(kind, c.transition_duration),
                 None => clip,
             };
-            // Colour grading chain (Eq → WB → Hue → Gamma → Curves → LUT → Vignette). Built from the
+            // Colour grading chain (Eq → WB → Hue → Gamma → ThreeWayCC → Curves → LUT → Vignette). Built from the
             // shared `apply_color_grade` so export and the preview
             // (`Clip::apply_video_effects`) apply the identical chain.
             let clip = apply_color_grade(
@@ -287,6 +321,7 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
                 c.gamma_r,
                 c.gamma_g,
                 c.gamma_b,
+                &c.wheels,
                 &c.curves,
                 c.lut_path.as_deref(),
                 c.vignette,
@@ -616,7 +651,8 @@ mod tests {
             gamma_r,
             gamma_g,
             gamma_b,
-            &crate::state::ToneCurves::default(), // curves (neutral)
+            &crate::state::ColorWheels::default(), // wheels (neutral)
+            &crate::state::ToneCurves::default(),  // curves (neutral)
             lut_path,
             0.0,  // vignette (neutral)
             50.0, // vignette_x
@@ -823,6 +859,7 @@ mod tests {
             1.0,
             1.0,
             1.0,
+            &crate::state::ColorWheels::default(),
             &crate::state::ToneCurves::default(),
             None,
             50.0, // strength %
@@ -857,6 +894,7 @@ mod tests {
             1.0,
             1.0,
             1.0,
+            &crate::state::ColorWheels::default(),
             &crate::state::ToneCurves::default(),
             None,
             0.0,
@@ -890,6 +928,7 @@ mod tests {
             1.0,
             1.0,
             1.0,
+            &crate::state::ColorWheels::default(),
             &curves,
             None,
             0.0,
@@ -908,6 +947,46 @@ mod tests {
                 assert!(b.is_empty());
             }
             other => panic!("expected Curves, got {other:?}"),
+        }
+    }
+
+    /// A non-neutral colour wheel appends a `ThreeWayCC` step; a neutral one is
+    /// skipped. Gamma channels stay `> 0`.
+    #[test]
+    fn color_wheels_map_to_three_way_cc() {
+        let mut wheels = crate::state::ColorWheels::default();
+        wheels.gain.y = 1.0; // push highlights toward red
+        let steps = apply_color_grade(
+            avio::Clip::new("test.mp4"),
+            0.0,
+            1.0,
+            1.0,
+            WB_NEUTRAL_TEMP,
+            0.0,
+            0.0,
+            1.0,
+            1.0,
+            1.0,
+            &wheels,
+            &crate::state::ToneCurves::default(),
+            None,
+            0.0,
+            50.0,
+            50.0,
+            1920,
+            1080,
+        )
+        .video_effect_chain();
+        assert_eq!(steps.len(), 1);
+        match &steps[0] {
+            avio::FilterStep::ThreeWayCC { gain, gamma, .. } => {
+                // gain.r raised (red), gain.g/b lowered by the 0.25 colour scale.
+                assert!(gain.r > 1.0);
+                assert!(gain.g < 1.0 && gain.b < 1.0);
+                // gamma stays neutral and positive.
+                assert!(gamma.r > 0.0 && gamma.g > 0.0 && gamma.b > 0.0);
+            }
+            other => panic!("expected ThreeWayCC, got {other:?}"),
         }
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -55,6 +55,8 @@ pub struct TrackClipData {
     pub height: u32,
     /// Per-clip tone curves (Luma + R/G/B).
     pub curves: crate::state::ToneCurves,
+    /// Per-clip 3-way colour corrector (lift / gamma / gain).
+    pub wheels: crate::state::ColorWheels,
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -431,7 +433,7 @@ pub fn spawn_timeline_player(
             if let Some(kind) = tc.transition {
                 c = c.with_transition(kind, tc.transition_duration);
             }
-            // Full colour grade (Eq → WB → Hue → Gamma → Curves → LUT → Vignette), shared with export.
+            // Full colour grade (Eq → WB → Hue → Gamma → ThreeWayCC → Curves → LUT → Vignette), shared with export.
             // The preview player applies these via avio's RealtimeComposer, so the
             // monitor matches the rendered output without any host-side re-grading.
             c = crate::export::apply_color_grade(
@@ -445,6 +447,7 @@ pub fn spawn_timeline_player(
                 tc.gamma_r,
                 tc.gamma_g,
                 tc.gamma_b,
+                &tc.wheels,
                 &tc.curves,
                 tc.lut_path.as_deref(),
                 tc.vignette,

--- a/src/project.rs
+++ b/src/project.rs
@@ -73,6 +73,8 @@ pub struct ProjectTimelineClip {
     pub vignette_y: f32,
     #[serde(default)]
     pub curves: crate::state::ToneCurves,
+    #[serde(default)]
+    pub wheels: crate::state::ColorWheels,
 }
 
 fn default_wb_temperature() -> u32 {
@@ -235,6 +237,7 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         vignette_x: tc.vignette_x,
         vignette_y: tc.vignette_y,
         curves: tc.curves.clone(),
+        wheels: tc.wheels,
     }
 }
 
@@ -277,6 +280,7 @@ fn project_to_timeline_clip(
         vignette_x: ptc.vignette_x,
         vignette_y: ptc.vignette_y,
         curves: ptc.curves.clone(),
+        wheels: ptc.wheels,
     })
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -515,6 +515,34 @@ pub enum CurveChannel {
     B,
 }
 
+/// A single 3-way colour-corrector wheel (shadows / midtones / highlights).
+/// `x`/`y` are the colour offset within the wheel disk (`-1.0..=1.0`, `0` = no
+/// tint) and `luma` is the range's luminance offset (`-1.0..=1.0`, `0` = neutral).
+#[derive(Clone, Copy, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ColorWheel {
+    pub x: f32,
+    pub y: f32,
+    pub luma: f32,
+}
+
+/// Per-clip 3-way colour corrector: lift (shadows), gamma (midtones), gain
+/// (highlights). All-zero is neutral (the `ThreeWayCC` step is then skipped).
+#[derive(Clone, Copy, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ColorWheels {
+    pub lift: ColorWheel,
+    pub gamma: ColorWheel,
+    pub gain: ColorWheel,
+}
+
+impl ColorWheels {
+    /// `true` when every wheel is neutral (all fields `0.0`).
+    pub fn is_neutral(&self) -> bool {
+        [self.lift, self.gamma, self.gain]
+            .iter()
+            .all(|w| w.x == 0.0 && w.y == 0.0 && w.luma == 0.0)
+    }
+}
+
 #[derive(Clone, PartialEq)]
 pub struct TimelineClip {
     pub source_index: usize,
@@ -583,6 +611,8 @@ pub struct TimelineClip {
     pub vignette_y: f32,
     /// Per-clip tone curves (Luma + R/G/B). Default: all identity (empty).
     pub curves: ToneCurves,
+    /// Per-clip 3-way colour corrector (lift / gamma / gain). Default: neutral.
+    pub wheels: ColorWheels,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -665,6 +665,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 vignette_x: 50.0,
                 vignette_y: 50.0,
                 curves: state::ToneCurves::default(),
+                wheels: state::ColorWheels::default(),
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/color_wheels.rs
+++ b/src/ui/color_wheels.rs
@@ -1,0 +1,92 @@
+//! 3-way colour-corrector wheels (lift / gamma / gain) for Clip Properties.
+//!
+//! Each wheel is a circular disk with a draggable dot: the dot's position is a
+//! colour offset (hue = angle, strength = radius) and a slider below sets the
+//! range's luminance. The wheel state is mapped to avio's `FilterStep::ThreeWayCC`
+//! (per-channel `Rgb`, neutral `1.0`) in `export::apply_color_grade` — a demo
+//! approximation (avio's `ThreeWayCC` is itself a 3-point curves model).
+
+use crate::state::{ColorWheel, ColorWheels};
+
+const WHEEL: f32 = 96.0;
+
+/// One colour wheel: label, draggable disk, luminance slider.
+fn color_wheel(ui: &mut egui::Ui, label: &str, w: &mut ColorWheel) {
+    ui.vertical(|ui| {
+        ui.label(label);
+        let (rect, resp) =
+            ui.allocate_exact_size(egui::vec2(WHEEL, WHEEL), egui::Sense::click_and_drag());
+        let center = rect.center();
+        let radius = WHEEL / 2.0 - 4.0;
+
+        // Drag the dot (clamped to the disk); double-click resets the colour.
+        if resp.double_clicked() {
+            w.x = 0.0;
+            w.y = 0.0;
+        } else if resp.dragged()
+            && let Some(pos) = resp.interact_pointer_pos()
+        {
+            let mut d = pos - center;
+            let len = d.length();
+            if len > radius {
+                d *= radius / len;
+            }
+            w.x = (d.x / radius).clamp(-1.0, 1.0);
+            w.y = (-d.y / radius).clamp(-1.0, 1.0);
+        }
+
+        {
+            let painter = ui.painter_at(rect);
+            painter.circle_filled(center, radius, egui::Color32::from_gray(24));
+            painter.circle_stroke(
+                center,
+                radius,
+                egui::Stroke::new(1.0, egui::Color32::from_gray(80)),
+            );
+            let cross = egui::Stroke::new(1.0, egui::Color32::from_gray(45));
+            painter.line_segment(
+                [
+                    egui::pos2(center.x - radius, center.y),
+                    egui::pos2(center.x + radius, center.y),
+                ],
+                cross,
+            );
+            painter.line_segment(
+                [
+                    egui::pos2(center.x, center.y - radius),
+                    egui::pos2(center.x, center.y + radius),
+                ],
+                cross,
+            );
+            let dot = egui::pos2(center.x + w.x * radius, center.y - w.y * radius);
+            painter.circle_filled(dot, 4.0, egui::Color32::WHITE);
+            painter.circle_stroke(
+                dot,
+                4.0,
+                egui::Stroke::new(1.0, egui::Color32::from_gray(30)),
+            );
+        }
+
+        ui.spacing_mut().slider_width = WHEEL - 24.0;
+        ui.add(egui::Slider::new(&mut w.luma, -1.0..=1.0).fixed_decimals(2));
+    });
+}
+
+/// Renders the three colour wheels (Lift / Gamma / Gain) plus a reset control.
+pub fn color_wheels_editor(ui: &mut egui::Ui, wheels: &mut ColorWheels) {
+    ui.horizontal(|ui| {
+        color_wheel(ui, "Lift", &mut wheels.lift);
+        color_wheel(ui, "Gamma", &mut wheels.gamma);
+        color_wheel(ui, "Gain", &mut wheels.gain);
+    });
+    ui.horizontal(|ui| {
+        let neutral = wheels.is_neutral();
+        if ui
+            .add_enabled(!neutral, egui::Button::new("Reset all"))
+            .clicked()
+        {
+            *wheels = ColorWheels::default();
+        }
+        ui.label("drag = colour · double-click = reset · slider = luminance");
+    });
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,4 +1,5 @@
 pub mod clip_browser;
+pub mod color_wheels;
 pub mod curve_editor;
 pub mod drain;
 pub mod monitor;

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -251,6 +251,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         width: src.info.primary_video().map(|v| v.width()).unwrap_or(0),
                         height: src.info.primary_video().map(|v| v.height()).unwrap_or(0),
                         curves: tc.curves.clone(),
+                        wheels: tc.wheels,
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -725,6 +726,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     .map(|v| v.height())
                     .unwrap_or(0),
                 curves: tc.curves.clone(),
+                wheels: tc.wheels,
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -811,6 +813,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                 .map(|v| v.height())
                                 .unwrap_or(0),
                             curves: tc.curves.clone(),
+                            wheels: tc.wheels,
                         };
                         let tracks = &state.timeline.tracks;
                         let audio_start = state.timeline.audio_track_start();
@@ -1083,6 +1086,12 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         .id_salt("tone_curves")
                         .show(ui, |ui| {
                             super::curve_editor::tone_curve_editor(ui, &mut clip.curves);
+                        });
+                    // 3-way colour corrector (lift/gamma/gain) via avio ThreeWayCC.
+                    egui::CollapsingHeader::new("Color Wheels")
+                        .id_salt("color_wheels")
+                        .show(ui, |ui| {
+                            super::color_wheels::color_wheels_editor(ui, &mut clip.wheels);
                         });
                     // 3D LUT (.cube) — export-only via avio Clip effect chain.
                     ui.horizontal(|ui| {
@@ -2941,6 +2950,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     .map(|v| v.height())
                     .unwrap_or(0),
                 curves: tc.curves.clone(),
+                wheels: tc.wheels,
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -3037,6 +3047,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             vignette_x: 50.0,
             vignette_y: 50.0,
             curves: state::ToneCurves::default(),
+            wheels: state::ColorWheels::default(),
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -3176,6 +3187,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 vignette_x: state.timeline.tracks[ti].clips[ci].vignette_x,
                 vignette_y: state.timeline.tracks[ti].clips[ci].vignette_y,
                 curves: state.timeline.tracks[ti].clips[ci].curves.clone(),
+                wheels: state.timeline.tracks[ti].clips[ci].wheels,
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }


### PR DESCRIPTION
## Summary

Adds a per-clip 3-way colour corrector with lift/gamma/gain colour wheels
(shadows/midtones/highlights), completing the colour grading panel #132 (after
LUT #148, white balance #149, HSL #150, vignette #151, tone curves #152). Each
wheel has a draggable colour dot and a luminance slider; the result is applied in
both the timeline preview and export through avio's `FilterStep::ThreeWayCC` via
the shared `apply_color_grade` chain, so the preview matches the rendered output.

## Changes

- **`state.rs`**: `ColorWheel { x, y, luma }` and `ColorWheels { lift, gamma, gain }`
  (serde-derived, `Copy`); `TimelineClip.wheels`. All-zero = neutral.
- **`export.rs`**: `ExportClip.wheels`; a `wheel_to_rgb` mapping (wheel colour →
  per-channel `Rgb`, neutral 1.0; R/G/B axes at 90°/210°/330°, `luma` shifts all
  channels, gamma clamped `> 0`); `apply_color_grade` attaches
  `FilterStep::ThreeWayCC` after Gamma and before Curves
  (`… → Gamma → ThreeWayCC → Curves → LUT → Vignette`), skipped when neutral.
  Unit test.
- **`player.rs`**: `TrackClipData.wheels`; `make_clip` forwards it.
- **`ui/color_wheels.rs`** (new): a 3-wheel editor — draggable dot per disk
  (clamped to the circle), double-click to reset a wheel, a luminance slider
  below each, and "Reset all".
- **`ui/timeline.rs`**: a "Color Wheels" `CollapsingHeader` in Clip Properties;
  `wheels` added at all construction sites. **`ui/mod.rs`**: module registered.
- **`clip_browser.rs` / `project.rs`**: defaults and save/load (serde default).

The wheels are per-pixel (resolution-independent), so no resolution plumbing is
needed. The wheel → lift/gamma/gain mapping is a demo approximation (avio's
`ThreeWayCC` is itself a 3-point curves model), noted in the module.

## Related Issues

Closes #153.

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes