### PR TITLE
feat(timeline): overlay scale control

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -468,7 +468,6 @@ The following limitations were identified and should be filed as Issues against 
 | `Timeline::render()` has no proxy-aware substitution | Must manually swap paths before render; fragile | `ff-pipeline` |
 | `PreviewPlayer` is not `Clone` / shareable | One player instance per panel; no shared seek state | `ff-preview` |
 | No frame-ready callback on `RgbaSink` (must poll) | Render loop wakes at 60 fps regardless of decode rate; wastes CPU when paused | `ff-preview` |
-| `FilterStep::OverlayImage` cannot scale the overlay image (native size only) | Per-clip watermark/logo overlay supports position + opacity but not scale; PNG must be pre-resized (docs/issue71.md) | `ff-filter` |
 
 ---
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -537,22 +537,29 @@ pub fn apply_aspect(
 /// against the output canvas dimensions. No-op when no overlay image is set.
 /// Shared by export and the timeline preview so both match.
 ///
-/// avio's `OverlayImage` has no scale for the overlay image, so the PNG is
-/// composited at its native resolution (avio gap — docs/issue71.md).
+/// `scale` (percent of the image's native size) is mapped to avio's
+/// `OverlayImage` `width`/`height` scale expressions (`iw*f`/`ih*f`); `100%`
+/// keeps the native size (no scale node).
+#[allow(clippy::float_cmp)]
 pub fn apply_overlay(clip: avio::Clip, overlay: &crate::state::Overlay) -> avio::Clip {
     let Some(path) = &overlay.path else {
         return clip;
     };
     let (x, y) = overlay.position.to_exprs(overlay.margin);
+    // Uniform scale about the native size; None keeps the native resolution.
+    let (width, height) = if overlay.scale > 0.0 && overlay.scale != 100.0 {
+        let f = overlay.scale / 100.0;
+        (Some(format!("iw*{f}")), Some(format!("ih*{f}")))
+    } else {
+        (None, None)
+    };
     clip.with_video_effect(avio::FilterStep::OverlayImage {
         path: path.to_string_lossy().into_owned(),
         x,
         y,
         opacity: overlay.opacity.clamp(0.0, 1.0),
-        // avio now supports an overlay-image scale, but the demo composites the
-        // PNG at its native size (no scale control) — see docs/issue71.md.
-        width: None,
-        height: None,
+        width,
+        height,
     })
 }
 
@@ -1571,6 +1578,7 @@ mod tests {
             position: OverlayPosition::BottomRight,
             margin: 20,
             opacity: 0.5,
+            scale: 100.0,
         };
         let steps = apply_overlay(avio::Clip::new("test.mp4"), &overlay).video_effect_chain();
         assert_eq!(steps.len(), 1);
@@ -1587,8 +1595,33 @@ mod tests {
                 assert_eq!(x, "W-w-20");
                 assert_eq!(y, "H-h-20");
                 assert_eq!(*opacity, 0.5);
+                // 100% scale keeps the native size — no scale exprs.
                 assert!(width.is_none());
                 assert!(height.is_none());
+            }
+            other => panic!("expected OverlayImage, got {other:?}"),
+        }
+    }
+
+    /// A non-100% scale maps to uniform `iw*f` / `ih*f` scale expressions.
+    #[test]
+    fn overlay_scale_maps_to_size_exprs() {
+        use super::apply_overlay;
+        use crate::state::{Overlay, OverlayPosition};
+
+        let overlay = Overlay {
+            path: Some(std::path::PathBuf::from("logo.png")),
+            position: OverlayPosition::TopLeft,
+            margin: 10,
+            opacity: 1.0,
+            scale: 50.0,
+        };
+        let steps = apply_overlay(avio::Clip::new("test.mp4"), &overlay).video_effect_chain();
+        assert_eq!(steps.len(), 1);
+        match &steps[0] {
+            avio::FilterStep::OverlayImage { width, height, .. } => {
+                assert_eq!(width.as_deref(), Some("iw*0.5"));
+                assert_eq!(height.as_deref(), Some("ih*0.5"));
             }
             other => panic!("expected OverlayImage, got {other:?}"),
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -792,6 +792,10 @@ pub struct Overlay {
     /// Opacity `0.0` (transparent)..=`1.0` (opaque).
     #[serde(default = "default_overlay_opacity")]
     pub opacity: f32,
+    /// Overlay size as a percentage of the image's native size. `100.0` = native
+    /// (no scaling). Mapped to avio `OverlayImage` `width`/`height` scale exprs.
+    #[serde(default = "default_overlay_scale")]
+    pub scale: f32,
 }
 
 fn default_overlay_margin() -> u32 {
@@ -802,6 +806,10 @@ fn default_overlay_opacity() -> f32 {
     1.0
 }
 
+fn default_overlay_scale() -> f32 {
+    100.0
+}
+
 impl Default for Overlay {
     fn default() -> Self {
         Self {
@@ -809,6 +817,7 @@ impl Default for Overlay {
             position: OverlayPosition::default(),
             margin: default_overlay_margin(),
             opacity: default_overlay_opacity(),
+            scale: default_overlay_scale(),
         }
     }
 }

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -403,11 +403,17 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                                 clip.overlay.opacity = (opacity_pct / 100.0).clamp(0.0, 1.0);
                             }
                         });
+                        ui.horizontal(|ui| {
+                            ui.label("Scale");
+                            ui.add(
+                                egui::Slider::new(&mut clip.overlay.scale, 10.0..=300.0)
+                                    .suffix(" %")
+                                    .fixed_decimals(0),
+                            );
+                        })
+                        .response
+                        .on_hover_text("Overlay size as a percentage of the image's native size.");
                     });
-                    ui.weak(
-                        "PNG is composited at its native pixel size — avio has no overlay \
-                         scale, so resize the source PNG to change its size.",
-                    );
                         });
                     egui::CollapsingHeader::new("Color Grading")
                         .id_salt("clip_color_grading")


### PR DESCRIPTION
## Summary

Adds a Scale control to the per-clip image overlay, completing the scale part of the overlay feature. #136 shipped position + opacity and documented scale as an avio gap; that gap is now fixed upstream (avio `OverlayImage` gained optional size), so the overlay can be resized in-app instead of pre-resizing the PNG.

## Changes

- **State** (`state.rs`): `Overlay.scale` (percent of the image's native size; default 100 = native), with `#[serde(default)]` so existing projects load unchanged.
- **avio mapping** (`export.rs`): `apply_overlay` maps a non-100% scale to avio `OverlayImage` `width`/`height` scale expressions (`iw*f` / `ih*f`); 100% keeps native size (no scale node). Shared by preview and export.
- **UI** (`ui/timeline.rs`): Scale slider (10–300%) in the Overlay inspector; removed the "resize the source PNG" note (no longer needed).
- **Docs** (`docs/specification.md`): removed the now-resolved OverlayImage-scale row from Known avio Gaps.
- **Tests**: `overlay_scale_maps_to_size_exprs` (50% → `iw*0.5` / `ih*0.5`); the native-size case still emits no scale exprs.

## Related Issues

Follow-up to #136 (scale control; #136 delivered position + opacity).

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes