### PR TITLE
feat(filter): per-clip stackable video effects

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -66,6 +66,8 @@ pub struct ExportClip {
     pub curves: crate::state::ToneCurves,
     /// Per-clip 3-way colour corrector. Attached via `FilterStep::ThreeWayCC`.
     pub wheels: crate::state::ColorWheels,
+    /// Per-clip stackable video effects (blur, sharpen, denoise, …).
+    pub video_effects: crate::state::VideoEffects,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -269,6 +271,68 @@ pub fn apply_color_grade(
     }
 }
 
+/// Attaches a clip's stackable video effects, in order
+/// (`Blur → Sharpen → Denoise → Grain → Glow → MotionBlur → ChromaticAberration`),
+/// skipping any whose intensity is `0.0`. Applied after [`apply_color_grade`] so
+/// effects act on the graded image. Shared by export and the timeline preview.
+#[allow(clippy::float_cmp)]
+pub fn apply_video_effects(clip: avio::Clip, fx: &crate::state::VideoEffects) -> avio::Clip {
+    let clip = if fx.blur > 0.0 {
+        clip.with_video_effect(avio::FilterStep::GBlur { sigma: fx.blur })
+    } else {
+        clip
+    };
+    let clip = if fx.sharpen > 0.0 {
+        clip.with_video_effect(avio::FilterStep::Unsharp {
+            luma_strength: fx.sharpen,
+            chroma_strength: fx.sharpen * 0.5,
+        })
+    } else {
+        clip
+    };
+    let clip = if fx.denoise > 0.0 {
+        clip.with_video_effect(avio::FilterStep::Hqdn3d {
+            luma_spatial: fx.denoise * 8.0,
+            chroma_spatial: fx.denoise * 6.0,
+            luma_tmp: fx.denoise * 6.0,
+            chroma_tmp: fx.denoise * 4.5,
+        })
+    } else {
+        clip
+    };
+    let clip = if fx.grain > 0.0 {
+        clip.with_video_effect(avio::FilterStep::FilmGrain {
+            luma_strength: fx.grain,
+            chroma_strength: fx.grain * 0.5,
+        })
+    } else {
+        clip
+    };
+    let clip = if fx.glow > 0.0 {
+        clip.with_video_effect(avio::FilterStep::Glow {
+            threshold: 0.6,
+            radius: 8.0,
+            intensity: fx.glow,
+        })
+    } else {
+        clip
+    };
+    let clip = if fx.motion_blur > 0.0 {
+        clip.with_video_effect(avio::FilterStep::MotionBlur {
+            shutter_angle_degrees: fx.motion_blur,
+            sub_frames: 8,
+        })
+    } else {
+        clip
+    };
+    if fx.chromatic_aberration > 0.0 {
+        let n = fx.chromatic_aberration.round() as i32;
+        clip.with_video_effect(avio::FilterStep::ChromaticAberration { rh: n, bh: -n })
+    } else {
+        clip
+    }
+}
+
 fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
     clips
         .into_iter()
@@ -330,6 +394,8 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
                 c.width,
                 c.height,
             );
+            // Stackable video effects, applied on top of the grade.
+            let clip = apply_video_effects(clip, &c.video_effects);
             #[allow(clippy::float_cmp)]
             let clip = if c.opacity != 1.0 {
                 clip.with_opacity(c.opacity)
@@ -987,6 +1053,38 @@ mod tests {
                 assert!(gamma.r > 0.0 && gamma.g > 0.0 && gamma.b > 0.0);
             }
             other => panic!("expected ThreeWayCC, got {other:?}"),
+        }
+    }
+
+    /// Active video effects attach one `FilterStep` each, in order; neutral is a
+    /// no-op.
+    #[test]
+    fn video_effects_attach_steps_in_order() {
+        use super::apply_video_effects;
+
+        let neutral = crate::state::VideoEffects::default();
+        let steps = apply_video_effects(avio::Clip::new("test.mp4"), &neutral).video_effect_chain();
+        assert!(steps.is_empty());
+
+        let fx = crate::state::VideoEffects {
+            blur: 4.0,
+            sharpen: 0.0,
+            denoise: 0.0,
+            grain: 0.0,
+            glow: 0.5,
+            motion_blur: 0.0,
+            chromatic_aberration: 3.0,
+        };
+        let steps = apply_video_effects(avio::Clip::new("test.mp4"), &fx).video_effect_chain();
+        assert_eq!(steps.len(), 3);
+        assert!(matches!(steps[0], avio::FilterStep::GBlur { .. }));
+        assert!(matches!(steps[1], avio::FilterStep::Glow { .. }));
+        match &steps[2] {
+            avio::FilterStep::ChromaticAberration { rh, bh } => {
+                assert_eq!(*rh, 3);
+                assert_eq!(*bh, -3);
+            }
+            other => panic!("expected ChromaticAberration, got {other:?}"),
         }
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -57,6 +57,8 @@ pub struct TrackClipData {
     pub curves: crate::state::ToneCurves,
     /// Per-clip 3-way colour corrector (lift / gamma / gain).
     pub wheels: crate::state::ColorWheels,
+    /// Per-clip stackable video effects.
+    pub video_effects: crate::state::VideoEffects,
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -456,6 +458,8 @@ pub fn spawn_timeline_player(
                 tc.width,
                 tc.height,
             );
+            // Stackable video effects, on top of the grade (matches export).
+            c = crate::export::apply_video_effects(c, &tc.video_effects);
             #[allow(clippy::float_cmp)]
             if tc.opacity != 1.0 {
                 c = c.with_opacity(tc.opacity);

--- a/src/project.rs
+++ b/src/project.rs
@@ -75,6 +75,8 @@ pub struct ProjectTimelineClip {
     pub curves: crate::state::ToneCurves,
     #[serde(default)]
     pub wheels: crate::state::ColorWheels,
+    #[serde(default)]
+    pub video_effects: crate::state::VideoEffects,
 }
 
 fn default_wb_temperature() -> u32 {
@@ -238,6 +240,7 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         vignette_y: tc.vignette_y,
         curves: tc.curves.clone(),
         wheels: tc.wheels,
+        video_effects: tc.video_effects,
     }
 }
 
@@ -281,6 +284,7 @@ fn project_to_timeline_clip(
         vignette_y: ptc.vignette_y,
         curves: ptc.curves.clone(),
         wheels: ptc.wheels,
+        video_effects: ptc.video_effects,
     })
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -543,6 +543,39 @@ impl ColorWheels {
     }
 }
 
+/// Per-clip stackable video effects. Each field is a single intensity (`0.0` =
+/// off); non-zero effects are attached in order via avio `FilterStep`s.
+#[derive(Clone, Copy, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct VideoEffects {
+    /// Gaussian blur radius (`GBlur` sigma, 0–10).
+    pub blur: f32,
+    /// Unsharp-mask sharpen amount (`Unsharp` luma strength, 0–1.5).
+    pub sharpen: f32,
+    /// Denoise strength (0–1) mapped to `Hqdn3d` spatial/temporal parameters.
+    pub denoise: f32,
+    /// Film-grain strength (`FilmGrain` luma strength, 0–100).
+    pub grain: f32,
+    /// Glow intensity (`Glow` intensity, 0–1).
+    pub glow: f32,
+    /// Motion-blur shutter angle in degrees (`MotionBlur`, 0–360).
+    pub motion_blur: f32,
+    /// Chromatic-aberration horizontal shift in pixels (`ChromaticAberration`, 0–10).
+    pub chromatic_aberration: f32,
+}
+
+impl VideoEffects {
+    /// `true` when no effect is active (every field `0.0`).
+    pub fn is_neutral(&self) -> bool {
+        self.blur == 0.0
+            && self.sharpen == 0.0
+            && self.denoise == 0.0
+            && self.grain == 0.0
+            && self.glow == 0.0
+            && self.motion_blur == 0.0
+            && self.chromatic_aberration == 0.0
+    }
+}
+
 #[derive(Clone, PartialEq)]
 pub struct TimelineClip {
     pub source_index: usize,
@@ -613,6 +646,8 @@ pub struct TimelineClip {
     pub curves: ToneCurves,
     /// Per-clip 3-way colour corrector (lift / gamma / gain). Default: neutral.
     pub wheels: ColorWheels,
+    /// Per-clip stackable video effects. Default: all off.
+    pub video_effects: VideoEffects,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -666,6 +666,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 vignette_y: 50.0,
                 curves: state::ToneCurves::default(),
                 wheels: state::ColorWheels::default(),
+                video_effects: state::VideoEffects::default(),
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -252,6 +252,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         height: src.info.primary_video().map(|v| v.height()).unwrap_or(0),
                         curves: tc.curves.clone(),
                         wheels: tc.wheels,
+                        video_effects: tc.video_effects,
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -727,6 +728,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     .unwrap_or(0),
                 curves: tc.curves.clone(),
                 wheels: tc.wheels,
+                video_effects: tc.video_effects,
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -814,6 +816,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                 .unwrap_or(0),
                             curves: tc.curves.clone(),
                             wheels: tc.wheels,
+                            video_effects: tc.video_effects,
                         };
                         let tracks = &state.timeline.tracks;
                         let audio_start = state.timeline.audio_track_start();
@@ -1092,6 +1095,46 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         .id_salt("color_wheels")
                         .show(ui, |ui| {
                             super::color_wheels::color_wheels_editor(ui, &mut clip.wheels);
+                        });
+                    // Stackable video effects via avio FilterSteps (blur, sharpen, …).
+                    egui::CollapsingHeader::new("Video Effects")
+                        .id_salt("video_effects")
+                        .show(ui, |ui| {
+                            let fx = &mut clip.video_effects;
+                            // Temporal filters (tblend / hqdn3d) need consecutive
+                            // frames; the realtime preview pushes a single frame, so
+                            // they only show during playback and on export.
+                            let temporal_note = "Temporal effect — shows during playback and on export, not on a paused frame.";
+                            ui.add(egui::Slider::new(&mut fx.blur, 0.0..=10.0).text("Blur"));
+                            ui.add(egui::Slider::new(&mut fx.sharpen, 0.0..=1.5).text("Sharpen"));
+                            ui.add(egui::Slider::new(&mut fx.denoise, 0.0..=1.0).text("Denoise"))
+                                .on_hover_text(temporal_note);
+                            ui.add(egui::Slider::new(&mut fx.grain, 0.0..=100.0).text("Grain"));
+                            ui.add(egui::Slider::new(&mut fx.glow, 0.0..=1.0).text("Glow"));
+                            ui.add(
+                                egui::Slider::new(&mut fx.motion_blur, 0.0..=360.0)
+                                    .text("Motion Blur"),
+                            )
+                            .on_hover_text(temporal_note);
+                            ui.add(
+                                egui::Slider::new(&mut fx.chromatic_aberration, 0.0..=10.0)
+                                    .text("Chromatic Aberration"),
+                            );
+                            ui.label(
+                                egui::RichText::new(
+                                    "Denoise / Motion Blur preview during playback & export",
+                                )
+                                .weak()
+                                .small(),
+                            );
+                            let off = fx.is_neutral();
+                            if ui
+                                .add_enabled(!off, egui::Button::new("Reset"))
+                                .on_hover_text("Reset all video effects")
+                                .clicked()
+                            {
+                                *fx = state::VideoEffects::default();
+                            }
                         });
                     // 3D LUT (.cube) — export-only via avio Clip effect chain.
                     ui.horizontal(|ui| {
@@ -2951,6 +2994,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     .unwrap_or(0),
                 curves: tc.curves.clone(),
                 wheels: tc.wheels,
+                video_effects: tc.video_effects,
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -3048,6 +3092,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             vignette_y: 50.0,
             curves: state::ToneCurves::default(),
             wheels: state::ColorWheels::default(),
+            video_effects: state::VideoEffects::default(),
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -3188,6 +3233,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 vignette_y: state.timeline.tracks[ti].clips[ci].vignette_y,
                 curves: state.timeline.tracks[ti].clips[ci].curves.clone(),
                 wheels: state.timeline.tracks[ti].clips[ci].wheels,
+                video_effects: state.timeline.tracks[ti].clips[ci].video_effects,
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }


### PR DESCRIPTION
## Summary

Adds a per-clip video-effects library with a single intensity control each,
stackable and applied in both the timeline preview and export via avio
`FilterStep`s. Covers blur, sharpen, denoise, film grain, glow, motion blur, and
chromatic aberration. Depends on the avio compound-step fix (itsakeyfut/avio#1253)
so the compound `Glow` effect builds in the realtime preview.

## Changes

- **`state.rs`**: `VideoEffects { blur, sharpen, denoise, grain, glow,
  motion_blur, chromatic_aberration }` (serde-derived, `Copy`, all `0.0` =
  neutral); `TimelineClip.video_effects`.
- **`export.rs`**: `ExportClip.video_effects`; `apply_video_effects` attaches one
  `FilterStep` per active effect in order (`GBlur`, `Unsharp`, `Hqdn3d`,
  `FilmGrain`, `Glow`, `MotionBlur`, `ChromaticAberration`), skipping zeros;
  applied after the colour grade in `clips_to_avio`. Unit test.
- **`player.rs`**: `TrackClipData.video_effects`; `make_clip` applies
  `apply_video_effects` after the grade so the preview matches export.
- **`ui/timeline.rs`**: a "Video Effects" `CollapsingHeader` in Clip Properties
  (one slider per effect + Reset). Denoise / Motion Blur carry a tooltip + note
  that they are temporal and show during playback and on export. All construction
  sites updated.
- **`clip_browser.rs` / `project.rs`**: defaults and save/load (serde default).

## Notes

Effects are per-pixel/temporal — no resolution plumbing. Verified via a pixel-diff
probe that each effect applies. Temporal effects (Motion Blur = `tblend`, the
temporal part of Denoise = `hqdn3d`) are visible during playback and on export but
not on a paused still (the realtime preview pushes a single frame with no
history); this preview limitation is recorded as an avio gap (`docs/issue66.md`).

## Related Issues

Closes #134.

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes