### PR TITLE
feat(timeline): per-clip image overlay (watermark/logo)

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -468,6 +468,7 @@ The following limitations were identified and should be filed as Issues against 
 | `Timeline::render()` has no proxy-aware substitution | Must manually swap paths before render; fragile | `ff-pipeline` |
 | `PreviewPlayer` is not `Clone` / shareable | One player instance per panel; no shared seek state | `ff-preview` |
 | No frame-ready callback on `RgbaSink` (must poll) | Render loop wakes at 60 fps regardless of decode rate; wastes CPU when paused | `ff-preview` |
+| `FilterStep::OverlayImage` cannot scale the overlay image (native size only) | Per-clip watermark/logo overlay supports position + opacity but not scale; PNG must be pre-resized (docs/issue71.md) | `ff-filter` |
 
 ---
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -70,6 +70,8 @@ pub struct ExportClip {
     pub video_effects: crate::state::VideoEffects,
     /// Per-clip geometric transform (crop / rotate / flip).
     pub transform: crate::state::Transform,
+    /// Per-clip image overlay (watermark / logo).
+    pub overlay: crate::state::Overlay,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -529,6 +531,31 @@ pub fn apply_aspect(
     }
 }
 
+/// Attaches a per-clip image overlay (watermark / logo) as an avio
+/// `FilterStep::OverlayImage`, applied *after* [`apply_aspect`] so the overlay
+/// composites onto the final framed image and its position expressions resolve
+/// against the output canvas dimensions. No-op when no overlay image is set.
+/// Shared by export and the timeline preview so both match.
+///
+/// avio's `OverlayImage` has no scale for the overlay image, so the PNG is
+/// composited at its native resolution (avio gap — docs/issue71.md).
+pub fn apply_overlay(clip: avio::Clip, overlay: &crate::state::Overlay) -> avio::Clip {
+    let Some(path) = &overlay.path else {
+        return clip;
+    };
+    let (x, y) = overlay.position.to_exprs(overlay.margin);
+    clip.with_video_effect(avio::FilterStep::OverlayImage {
+        path: path.to_string_lossy().into_owned(),
+        x,
+        y,
+        opacity: overlay.opacity.clamp(0.0, 1.0),
+        // avio now supports an overlay-image scale, but the demo composites the
+        // PNG at its native size (no scale control) — see docs/issue71.md.
+        width: None,
+        height: None,
+    })
+}
+
 fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio::Clip> {
     clips
         .into_iter()
@@ -603,6 +630,10 @@ fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio
                 }
                 None => clip,
             };
+            // Image overlay (watermark / logo) — composited on the final framed
+            // image, so its position resolves against the output canvas. Shared
+            // with the preview. No-op when no overlay image is set.
+            let clip = apply_overlay(clip, &c.overlay);
             #[allow(clippy::float_cmp)]
             let clip = if c.opacity != 1.0 {
                 clip.with_opacity(c.opacity)
@@ -1516,5 +1547,73 @@ mod tests {
             }
             other => panic!("expected Scale, got {other:?}"),
         }
+    }
+
+    /// An overlay with no image path attaches no step.
+    #[test]
+    fn overlay_none_produces_no_step() {
+        use super::apply_overlay;
+
+        let overlay = crate::state::Overlay::default();
+        let steps = apply_overlay(avio::Clip::new("test.mp4"), &overlay).video_effect_chain();
+        assert!(steps.is_empty());
+    }
+
+    /// A bottom-right overlay emits an `OverlayImage` with margin-offset position
+    /// expressions and the opacity carried through.
+    #[test]
+    fn overlay_emits_overlay_image_bottom_right() {
+        use super::apply_overlay;
+        use crate::state::{Overlay, OverlayPosition};
+
+        let overlay = Overlay {
+            path: Some(std::path::PathBuf::from("logo.png")),
+            position: OverlayPosition::BottomRight,
+            margin: 20,
+            opacity: 0.5,
+        };
+        let steps = apply_overlay(avio::Clip::new("test.mp4"), &overlay).video_effect_chain();
+        assert_eq!(steps.len(), 1);
+        match &steps[0] {
+            avio::FilterStep::OverlayImage {
+                path,
+                x,
+                y,
+                opacity,
+                width,
+                height,
+            } => {
+                assert_eq!(path, "logo.png");
+                assert_eq!(x, "W-w-20");
+                assert_eq!(y, "H-h-20");
+                assert_eq!(*opacity, 0.5);
+                assert!(width.is_none());
+                assert!(height.is_none());
+            }
+            other => panic!("expected OverlayImage, got {other:?}"),
+        }
+    }
+
+    /// Anchor positions map to the expected FFmpeg `overlay` x/y expressions.
+    #[test]
+    fn overlay_position_exprs() {
+        use crate::state::OverlayPosition;
+
+        assert_eq!(
+            OverlayPosition::TopLeft.to_exprs(10),
+            ("10".to_string(), "10".to_string())
+        );
+        assert_eq!(
+            OverlayPosition::Centre.to_exprs(10),
+            ("(W-w)/2".to_string(), "(H-h)/2".to_string())
+        );
+        assert_eq!(
+            OverlayPosition::TopRight.to_exprs(30),
+            ("W-w-30".to_string(), "30".to_string())
+        );
+        assert_eq!(
+            OverlayPosition::BottomCentre.to_exprs(15),
+            ("(W-w)/2".to_string(), "H-h-15".to_string())
+        );
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -61,6 +61,8 @@ pub struct TrackClipData {
     pub video_effects: crate::state::VideoEffects,
     /// Per-clip geometric transform (crop / rotate / flip).
     pub transform: crate::state::Transform,
+    /// Per-clip image overlay (watermark / logo).
+    pub overlay: crate::state::Overlay,
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -478,6 +480,8 @@ pub fn spawn_timeline_player(
                     ch,
                 );
             }
+            // Image overlay (watermark / logo) — final video step, matches export.
+            c = crate::export::apply_overlay(c, &tc.overlay);
             #[allow(clippy::float_cmp)]
             if tc.opacity != 1.0 {
                 c = c.with_opacity(tc.opacity);

--- a/src/project.rs
+++ b/src/project.rs
@@ -81,6 +81,8 @@ pub struct ProjectTimelineClip {
     pub video_effects: crate::state::VideoEffects,
     #[serde(default)]
     pub transform: crate::state::Transform,
+    #[serde(default)]
+    pub overlay: crate::state::Overlay,
 }
 
 fn default_wb_temperature() -> u32 {
@@ -246,6 +248,7 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         wheels: tc.wheels,
         video_effects: tc.video_effects,
         transform: tc.transform,
+        overlay: tc.overlay.clone(),
     }
 }
 
@@ -291,6 +294,7 @@ fn project_to_timeline_clip(
         wheels: ptc.wheels,
         video_effects: ptc.video_effects,
         transform: ptc.transform,
+        overlay: ptc.overlay.clone(),
     })
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -687,6 +687,139 @@ impl AspectPreset {
     ];
 }
 
+/// Anchor position of an image overlay on the frame.
+#[derive(Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum OverlayPosition {
+    TopLeft,
+    TopCentre,
+    TopRight,
+    MiddleLeft,
+    Centre,
+    MiddleRight,
+    BottomLeft,
+    BottomCentre,
+    /// Default anchor for a watermark / logo.
+    #[default]
+    BottomRight,
+}
+
+impl OverlayPosition {
+    /// Short label for the position selector.
+    pub fn label(self) -> &'static str {
+        match self {
+            OverlayPosition::TopLeft => "Top Left",
+            OverlayPosition::TopCentre => "Top Centre",
+            OverlayPosition::TopRight => "Top Right",
+            OverlayPosition::MiddleLeft => "Middle Left",
+            OverlayPosition::Centre => "Centre",
+            OverlayPosition::MiddleRight => "Middle Right",
+            OverlayPosition::BottomLeft => "Bottom Left",
+            OverlayPosition::BottomCentre => "Bottom Centre",
+            OverlayPosition::BottomRight => "Bottom Right",
+        }
+    }
+
+    /// All positions, in selector order.
+    pub const ALL: [OverlayPosition; 9] = [
+        OverlayPosition::TopLeft,
+        OverlayPosition::TopCentre,
+        OverlayPosition::TopRight,
+        OverlayPosition::MiddleLeft,
+        OverlayPosition::Centre,
+        OverlayPosition::MiddleRight,
+        OverlayPosition::BottomLeft,
+        OverlayPosition::BottomCentre,
+        OverlayPosition::BottomRight,
+    ];
+
+    /// FFmpeg `overlay` `x`/`y` position expressions for this anchor and `margin`
+    /// (in pixels). `W`/`H` are the main-frame dimensions, `w`/`h` the overlay's.
+    pub fn to_exprs(self, margin: u32) -> (String, String) {
+        let (col, row) = self.col_row();
+        let x = match col {
+            Col::Left => margin.to_string(),
+            Col::Centre => "(W-w)/2".to_string(),
+            Col::Right => format!("W-w-{margin}"),
+        };
+        let y = match row {
+            Row::Top => margin.to_string(),
+            Row::Middle => "(H-h)/2".to_string(),
+            Row::Bottom => format!("H-h-{margin}"),
+        };
+        (x, y)
+    }
+
+    fn col_row(self) -> (Col, Row) {
+        match self {
+            OverlayPosition::TopLeft => (Col::Left, Row::Top),
+            OverlayPosition::TopCentre => (Col::Centre, Row::Top),
+            OverlayPosition::TopRight => (Col::Right, Row::Top),
+            OverlayPosition::MiddleLeft => (Col::Left, Row::Middle),
+            OverlayPosition::Centre => (Col::Centre, Row::Middle),
+            OverlayPosition::MiddleRight => (Col::Right, Row::Middle),
+            OverlayPosition::BottomLeft => (Col::Left, Row::Bottom),
+            OverlayPosition::BottomCentre => (Col::Centre, Row::Bottom),
+            OverlayPosition::BottomRight => (Col::Right, Row::Bottom),
+        }
+    }
+}
+
+enum Col {
+    Left,
+    Centre,
+    Right,
+}
+enum Row {
+    Top,
+    Middle,
+    Bottom,
+}
+
+/// Per-clip image overlay (watermark / logo). Neutral when `path` is `None`.
+/// The image is composited via avio `FilterStep::OverlayImage` at the anchored
+/// position with the given opacity. avio has no scale for the overlay image, so
+/// the PNG is placed at its native resolution (avio gap — docs/issue71.md).
+#[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Overlay {
+    /// PNG file path. `None` = no overlay.
+    pub path: Option<PathBuf>,
+    /// Anchor position on the frame.
+    #[serde(default)]
+    pub position: OverlayPosition,
+    /// Margin from the anchored edges, in pixels.
+    #[serde(default = "default_overlay_margin")]
+    pub margin: u32,
+    /// Opacity `0.0` (transparent)..=`1.0` (opaque).
+    #[serde(default = "default_overlay_opacity")]
+    pub opacity: f32,
+}
+
+fn default_overlay_margin() -> u32 {
+    20
+}
+
+fn default_overlay_opacity() -> f32 {
+    1.0
+}
+
+impl Default for Overlay {
+    fn default() -> Self {
+        Self {
+            path: None,
+            position: OverlayPosition::default(),
+            margin: default_overlay_margin(),
+            opacity: default_overlay_opacity(),
+        }
+    }
+}
+
+impl Overlay {
+    /// `true` when an overlay image is set.
+    pub fn is_active(&self) -> bool {
+        self.path.is_some()
+    }
+}
+
 #[derive(Clone, PartialEq)]
 pub struct TimelineClip {
     pub source_index: usize,
@@ -761,6 +894,8 @@ pub struct TimelineClip {
     pub video_effects: VideoEffects,
     /// Per-clip geometric transform (crop / rotate / flip). Default: neutral.
     pub transform: Transform,
+    /// Per-clip image overlay (watermark / logo). Default: none.
+    pub overlay: Overlay,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -668,6 +668,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 wheels: state::ColorWheels::default(),
                 video_effects: state::VideoEffects::default(),
                 transform: state::Transform::default(),
+                overlay: state::Overlay::default(),
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -338,6 +338,77 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                          Fill covers and crops; Fit letterboxes. No effect when Aspect is Original.",
                     );
                         });
+                    egui::CollapsingHeader::new("Overlay")
+                        .id_salt("clip_overlay")
+                        .default_open(false)
+                        .show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        let name = clip
+                            .overlay
+                            .path
+                            .as_ref()
+                            .and_then(|p| p.file_name())
+                            .and_then(|n| n.to_str())
+                            .unwrap_or("(none)")
+                            .to_owned();
+                        if ui.button("Choose PNG…").clicked()
+                            && let Some(path) = rfd::FileDialog::new()
+                                .add_filter("PNG image", &["png"])
+                                .pick_file()
+                        {
+                            clip.overlay.path = Some(path);
+                        }
+                        if ui
+                            .add_enabled(clip.overlay.is_active(), egui::Button::new("Remove"))
+                            .clicked()
+                        {
+                            clip.overlay.path = None;
+                        }
+                        ui.label(name);
+                    });
+                    ui.add_enabled_ui(clip.overlay.is_active(), |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label("Position");
+                            egui::ComboBox::from_id_salt("clip_overlay_pos")
+                                .selected_text(clip.overlay.position.label())
+                                .show_ui(ui, |ui| {
+                                    for pos in state::OverlayPosition::ALL {
+                                        ui.selectable_value(
+                                            &mut clip.overlay.position,
+                                            pos,
+                                            pos.label(),
+                                        );
+                                    }
+                                });
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("Margin");
+                            ui.add(
+                                egui::DragValue::new(&mut clip.overlay.margin)
+                                    .range(0..=500)
+                                    .suffix(" px"),
+                            );
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("Opacity");
+                            let mut opacity_pct = clip.overlay.opacity * 100.0;
+                            if ui
+                                .add(
+                                    egui::Slider::new(&mut opacity_pct, 0.0..=100.0)
+                                        .suffix(" %")
+                                        .fixed_decimals(0),
+                                )
+                                .changed()
+                            {
+                                clip.overlay.opacity = (opacity_pct / 100.0).clamp(0.0, 1.0);
+                            }
+                        });
+                    });
+                    ui.weak(
+                        "PNG is composited at its native pixel size — avio has no overlay \
+                         scale, so resize the source PNG to change its size.",
+                    );
+                        });
                     egui::CollapsingHeader::new("Color Grading")
                         .id_salt("clip_color_grading")
                         .default_open(true)
@@ -715,6 +786,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         wheels: tc.wheels,
                         video_effects: tc.video_effects,
                         transform: tc.transform,
+                        overlay: tc.overlay.clone(),
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -1193,6 +1265,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 wheels: tc.wheels,
                 video_effects: tc.video_effects,
                 transform: tc.transform,
+                overlay: tc.overlay.clone(),
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -1283,6 +1356,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             wheels: tc.wheels,
                             video_effects: tc.video_effects,
                             transform: tc.transform,
+                            overlay: tc.overlay.clone(),
                         };
                         let tracks = &state.timeline.tracks;
                         let audio_start = state.timeline.audio_track_start();
@@ -3118,6 +3192,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 wheels: tc.wheels,
                 video_effects: tc.video_effects,
                 transform: tc.transform,
+                overlay: tc.overlay.clone(),
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -3218,6 +3293,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             wheels: state::ColorWheels::default(),
             video_effects: state::VideoEffects::default(),
             transform: state::Transform::default(),
+            overlay: state::Overlay::default(),
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -3360,6 +3436,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 wheels: state.timeline.tracks[ti].clips[ci].wheels,
                 video_effects: state.timeline.tracks[ti].clips[ci].video_effects,
                 transform: state.timeline.tracks[ti].clips[ci].transform,
+                overlay: state.timeline.tracks[ti].clips[ci].overlay.clone(),
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }


### PR DESCRIPTION
## Summary

Adds a per-clip image overlay (watermark / logo): pick a PNG in the clip inspector and composite it over the clip with a 9-anchor position, margin, and opacity. The overlay is applied identically in the timeline preview and on export via avio's `FilterStep::OverlayImage`, so what you see matches what renders.

## Changes

- **State** (`state.rs`): new `Overlay` struct (`path` / `position` / `margin` / `opacity`, defaults: none / bottom-right / 20 px / 1.0) and `OverlayPosition` enum (9 anchors) with `to_exprs(margin)` producing the FFmpeg `overlay` `x`/`y` expressions; `overlay` field added to `TimelineClip`.
- **avio mapping** (`export.rs`): shared `apply_overlay()` emits `FilterStep::OverlayImage`, applied as the final video step (after `apply_aspect`) so the position resolves against the output canvas; no-op when no image is set. Wired into `clips_to_avio`; `overlay` added to `ExportClip`.
- **Preview** (`player.rs`): `overlay` added to `TrackClipData`; `make_clip` calls `apply_overlay` as the final video step, matching export.
- **UI** (`ui/timeline.rs`): "Overlay" inspector section — Choose PNG… / Remove / Position / Margin / Opacity; threaded through the export snapshot, the three preview spawn sites, and the drop/split clip constructors. Default overlay on clip placement (`ui/clip_browser.rs`).
- **Persistence** (`project.rs`): `overlay` round-trips via `#[serde(default)]`.
- **Scale is an avio gap**: `OverlayImage` had no overlay-image scale, so the PNG composites at native size — noted in the inspector and the spec's Known avio Gaps table (`docs/specification.md`). (Now addressed upstream in avio; a demo Scale control can follow.)
- **Tests**: `apply_overlay` emits no step when unset, emits `OverlayImage` with margin-offset position exprs + opacity when set; anchor→expression mapping covered.

## Related Issues

Closes #136

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes