### PR TITLE
feat(export): aspect-ratio presets & per-clip fit/fill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -239,7 +239,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -484,7 +484,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "avio"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ff-common",
  "ff-decode",
@@ -1242,7 +1242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1295,14 +1295,14 @@ dependencies = [
 
 [[package]]
 name = "ff-common"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "ff-decode"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ff-common",
  "ff-format",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "ff-encode"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ff-format",
  "ff-sys",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "ff-filter"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ff-common",
  "ff-format",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "ff-format"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ff-common",
  "log",
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "ff-pipeline"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ff-common",
  "ff-decode",
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "ff-preview"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ff-decode",
  "ff-encode",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "ff-probe"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ff-format",
  "ff-sys",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sys"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bindgen",
  "log",
@@ -3133,7 +3133,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3380,7 +3380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3442,7 +3442,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3656,7 +3656,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4138,7 +4138,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/export.rs
+++ b/src/export.rs
@@ -90,6 +90,10 @@ pub struct ExportSnapshot {
     pub export_in: Option<Duration>,
     /// Export out-point. `Some` only when export range mode is active.
     pub export_out: Option<Duration>,
+    /// Project aspect-ratio canvas (from `AspectPreset::dims`). When `Some`, every
+    /// clip is re-framed (fit/fill) to these dimensions and the export container is
+    /// this size. `None` = `Original` (no reframe).
+    pub canvas: Option<(u32, u32)>,
 }
 
 /// A single entry in the export queue.
@@ -418,7 +422,114 @@ pub fn apply_transform(
     }
 }
 
-fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
+/// Rounds `v` down to the nearest even `u32` (yuv420 chroma needs even sizes).
+fn even_floor(v: f32) -> u32 {
+    let n = v.round().max(0.0) as u32;
+    n & !1
+}
+
+/// Re-frames a clip into the project canvas (`canvas_w`×`canvas_h`) according to
+/// `fit_mode`, as avio `FilterStep`s. Applied *last* (after grade + effects) so the
+/// grade acts on the source-framed image and reframing is the final output step.
+/// `src_w`/`src_h` are the clip's source dimensions (the frame size entering this
+/// step, since crop already scales back to source size).
+///
+/// - [`FitMode::Fill`] → centre-crop the source to the canvas aspect ratio, then
+///   scale to the canvas (cover, edges cropped).
+/// - [`FitMode::Fit`] → scale the source to fit inside the canvas, then centre-pad
+///   to the canvas (letterbox / pillarbox).
+///
+/// Both are built **crop/scale-before-resize** deliberately, avoiding two avio
+/// realtime-composer bugs: a large-offset `Crop` after a large up-`Scale` segfaults
+/// (docs/issue69.md), and `FitToAspect` is not padded in the realtime composer
+/// (docs/issue70.md). Cropping the small source first (small offsets) then scaling,
+/// and using an explicit `Scale`+`Pad`, sidestep both while producing identical
+/// preview and export framing. No-op when the source already matches the canvas or
+/// has no video dimensions.
+pub fn apply_aspect(
+    clip: avio::Clip,
+    fit_mode: crate::state::FitMode,
+    src_w: u32,
+    src_h: u32,
+    canvas_w: u32,
+    canvas_h: u32,
+) -> avio::Clip {
+    if src_w == 0 || src_h == 0 || canvas_w == 0 || canvas_h == 0 {
+        return clip;
+    }
+    if src_w == canvas_w && src_h == canvas_h {
+        return clip;
+    }
+    // Aspect ratios as cross-multiplied integers to avoid float compares.
+    let src_wider = src_w * canvas_h > canvas_w * src_h;
+    match fit_mode {
+        crate::state::FitMode::Fill => {
+            // Cover: crop the source to the canvas aspect ratio (centred), then scale
+            // the cropped region up to the canvas. Cropping the source first keeps the
+            // crop offset small (no large-scale crash).
+            let (crop_w, crop_h) = if src_wider {
+                // Source is wider than the canvas → crop the sides.
+                (
+                    even_floor(src_h as f32 * canvas_w as f32 / canvas_h as f32).min(src_w & !1),
+                    src_h & !1,
+                )
+            } else {
+                // Source is taller/narrower → crop top and bottom.
+                (
+                    src_w & !1,
+                    even_floor(src_w as f32 * canvas_h as f32 / canvas_w as f32).min(src_h & !1),
+                )
+            };
+            let x = even_floor((src_w.saturating_sub(crop_w)) as f32 / 2.0);
+            let y = even_floor((src_h.saturating_sub(crop_h)) as f32 / 2.0);
+            clip.with_video_effect(avio::FilterStep::Crop {
+                x,
+                y,
+                width: crop_w,
+                height: crop_h,
+            })
+            .with_video_effect(avio::FilterStep::Scale {
+                width: canvas_w,
+                height: canvas_h,
+                algorithm: avio::ScaleAlgorithm::Bicubic,
+            })
+        }
+        crate::state::FitMode::Fit => {
+            // Letterbox: scale the source to fit inside the canvas (preserving AR),
+            // then centre-pad to the canvas. Explicit Scale+Pad because the realtime
+            // composer does not pad `FitToAspect` (docs/issue70.md).
+            let (fit_w, fit_h) = if src_wider {
+                // Constrained by width.
+                (
+                    canvas_w & !1,
+                    even_floor(src_h as f32 * canvas_w as f32 / src_w as f32).min(canvas_h & !1),
+                )
+            } else {
+                // Constrained by height.
+                (
+                    even_floor(src_w as f32 * canvas_h as f32 / src_h as f32).min(canvas_w & !1),
+                    canvas_h & !1,
+                )
+            };
+            let x = ((canvas_w.saturating_sub(fit_w)) / 2) as i32;
+            let y = ((canvas_h.saturating_sub(fit_h)) / 2) as i32;
+            clip.with_video_effect(avio::FilterStep::Scale {
+                width: fit_w,
+                height: fit_h,
+                algorithm: avio::ScaleAlgorithm::Bicubic,
+            })
+            .with_video_effect(avio::FilterStep::Pad {
+                width: canvas_w,
+                height: canvas_h,
+                x,
+                y,
+                color: "black".to_string(),
+            })
+        }
+    }
+}
+
+fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio::Clip> {
     clips
         .into_iter()
         .map(|c| {
@@ -484,6 +595,14 @@ fn clips_to_avio(clips: Vec<ExportClip>) -> Vec<avio::Clip> {
             );
             // Stackable video effects, applied on top of the grade.
             let clip = apply_video_effects(clip, &c.video_effects);
+            // Re-frame into the project canvas (fit/fill) — the final video step,
+            // shared with the preview so both match. No-op when aspect is Original.
+            let clip = match canvas {
+                Some((cw, ch)) => {
+                    apply_aspect(clip, c.transform.fit_mode, c.width, c.height, cw, ch)
+                }
+                None => clip,
+            };
             #[allow(clippy::float_cmp)]
             let clip = if c.opacity != 1.0 {
                 clip.with_opacity(c.opacity)
@@ -684,11 +803,28 @@ fn build_and_render(
         })
         .fold(0.0_f64, f64::max);
 
+    // Effective output canvas: the aspect preset (if any) overrides the manual
+    // "Scale output" dimensions. `reframe_canvas` (Some only when an aspect preset
+    // is active) is what drives the per-clip fit/fill reframe.
+    let reframe_canvas = snapshot.canvas;
+    let builder_canvas = reframe_canvas.or(if snapshot.export_filters.scale_enabled {
+        Some((
+            snapshot.export_filters.output_width,
+            snapshot.export_filters.output_height,
+        ))
+    } else {
+        None
+    });
+    let (overlay_w, overlay_h) = builder_canvas.unwrap_or((
+        snapshot.export_filters.output_width,
+        snapshot.export_filters.output_height,
+    ));
+
     let lavfi_overlay = if timeline_dur_secs > 0.0 {
         build_lavfi_overlay_filter(
             &snapshot.title_clips,
-            snapshot.export_filters.output_width,
-            snapshot.export_filters.output_height,
+            overlay_w,
+            overlay_h,
             timeline_dur_secs,
         )
     } else {
@@ -704,9 +840,9 @@ fn build_and_render(
     let avio_video: Vec<Vec<avio::Clip>> = snapshot
         .video_clips
         .into_iter()
-        .map(clips_to_avio)
+        .map(|track| clips_to_avio(track, reframe_canvas))
         .collect();
-    let a1 = clips_to_avio(snapshot.a1_clips);
+    let a1 = clips_to_avio(snapshot.a1_clips, reframe_canvas);
 
     if avio_video.is_empty() || avio_video[0].is_empty() {
         return Err("V1 track has no clips to export".to_string());
@@ -716,11 +852,8 @@ fn build_and_render(
 
     let mut builder = avio::Timeline::builder().video_track(avio_video[0].clone());
 
-    if snapshot.export_filters.scale_enabled {
-        builder = builder.canvas(
-            snapshot.export_filters.output_width,
-            snapshot.export_filters.output_height,
-        );
+    if let Some((cw, ch)) = builder_canvas {
+        builder = builder.canvas(cw, ch);
     }
 
     // avio API gap: TimelineBuilder has no audio_filter() method.
@@ -1274,6 +1407,114 @@ mod tests {
                 assert_eq!(fill_color, "black");
             }
             other => panic!("expected Rotate, got {other:?}"),
+        }
+    }
+
+    /// A source already matching the canvas emits no aspect step.
+    #[test]
+    fn aspect_matching_size_produces_no_step() {
+        use super::apply_aspect;
+        use crate::state::FitMode;
+
+        let steps = apply_aspect(
+            avio::Clip::new("test.mp4"),
+            FitMode::Fill,
+            1920,
+            1080,
+            1920,
+            1080,
+        )
+        .video_effect_chain();
+        assert!(steps.is_empty());
+    }
+
+    /// Fit mode scales the source to fit inside the canvas, then centre-pads to it
+    /// (letterbox). Scale comes before Pad so both are within canvas bounds.
+    #[test]
+    fn aspect_fit_scales_then_pads() {
+        use super::apply_aspect;
+        use crate::state::FitMode;
+
+        // 16:9 source (1920×1080) into a 9:16 canvas (1080×1920): width-constrained,
+        // scaled to 1080×608, padded top/bottom to 1080×1920.
+        let steps = apply_aspect(
+            avio::Clip::new("test.mp4"),
+            FitMode::Fit,
+            1920,
+            1080,
+            1080,
+            1920,
+        )
+        .video_effect_chain();
+        assert_eq!(steps.len(), 2);
+        let (fw, fh) = match &steps[0] {
+            avio::FilterStep::Scale { width, height, .. } => (*width, *height),
+            other => panic!("expected Scale, got {other:?}"),
+        };
+        assert_eq!(fw, 1080);
+        assert!(fh <= 1920 && fh % 2 == 0);
+        match &steps[1] {
+            avio::FilterStep::Pad {
+                width,
+                height,
+                x,
+                y,
+                color,
+            } => {
+                assert_eq!(*width, 1080);
+                assert_eq!(*height, 1920);
+                assert_eq!(*x, 0);
+                assert_eq!(*y, ((1920 - fh) / 2) as i32);
+                assert_eq!(color, "black");
+            }
+            other => panic!("expected Pad, got {other:?}"),
+        }
+    }
+
+    /// Fill mode centre-crops the source to the canvas aspect ratio, then scales up
+    /// to the canvas. Cropping the small source first keeps the crop offset small
+    /// (avoids the large-scale crop crash — docs/issue69.md).
+    #[test]
+    fn aspect_fill_crops_then_scales() {
+        use super::apply_aspect;
+        use crate::state::FitMode;
+
+        // 16:9 source into a 9:16 canvas: crop the sides to 9:16, then scale up.
+        let steps = apply_aspect(
+            avio::Clip::new("test.mp4"),
+            FitMode::Fill,
+            1920,
+            1080,
+            1080,
+            1920,
+        )
+        .video_effect_chain();
+        assert_eq!(steps.len(), 2);
+        let (cx, cw, ch) = match &steps[0] {
+            avio::FilterStep::Crop {
+                x,
+                y,
+                width,
+                height,
+            } => {
+                assert_eq!(*y, 0);
+                // Crop is narrower than the source and even-aligned, within bounds.
+                assert!(*width < 1920 && *width % 2 == 0);
+                assert_eq!(*height, 1080);
+                assert!(*x + *width <= 1920);
+                (*x, *width, *height)
+            }
+            other => panic!("expected Crop, got {other:?}"),
+        };
+        // Centre crop.
+        assert_eq!(cx, (1920 - cw) / 2 & !1);
+        assert_eq!(ch, 1080);
+        match &steps[1] {
+            avio::FilterStep::Scale { width, height, .. } => {
+                assert_eq!(*width, 1080);
+                assert_eq!(*height, 1920);
+            }
+            other => panic!("expected Scale, got {other:?}"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -343,6 +343,24 @@ impl eframe::App for AvioEditorApp {
                         }
                     }
                 });
+                ui.separator();
+                ui.label("Aspect");
+                egui::ComboBox::from_id_salt("project_aspect")
+                    .selected_text(self.state.project_aspect.label())
+                    .show_ui(ui, |ui| {
+                        for preset in state::AspectPreset::ALL {
+                            ui.selectable_value(
+                                &mut self.state.project_aspect,
+                                preset,
+                                preset.label(),
+                            );
+                        }
+                    })
+                    .response
+                    .on_hover_text(
+                        "Project output aspect ratio. Re-frames the preview and export; \
+                         applies on the next ▶ Play. Per-clip Fit/Fill is set in the Transform section.",
+                    );
             });
         });
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -413,6 +413,7 @@ pub fn spawn_timeline_player(
     ctx: egui::Context,
     start_pos: Duration,
     cpal_rate: Arc<AtomicU64>,
+    canvas: Option<(u32, u32)>,
 ) -> (std::thread::JoinHandle<()>, mpsc::Receiver<PlayerHandle>) {
     let (handle_tx, handle_rx) = mpsc::sync_channel::<PlayerHandle>(1);
 
@@ -465,6 +466,18 @@ pub fn spawn_timeline_player(
             );
             // Stackable video effects, on top of the grade (matches export).
             c = crate::export::apply_video_effects(c, &tc.video_effects);
+            // Re-frame into the project canvas (fit/fill) — final video step, matches
+            // export. No-op when no aspect preset is active.
+            if let Some((cw, ch)) = canvas {
+                c = crate::export::apply_aspect(
+                    c,
+                    tc.transform.fit_mode,
+                    tc.width,
+                    tc.height,
+                    cw,
+                    ch,
+                );
+            }
             #[allow(clippy::float_cmp)]
             if tc.opacity != 1.0 {
                 c = c.with_opacity(tc.opacity);

--- a/src/project.rs
+++ b/src/project.rs
@@ -25,6 +25,8 @@ pub struct ProjectFile {
     pub export_range_enabled: bool,
     pub timeline_loop_enabled: bool,
     pub pixels_per_second: f32,
+    #[serde(default)]
+    pub project_aspect: crate::state::AspectPreset,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -367,6 +369,7 @@ pub fn save_project(state: &AppState, path: &Path) -> Result<(), String> {
         export_range_enabled: state.export_range_enabled,
         timeline_loop_enabled: state.timeline_loop_enabled,
         pixels_per_second: state.timeline.pixels_per_second,
+        project_aspect: state.project_aspect,
     };
 
     let file = std::fs::File::create(path).map_err(|e| e.to_string())?;
@@ -500,6 +503,7 @@ pub fn load_project(state: &mut AppState, path: &Path) -> Result<Vec<String>, St
     state.export_range_enabled = project.export_range_enabled;
     state.timeline_loop_enabled = project.timeline_loop_enabled;
     state.timeline.pixels_per_second = project.pixels_per_second;
+    state.project_aspect = project.project_aspect;
 
     // Regenerate clip browser thumbnails, sprite sheets, scenes, waveforms, and
     // silence regions — these are not serialized and must be rebuilt from source.

--- a/src/state.rs
+++ b/src/state.rs
@@ -159,6 +159,9 @@ pub struct AppState {
     pub export_use_proxies: bool,
     /// Index into `TimelineState::title_clips` of the currently selected title clip.
     pub selected_title_clip: Option<usize>,
+    /// Project-level output aspect ratio. Drives both the preview reframe and the
+    /// export canvas. `Original` = no reframe (each clip keeps its source framing).
+    pub project_aspect: AspectPreset,
     /// Persisted width of the right inspector panel. Fed back as the panel's
     /// `default_width` each frame so the width survives even when egui drops its
     /// own `PanelState` (which happens during continuous playback repaints).
@@ -248,6 +251,7 @@ impl Default for AppState {
             export_range_enabled: false,
             export_use_proxies: false,
             selected_title_clip: None,
+            project_aspect: AspectPreset::default(),
             inspector_width: 320.0,
             browser_tab: BrowserTab::Media,
             text_presets: Vec::new(),
@@ -600,10 +604,16 @@ pub struct Transform {
     pub flip_h: bool,
     /// Vertical flip (mirror top–bottom).
     pub flip_v: bool,
+    /// How this clip is fitted into the project canvas when a non-`Original`
+    /// [`AspectPreset`] is active. Irrelevant when the aspect is `Original`.
+    #[serde(default)]
+    pub fit_mode: FitMode,
 }
 
 impl Transform {
-    /// `true` when no transform is active (no crop, no rotation, no flip).
+    /// `true` when no geometric transform is active (no crop, no rotation, no
+    /// flip). `fit_mode` is a framing mode, not a value to reset, so it is
+    /// intentionally excluded.
     pub fn is_neutral(&self) -> bool {
         self.crop_left == 0.0
             && self.crop_right == 0.0
@@ -613,6 +623,68 @@ impl Transform {
             && !self.flip_h
             && !self.flip_v
     }
+}
+
+/// How a clip is fitted into the project canvas when a non-`Original`
+/// [`AspectPreset`] is active.
+#[derive(Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum FitMode {
+    /// Scale to cover the canvas, cropping the overflowing edges (no bars).
+    #[default]
+    Fill,
+    /// Scale to fit inside the canvas, letterboxing/pillarboxing with black bars.
+    Fit,
+}
+
+/// Project-level output aspect ratio. `Original` keeps each clip's own framing
+/// (no reframe); the others re-frame the whole project to a social format using
+/// 1080-based canvas dimensions.
+#[derive(Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum AspectPreset {
+    /// No reframe — clips keep their source framing (existing behaviour).
+    #[default]
+    Original,
+    /// 16:9 landscape (1920×1080).
+    Widescreen16x9,
+    /// 9:16 vertical (1080×1920).
+    Vertical9x16,
+    /// 1:1 square (1080×1080).
+    Square1x1,
+    /// 4:5 portrait (1080×1350).
+    Portrait4x5,
+}
+
+impl AspectPreset {
+    /// Target canvas dimensions, or `None` for `Original` (no reframe).
+    pub fn dims(self) -> Option<(u32, u32)> {
+        match self {
+            AspectPreset::Original => None,
+            AspectPreset::Widescreen16x9 => Some((1920, 1080)),
+            AspectPreset::Vertical9x16 => Some((1080, 1920)),
+            AspectPreset::Square1x1 => Some((1080, 1080)),
+            AspectPreset::Portrait4x5 => Some((1080, 1350)),
+        }
+    }
+
+    /// Short label for the aspect selector.
+    pub fn label(self) -> &'static str {
+        match self {
+            AspectPreset::Original => "Original",
+            AspectPreset::Widescreen16x9 => "16:9",
+            AspectPreset::Vertical9x16 => "9:16",
+            AspectPreset::Square1x1 => "1:1",
+            AspectPreset::Portrait4x5 => "4:5",
+        }
+    }
+
+    /// All presets, in menu order.
+    pub const ALL: [AspectPreset; 5] = [
+        AspectPreset::Original,
+        AspectPreset::Widescreen16x9,
+        AspectPreset::Vertical9x16,
+        AspectPreset::Square1x1,
+        AspectPreset::Portrait4x5,
+    ];
 }
 
 #[derive(Clone, PartialEq)]

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -38,8 +38,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
 
     if timeline_is_active {
         if let Some(tex) = &state.preview_texture {
-            let img_resp = ui.image(egui::load::SizedTexture::new(tex.id(), video_size));
-            draw_title_overlays(state, ui, img_resp.rect);
+            let img_rect = show_frame_fitted(ui, tex, video_size);
+            draw_title_overlays(state, ui, img_rect);
         } else {
             ui.allocate_ui(video_size, |ui| {
                 ui.centered_and_justified(|ui| {
@@ -54,7 +54,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
             .map(|c| c.info.primary_video().is_none() && c.info.primary_audio().is_some())
             .unwrap_or(false);
         if let Some(tex) = &state.preview_texture {
-            ui.image(egui::load::SizedTexture::new(tex.id(), video_size));
+            show_frame_fitted(ui, tex, video_size);
         } else if is_audio_only {
             ui.allocate_ui(video_size, |ui| {
                 ui.centered_and_justified(|ui| {
@@ -404,6 +404,27 @@ fn spawn_and_store(
     state.pending_proxy_rx = Some(proxy_rx);
     state.proxy_active = false;
     state.is_paused = false;
+}
+
+/// Paints the preview texture inside `video_size`, preserving the frame's aspect
+/// ratio (letterbox/pillarbox within the area) rather than stretching to fill it —
+/// so a 9:16 (or 1:1, 4:5) project shows its true shape. Returns the rect the image
+/// was painted into (used to anchor title overlays).
+fn show_frame_fitted(
+    ui: &mut egui::Ui,
+    tex: &egui::TextureHandle,
+    video_size: egui::Vec2,
+) -> egui::Rect {
+    let (area, _) = ui.allocate_exact_size(video_size, egui::Sense::hover());
+    let tex_size = tex.size_vec2();
+    if tex_size.x <= 0.0 || tex_size.y <= 0.0 || video_size.x <= 0.0 || video_size.y <= 0.0 {
+        return area;
+    }
+    let scale = (video_size.x / tex_size.x).min(video_size.y / tex_size.y);
+    let disp = tex_size * scale;
+    let img_rect = egui::Rect::from_center_size(area.center(), disp);
+    egui::Image::new(egui::load::SizedTexture::new(tex.id(), disp)).paint_at(ui, img_rect);
+    img_rect
 }
 
 /// Draws active T1 title clips as egui text on top of the preview image rect.

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -319,6 +319,24 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                             clip.transform = state::Transform::default();
                         }
                     });
+                    ui.horizontal(|ui| {
+                        ui.label("Aspect fit");
+                        ui.selectable_value(
+                            &mut clip.transform.fit_mode,
+                            state::FitMode::Fill,
+                            "Fill",
+                        );
+                        ui.selectable_value(
+                            &mut clip.transform.fit_mode,
+                            state::FitMode::Fit,
+                            "Fit",
+                        );
+                    })
+                    .response
+                    .on_hover_text(
+                        "How this clip fills the project aspect (menu bar → Aspect). \
+                         Fill covers and crops; Fit letterboxes. No effect when Aspect is Original.",
+                    );
                         });
                     egui::CollapsingHeader::new("Color Grading")
                         .id_salt("clip_color_grading")
@@ -732,6 +750,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     } else {
                         None
                     },
+                    canvas: state.project_aspect.dims(),
                 };
                 state
                     .export_queue
@@ -1204,6 +1223,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 ui.ctx().clone(),
                 start,
                 Arc::clone(&state.cpal_rate),
+                state.project_aspect.dims(),
             );
             state.timeline_player_thread = Some(thread);
             state.timeline_pending_handle_rx = Some(handle_rx);
@@ -1291,6 +1311,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             ui.ctx().clone(),
                             resume_pos,
                             Arc::clone(&state.cpal_rate),
+                            state.project_aspect.dims(),
                         );
                         state.timeline_player_thread = Some(thread);
                         state.timeline_pending_handle_rx = Some(handle_rx);
@@ -3054,6 +3075,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
         if is_playing && !state.timeline_is_paused {
             // Restart the player immediately so the new mute/solo state is heard.
             let resume_pos = Duration::from_secs_f64(state.timeline_playhead_secs.max(0.0));
+            let aspect_canvas = state.project_aspect.dims();
             state.stop_timeline_player();
             let clips = &state.clips;
             let make_tcd = |tc: &state::TimelineClip| player::TrackClipData {
@@ -3123,6 +3145,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 ctx,
                 resume_pos,
                 Arc::clone(&state.cpal_rate),
+                aspect_canvas,
             );
             state.timeline_player_thread = Some(thread);
             state.timeline_pending_handle_rx = Some(handle_rx);


### PR DESCRIPTION
## Summary

Adds project aspect-ratio presets (Original / 16:9 / 9:16 / 1:1 / 4:5) and a per-clip Fit/Fill mode, re-framing the whole project for social formats. The reframe is applied identically in the timeline preview and on export, and the monitor now previews the true output shape. This completes #135 (the crop/rotate/flip layer landed in #163).

## Changes

- **Aspect presets** (`state::AspectPreset`, menu-bar selector): 1080-based canvas dims (16:9=1920×1080, 9:16=1080×1920, 1:1=1080×1080, 4:5=1080×1350). `Original` = no reframe. Drives both the export container canvas and the per-clip reframe.
- **Per-clip Fit/Fill** (`state::FitMode`, in the Transform section): Fill covers the canvas and crops the overflow; Fit letterboxes/pillarboxes with black bars.
- **`apply_aspect`** (`src/export.rs`): a shared reframe step applied last (after grade + effects) so preview and export match. Fill = centre-crop the source to the canvas aspect, then scale up; Fit = scale to fit, then centre-pad.
- **Preview reframe**: the realtime preview ignores the `Timeline` canvas, so the reframe is baked into each clip's effect chain (`spawn_timeline_player` now takes the canvas); with the composited-dimensions fix already in avio, dimension-changing steps survive the preview.
- **Aspect-preserving monitor** (`src/ui/monitor.rs`): the preview frame is now letterboxed within the panel at its true aspect ratio instead of being stretched to fill, so a 9:16/1:1/4:5 project shows its real shape.
- Project save/load round-trips the aspect preset (project-level) and per-clip fit mode (via the existing `transform`).
- Unit tests for `apply_aspect` (Fit scale+pad, Fill crop+scale, no-op when source matches canvas).

## avio gaps discovered

The straightforward Fill/Fit primitives crash or misbehave in avio's realtime composer, so `apply_aspect` deliberately orders its steps to avoid them (preview and export stay identical):
- A large-offset `Crop` after a large up-`Scale` segfaults the realtime composer — Fill crops the small source first, then scales.
- `FitToAspect` is not padded in the realtime composer (only the scale is applied) — Fit uses an explicit `Scale` + `Pad`.

Both are reported as gaps for the avio repository.

## Related Issues

Closes #135

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes