### PR TITLE
feat(timeline): per-clip transform — crop, rotate, flip

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -68,6 +68,8 @@ pub struct ExportClip {
     pub wheels: crate::state::ColorWheels,
     /// Per-clip stackable video effects (blur, sharpen, denoise, …).
     pub video_effects: crate::state::VideoEffects,
+    /// Per-clip geometric transform (crop / rotate / flip).
+    pub transform: crate::state::Transform,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -333,6 +335,89 @@ pub fn apply_video_effects(clip: avio::Clip, fx: &crate::state::VideoEffects) ->
     }
 }
 
+/// Attaches the per-clip geometric transform (crop → flip → rotate) as avio
+/// `FilterStep`s, applied *before* [`apply_color_grade`] so the grade and effects
+/// act on the transformed geometry. `width`/`height` are the source dimensions,
+/// used to convert crop edge-inset percentages to a pixel rectangle. Shared by
+/// export and the timeline preview so both apply the identical chain.
+///
+/// Crop is followed by a `Scale` back to the source `width`×`height`, so a crop
+/// is a "crop & zoom to fill" that keeps the frame at its original size. This is
+/// deliberate: a bare `Crop` yields a smaller frame, which the preview auto-fits
+/// to the monitor (appears zoomed) while the export overlays it at native size on
+/// the canvas (appears small on black) — the two would diverge. Scaling back to
+/// the source size makes preview and export identical. A true letterbox crop
+/// needs project canvas / aspect plumbing (deferred, see #135 scope note).
+///
+/// (Separately, the realtime preview used to freeze on any frame whose size
+/// changed mid-graph; that avio gap is fixed — docs/issue67.md.)
+#[allow(clippy::float_cmp)]
+pub fn apply_transform(
+    clip: avio::Clip,
+    t: &crate::state::Transform,
+    width: u32,
+    height: u32,
+) -> avio::Clip {
+    // Crop: convert edge insets (%) to an even-aligned pixel rectangle, then
+    // scale the cropped region back to the source size (see the fn docs).
+    let clip = if width > 0
+        && height > 0
+        && (t.crop_left > 0.0 || t.crop_right > 0.0 || t.crop_top > 0.0 || t.crop_bottom > 0.0)
+    {
+        // Round to the nearest even value (yuv420 chroma requires even offsets/sizes).
+        let round_even = |v: f32| -> u32 {
+            let n = v.round().max(0.0) as u32;
+            n & !1
+        };
+        let x = round_even(width as f32 * t.crop_left / 100.0);
+        let right = round_even(width as f32 * t.crop_right / 100.0);
+        let y = round_even(height as f32 * t.crop_top / 100.0);
+        let bottom = round_even(height as f32 * t.crop_bottom / 100.0);
+        let crop_w = width.saturating_sub(x + right) & !1;
+        let crop_h = height.saturating_sub(y + bottom) & !1;
+        if crop_w >= 2 && crop_h >= 2 {
+            clip.with_video_effect(avio::FilterStep::Crop {
+                x,
+                y,
+                width: crop_w,
+                height: crop_h,
+            })
+            .with_video_effect(avio::FilterStep::Scale {
+                width,
+                height,
+                algorithm: avio::ScaleAlgorithm::Bicubic,
+            })
+        } else {
+            log::warn!(
+                "apply_transform: crop insets exceed frame ({}x{}); skipping crop",
+                width,
+                height
+            );
+            clip
+        }
+    } else {
+        clip
+    };
+    let clip = if t.flip_h {
+        clip.with_video_effect(avio::FilterStep::HFlip)
+    } else {
+        clip
+    };
+    let clip = if t.flip_v {
+        clip.with_video_effect(avio::FilterStep::VFlip)
+    } else {
+        clip
+    };
+    if t.rotation != 0.0 {
+        clip.with_video_effect(avio::FilterStep::Rotate {
+            angle_degrees: t.rotation as f64,
+            fill_color: "black".to_string(),
+        })
+    } else {
+        clip
+    }
+}
+
 fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
     clips
         .into_iter()
@@ -371,6 +456,9 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
                 Some(kind) => clip.with_transition(kind, c.transition_duration),
                 None => clip,
             };
+            // Geometric transform (crop → flip → rotate) applied before the grade
+            // so grading/effects act on the transformed image. Shared with preview.
+            let clip = apply_transform(clip, &c.transform, c.width, c.height);
             // Colour grading chain (Eq → WB → Hue → Gamma → ThreeWayCC → Curves → LUT → Vignette). Built from the
             // shared `apply_color_grade` so export and the preview
             // (`Clip::apply_video_effects`) apply the identical chain.
@@ -1085,6 +1173,107 @@ mod tests {
                 assert_eq!(*bh, -3);
             }
             other => panic!("expected ChromaticAberration, got {other:?}"),
+        }
+    }
+
+    /// A neutral transform attaches no steps.
+    #[test]
+    fn transform_neutral_produces_no_step() {
+        use super::apply_transform;
+
+        let t = crate::state::Transform::default();
+        let steps =
+            apply_transform(avio::Clip::new("test.mp4"), &t, 1920, 1080).video_effect_chain();
+        assert!(steps.is_empty());
+    }
+
+    /// Crop edge insets map to an even-aligned pixel rectangle.
+    #[test]
+    fn crop_insets_map_to_even_rect() {
+        use super::apply_transform;
+
+        let t = crate::state::Transform {
+            crop_left: 10.0,   // 192 px
+            crop_right: 10.0,  // 192 px
+            crop_top: 25.0,    // 270 px
+            crop_bottom: 25.0, // 270 px
+            ..Default::default()
+        };
+        let steps =
+            apply_transform(avio::Clip::new("test.mp4"), &t, 1920, 1080).video_effect_chain();
+        // Crop is followed by a Scale back to the source size (crop & zoom to fill).
+        assert_eq!(steps.len(), 2);
+        match &steps[0] {
+            avio::FilterStep::Crop {
+                x,
+                y,
+                width,
+                height,
+            } => {
+                assert_eq!(*x, 192);
+                assert_eq!(*y, 270);
+                assert_eq!(*width, 1920 - 192 - 192); // 1536
+                assert_eq!(*height, 1080 - 270 - 270); // 540
+                // All even.
+                assert_eq!(*x % 2, 0);
+                assert_eq!(*y % 2, 0);
+                assert_eq!(*width % 2, 0);
+                assert_eq!(*height % 2, 0);
+            }
+            other => panic!("expected Crop, got {other:?}"),
+        }
+        match &steps[1] {
+            avio::FilterStep::Scale { width, height, .. } => {
+                assert_eq!(*width, 1920);
+                assert_eq!(*height, 1080);
+            }
+            other => panic!("expected Scale, got {other:?}"),
+        }
+    }
+
+    /// Crop insets that exceed the frame skip the crop step entirely.
+    #[test]
+    fn crop_insets_exceeding_frame_skip() {
+        use super::apply_transform;
+
+        let t = crate::state::Transform {
+            crop_left: 45.0,
+            crop_right: 45.0,
+            crop_top: 45.0,
+            crop_bottom: 45.0,
+            ..Default::default()
+        };
+        // On a tiny 8×8 source the insets round to 4 px per side, leaving a
+        // 0 px residual (< 2), forcing the skip path.
+        let steps = apply_transform(avio::Clip::new("test.mp4"), &t, 8, 8).video_effect_chain();
+        assert!(steps.is_empty());
+    }
+
+    /// Flips and rotation emit steps in order (flip H → flip V → rotate).
+    #[test]
+    fn flip_and_rotation_emit_steps_in_order() {
+        use super::apply_transform;
+
+        let t = crate::state::Transform {
+            rotation: 30.0,
+            flip_h: true,
+            flip_v: true,
+            ..Default::default()
+        };
+        let steps =
+            apply_transform(avio::Clip::new("test.mp4"), &t, 1920, 1080).video_effect_chain();
+        assert_eq!(steps.len(), 3);
+        assert!(matches!(steps[0], avio::FilterStep::HFlip));
+        assert!(matches!(steps[1], avio::FilterStep::VFlip));
+        match &steps[2] {
+            avio::FilterStep::Rotate {
+                angle_degrees,
+                fill_color,
+            } => {
+                assert!((*angle_degrees - 30.0).abs() < 1e-9);
+                assert_eq!(fill_color, "black");
+            }
+            other => panic!("expected Rotate, got {other:?}"),
         }
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -59,6 +59,8 @@ pub struct TrackClipData {
     pub wheels: crate::state::ColorWheels,
     /// Per-clip stackable video effects.
     pub video_effects: crate::state::VideoEffects,
+    /// Per-clip geometric transform (crop / rotate / flip).
+    pub transform: crate::state::Transform,
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -435,6 +437,9 @@ pub fn spawn_timeline_player(
             if let Some(kind) = tc.transition {
                 c = c.with_transition(kind, tc.transition_duration);
             }
+            // Geometric transform (crop → flip → rotate) applied before the grade,
+            // matching export so the monitor reflects the rendered geometry.
+            c = crate::export::apply_transform(c, &tc.transform, tc.width, tc.height);
             // Full colour grade (Eq → WB → Hue → Gamma → ThreeWayCC → Curves → LUT → Vignette), shared with export.
             // The preview player applies these via avio's RealtimeComposer, so the
             // monitor matches the rendered output without any host-side re-grading.

--- a/src/project.rs
+++ b/src/project.rs
@@ -77,6 +77,8 @@ pub struct ProjectTimelineClip {
     pub wheels: crate::state::ColorWheels,
     #[serde(default)]
     pub video_effects: crate::state::VideoEffects,
+    #[serde(default)]
+    pub transform: crate::state::Transform,
 }
 
 fn default_wb_temperature() -> u32 {
@@ -241,6 +243,7 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         curves: tc.curves.clone(),
         wheels: tc.wheels,
         video_effects: tc.video_effects,
+        transform: tc.transform,
     }
 }
 
@@ -285,6 +288,7 @@ fn project_to_timeline_clip(
         curves: ptc.curves.clone(),
         wheels: ptc.wheels,
         video_effects: ptc.video_effects,
+        transform: ptc.transform,
     })
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -581,6 +581,40 @@ impl VideoEffects {
     }
 }
 
+/// Per-clip geometric transform: crop (edge insets), free rotation, and flips.
+/// Neutral (`Default`) = no transform; non-neutral fields are attached in order
+/// via avio `FilterStep`s (`Crop` → `HFlip`/`VFlip` → `Rotate`) before grading.
+#[derive(Clone, Copy, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Transform {
+    /// Crop inset from the left edge, as a percentage of width (0.0–45.0).
+    pub crop_left: f32,
+    /// Crop inset from the right edge, as a percentage of width (0.0–45.0).
+    pub crop_right: f32,
+    /// Crop inset from the top edge, as a percentage of height (0.0–45.0).
+    pub crop_top: f32,
+    /// Crop inset from the bottom edge, as a percentage of height (0.0–45.0).
+    pub crop_bottom: f32,
+    /// Free rotation in degrees, clockwise (−180.0–180.0). `0.0` = no rotation.
+    pub rotation: f32,
+    /// Horizontal flip (mirror left–right).
+    pub flip_h: bool,
+    /// Vertical flip (mirror top–bottom).
+    pub flip_v: bool,
+}
+
+impl Transform {
+    /// `true` when no transform is active (no crop, no rotation, no flip).
+    pub fn is_neutral(&self) -> bool {
+        self.crop_left == 0.0
+            && self.crop_right == 0.0
+            && self.crop_top == 0.0
+            && self.crop_bottom == 0.0
+            && self.rotation == 0.0
+            && !self.flip_h
+            && !self.flip_v
+    }
+}
+
 #[derive(Clone, PartialEq)]
 pub struct TimelineClip {
     pub source_index: usize,
@@ -653,6 +687,8 @@ pub struct TimelineClip {
     pub wheels: ColorWheels,
     /// Per-clip stackable video effects. Default: all off.
     pub video_effects: VideoEffects,
+    /// Per-clip geometric transform (crop / rotate / flip). Default: neutral.
+    pub transform: Transform,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -667,6 +667,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 curves: state::ToneCurves::default(),
                 wheels: state::ColorWheels::default(),
                 video_effects: state::VideoEffects::default(),
+                transform: state::Transform::default(),
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -208,8 +208,8 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                 .id_salt("clip_properties")
                 .default_open(true)
                 .show(ui, |ui| {
-                    egui::CollapsingHeader::new("Transform")
-                        .id_salt("clip_transform")
+                    egui::CollapsingHeader::new("Speed & Compositing")
+                        .id_salt("clip_speed_compositing")
                         .default_open(true)
                         .show(ui, |ui| {
                     ui.horizontal(|ui| {
@@ -262,6 +262,63 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                                 });
                         });
                     }
+                        });
+                    egui::CollapsingHeader::new("Transform")
+                        .id_salt("clip_transform")
+                        .default_open(false)
+                        .show(ui, |ui| {
+                    ui.label("Crop (edge insets)");
+                    ui.horizontal_wrapped(|ui| {
+                        ui.label("Left");
+                        ui.add(
+                            egui::Slider::new(&mut clip.transform.crop_left, 0.0..=45.0)
+                                .suffix(" %")
+                                .fixed_decimals(1),
+                        );
+                        ui.separator();
+                        ui.label("Right");
+                        ui.add(
+                            egui::Slider::new(&mut clip.transform.crop_right, 0.0..=45.0)
+                                .suffix(" %")
+                                .fixed_decimals(1),
+                        );
+                    });
+                    ui.horizontal_wrapped(|ui| {
+                        ui.label("Top");
+                        ui.add(
+                            egui::Slider::new(&mut clip.transform.crop_top, 0.0..=45.0)
+                                .suffix(" %")
+                                .fixed_decimals(1),
+                        );
+                        ui.separator();
+                        ui.label("Bottom");
+                        ui.add(
+                            egui::Slider::new(&mut clip.transform.crop_bottom, 0.0..=45.0)
+                                .suffix(" %")
+                                .fixed_decimals(1),
+                        );
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("Rotation");
+                        ui.add(
+                            egui::Slider::new(&mut clip.transform.rotation, -180.0..=180.0)
+                                .suffix(" °")
+                                .fixed_decimals(1),
+                        );
+                    });
+                    ui.horizontal(|ui| {
+                        ui.checkbox(&mut clip.transform.flip_h, "Flip H");
+                        ui.checkbox(&mut clip.transform.flip_v, "Flip V");
+                        if ui
+                            .add_enabled(
+                                !clip.transform.is_neutral(),
+                                egui::Button::new("Reset"),
+                            )
+                            .clicked()
+                        {
+                            clip.transform = state::Transform::default();
+                        }
+                    });
                         });
                     egui::CollapsingHeader::new("Color Grading")
                         .id_salt("clip_color_grading")
@@ -639,6 +696,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         curves: tc.curves.clone(),
                         wheels: tc.wheels,
                         video_effects: tc.video_effects,
+                        transform: tc.transform,
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -1115,6 +1173,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 curves: tc.curves.clone(),
                 wheels: tc.wheels,
                 video_effects: tc.video_effects,
+                transform: tc.transform,
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -1203,6 +1262,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             curves: tc.curves.clone(),
                             wheels: tc.wheels,
                             video_effects: tc.video_effects,
+                            transform: tc.transform,
                         };
                         let tracks = &state.timeline.tracks;
                         let audio_start = state.timeline.audio_track_start();
@@ -3035,6 +3095,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 curves: tc.curves.clone(),
                 wheels: tc.wheels,
                 video_effects: tc.video_effects,
+                transform: tc.transform,
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -3133,6 +3194,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             curves: state::ToneCurves::default(),
             wheels: state::ColorWheels::default(),
             video_effects: state::VideoEffects::default(),
+            transform: state::Transform::default(),
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -3274,6 +3336,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 curves: state.timeline.tracks[ti].clips[ci].curves.clone(),
                 wheels: state.timeline.tracks[ti].clips[ci].wheels,
                 video_effects: state.timeline.tracks[ti].clips[ci].video_effects,
+                transform: state.timeline.tracks[ti].clips[ci].transform,
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }


### PR DESCRIPTION
## Summary

Adds a per-clip **Transform** section (crop, free rotation, horizontal/vertical flip) to the clip inspector, applied identically in the timeline preview and on export via avio `FilterStep`s. This delivers the crop/rotate/flip layer of #135; the project aspect-ratio presets (9:16 / 1:1 / 4:5) and per-clip fit/fill are intentionally deferred to a follow-up (they need a target canvas plumbed into the preview and overlap with Export social presets #147).

## Changes

- **State** (`src/state.rs`): new `Transform` struct (crop L/R/T/B %, `rotation`°, `flip_h`/`flip_v`) with `is_neutral()`; added to `TimelineClip`.
- **avio mapping** (`src/export.rs`): shared `apply_transform()` emits `Crop → HFlip → VFlip → Rotate`, applied before the colour grade so geometry precedes colour. Crop converts edge insets to an even-aligned pixel rect (yuv420-safe) and is followed by a `Scale` back to the source size — a deliberate "crop & zoom to fill" that keeps the frame size constant so preview and export match (a true letterbox crop needs the deferred canvas/aspect work). Degenerate crops (insets ≥ frame) are skipped with a warning.
- **Preview** (`src/player.rs`): `TrackClipData.transform`; `make_clip` runs `apply_transform` before the grade, so the monitor reflects the exported geometry.
- **UI** (`src/ui/timeline.rs`): new collapsible **Transform** section (crop sliders, rotation slider, flip toggles, Reset). The prior "Transform" group (speed/opacity/blend) is renamed **Speed & Compositing** to free the name for the geometric section.
- **Persistence** (`src/project.rs`): `transform` saved/loaded round-trips.
- Plumbed `transform` through every clip construction site.
- Unit tests: neutral no-op, crop → even rect + zoom-back `Scale`, degenerate-crop skip, flip/rotation ordering.

## avio dependency

Cropping a V1 clip froze the preview: the realtime runner pushed composited frames tagged with the decoded (pre-effect) dimensions, so any dimension-changing base-layer effect mismatched the buffer length and was dropped. Fixed on the avio side (`fix/realtime-composite-frame-dimensions`): `composite_frame` now returns and the runner pushes the composited frame's real size. The demo's zoom-back `Scale` keeps crop at a constant size regardless, so preview and export stay identical.

## Related Issues

Part of #135

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes