### PR TITLE
feat(timeline): per-clip subtitle import (SRT / ASS)

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -72,6 +72,8 @@ pub struct ExportClip {
     pub transform: crate::state::Transform,
     /// Per-clip image overlay (watermark / logo).
     pub overlay: crate::state::Overlay,
+    /// Per-clip burned-in subtitle (SRT / ASS).
+    pub subtitle: crate::state::Subtitle,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -563,6 +565,44 @@ pub fn apply_overlay(clip: avio::Clip, overlay: &crate::state::Overlay) -> avio:
     })
 }
 
+/// Builds the ASS `force_style` string for an SRT subtitle from the demo's style
+/// fields: font size, primary colour (ASS `&H00BBGGRR&`, opaque), and alignment.
+fn build_force_style(sub: &crate::state::Subtitle) -> String {
+    let [r, g, b] = sub.colour;
+    format!(
+        "Fontsize={fs},PrimaryColour=&H00{b:02X}{g:02X}{r:02X}&,Alignment={a}",
+        fs = sub.font_size,
+        a = sub.position.ass_alignment(),
+    )
+}
+
+/// Attaches a per-clip burned-in subtitle as an avio `FilterStep::SubtitlesSrt` /
+/// `SubtitlesAss`, applied *after* [`apply_overlay`] so it sits on top of the final
+/// framed image. No-op when no subtitle file is set. SRT carries a `force_style`
+/// built from the demo's font size / colour / position; ASS uses the file's own
+/// styles (style fields ignored). Shared by export and the timeline preview.
+///
+/// Subtitle timing is clip-relative (the subtitle's `t=0` aligns to this clip's
+/// start), since avio applies it in the per-clip effect chain — a global timeline
+/// subtitle source with preview is an avio limitation (see docs/issue74.md).
+pub fn apply_subtitle(clip: avio::Clip, sub: &crate::state::Subtitle) -> avio::Clip {
+    let Some(path) = &sub.path else {
+        return clip;
+    };
+    let path = path.to_string_lossy().into_owned();
+    match sub.format {
+        crate::state::SubtitleFormat::Srt => {
+            clip.with_video_effect(avio::FilterStep::SubtitlesSrt {
+                path,
+                force_style: Some(build_force_style(sub)),
+            })
+        }
+        crate::state::SubtitleFormat::Ass => {
+            clip.with_video_effect(avio::FilterStep::SubtitlesAss { path })
+        }
+    }
+}
+
 fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio::Clip> {
     clips
         .into_iter()
@@ -641,6 +681,9 @@ fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio
             // image, so its position resolves against the output canvas. Shared
             // with the preview. No-op when no overlay image is set.
             let clip = apply_overlay(clip, &c.overlay);
+            // Burned-in subtitle — on top of the overlay. Shared with the preview.
+            // No-op when no subtitle file is set.
+            let clip = apply_subtitle(clip, &c.subtitle);
             #[allow(clippy::float_cmp)]
             let clip = if c.opacity != 1.0 {
                 clip.with_opacity(c.opacity)
@@ -1624,6 +1667,63 @@ mod tests {
                 assert_eq!(height.as_deref(), Some("ih*0.5"));
             }
             other => panic!("expected OverlayImage, got {other:?}"),
+        }
+    }
+
+    /// A subtitle with no path attaches no step.
+    #[test]
+    fn subtitle_none_produces_no_step() {
+        use super::apply_subtitle;
+
+        let sub = crate::state::Subtitle::default();
+        let steps = apply_subtitle(avio::Clip::new("test.mp4"), &sub).video_effect_chain();
+        assert!(steps.is_empty());
+    }
+
+    /// An SRT subtitle emits `SubtitlesSrt` with a force_style built from the
+    /// font size / colour / position.
+    #[test]
+    fn subtitle_srt_emits_force_style() {
+        use super::apply_subtitle;
+        use crate::state::{Subtitle, SubtitleFormat, SubtitlePosition};
+
+        let sub = Subtitle {
+            path: Some(std::path::PathBuf::from("ep1.srt")),
+            format: SubtitleFormat::Srt,
+            font_size: 28,
+            colour: [255, 0, 0], // red → BGR &H000000FF&
+            position: SubtitlePosition::Top,
+        };
+        let steps = apply_subtitle(avio::Clip::new("test.mp4"), &sub).video_effect_chain();
+        assert_eq!(steps.len(), 1);
+        match &steps[0] {
+            avio::FilterStep::SubtitlesSrt { path, force_style } => {
+                assert_eq!(path, "ep1.srt");
+                let fs = force_style.as_deref().expect("force_style");
+                assert!(fs.contains("Fontsize=28"));
+                assert!(fs.contains("PrimaryColour=&H000000FF&")); // BGR of red
+                assert!(fs.contains("Alignment=8")); // Top
+            }
+            other => panic!("expected SubtitlesSrt, got {other:?}"),
+        }
+    }
+
+    /// An ASS subtitle emits `SubtitlesAss` (no force_style; embedded styles).
+    #[test]
+    fn subtitle_ass_emits_ass_step() {
+        use super::apply_subtitle;
+        use crate::state::{Subtitle, SubtitleFormat};
+
+        let sub = Subtitle {
+            path: Some(std::path::PathBuf::from("ep1.ass")),
+            format: SubtitleFormat::Ass,
+            ..Default::default()
+        };
+        let steps = apply_subtitle(avio::Clip::new("test.mp4"), &sub).video_effect_chain();
+        assert_eq!(steps.len(), 1);
+        match &steps[0] {
+            avio::FilterStep::SubtitlesAss { path } => assert_eq!(path, "ep1.ass"),
+            other => panic!("expected SubtitlesAss, got {other:?}"),
         }
     }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -63,6 +63,8 @@ pub struct TrackClipData {
     pub transform: crate::state::Transform,
     /// Per-clip image overlay (watermark / logo).
     pub overlay: crate::state::Overlay,
+    /// Per-clip burned-in subtitle (SRT / ASS).
+    pub subtitle: crate::state::Subtitle,
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -480,8 +482,10 @@ pub fn spawn_timeline_player(
                     ch,
                 );
             }
-            // Image overlay (watermark / logo) — final video step, matches export.
+            // Image overlay (watermark / logo) — matches export.
             c = crate::export::apply_overlay(c, &tc.overlay);
+            // Burned-in subtitle — on top of the overlay, matches export.
+            c = crate::export::apply_subtitle(c, &tc.subtitle);
             #[allow(clippy::float_cmp)]
             if tc.opacity != 1.0 {
                 c = c.with_opacity(tc.opacity);

--- a/src/project.rs
+++ b/src/project.rs
@@ -83,6 +83,8 @@ pub struct ProjectTimelineClip {
     pub transform: crate::state::Transform,
     #[serde(default)]
     pub overlay: crate::state::Overlay,
+    #[serde(default)]
+    pub subtitle: crate::state::Subtitle,
 }
 
 fn default_wb_temperature() -> u32 {
@@ -249,6 +251,7 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         video_effects: tc.video_effects,
         transform: tc.transform,
         overlay: tc.overlay.clone(),
+        subtitle: tc.subtitle.clone(),
     }
 }
 
@@ -295,6 +298,7 @@ fn project_to_timeline_clip(
         video_effects: ptc.video_effects,
         transform: ptc.transform,
         overlay: ptc.overlay.clone(),
+        subtitle: ptc.subtitle.clone(),
     })
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -829,6 +829,102 @@ impl Overlay {
     }
 }
 
+/// Subtitle file format, inferred from the picked file's extension.
+#[derive(Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum SubtitleFormat {
+    /// `.srt` — burned via the `subtitles` filter; supports style overrides.
+    #[default]
+    Srt,
+    /// `.ass` / `.ssa` — burned via the `ass` filter with the file's own styles.
+    Ass,
+}
+
+/// Vertical anchor for SRT subtitle text (maps to the ASS `Alignment` value).
+#[derive(Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum SubtitlePosition {
+    /// Bottom-centre (ASS Alignment 2).
+    #[default]
+    Bottom,
+    /// Middle-centre (ASS Alignment 5).
+    Middle,
+    /// Top-centre (ASS Alignment 8).
+    Top,
+}
+
+impl SubtitlePosition {
+    /// ASS `Alignment` value (numpad convention: 2=bottom, 5=middle, 8=top; all centred).
+    pub fn ass_alignment(self) -> u8 {
+        match self {
+            SubtitlePosition::Bottom => 2,
+            SubtitlePosition::Middle => 5,
+            SubtitlePosition::Top => 8,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            SubtitlePosition::Bottom => "Bottom",
+            SubtitlePosition::Middle => "Middle",
+            SubtitlePosition::Top => "Top",
+        }
+    }
+
+    pub const ALL: [SubtitlePosition; 3] = [
+        SubtitlePosition::Bottom,
+        SubtitlePosition::Middle,
+        SubtitlePosition::Top,
+    ];
+}
+
+/// Per-clip burned-in subtitle. Neutral when `path` is `None`. Applied via avio
+/// `FilterStep::SubtitlesSrt` / `SubtitlesAss` in the clip effect chain, so it
+/// shows identically in the preview and the export. The style fields (font size /
+/// colour / position) apply to **SRT only** — ASS files carry their own styles.
+#[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Subtitle {
+    /// Path to the `.srt` / `.ass` file. `None` = no subtitle.
+    pub path: Option<PathBuf>,
+    /// Format inferred from the file extension.
+    #[serde(default)]
+    pub format: SubtitleFormat,
+    /// Font size in the subtitle script's units (SRT force_style `Fontsize`).
+    #[serde(default = "default_subtitle_font_size")]
+    pub font_size: u32,
+    /// Text colour (SRT force_style `PrimaryColour`). Default white.
+    #[serde(default = "default_subtitle_colour")]
+    pub colour: [u8; 3],
+    /// Vertical position (SRT force_style `Alignment`).
+    #[serde(default)]
+    pub position: SubtitlePosition,
+}
+
+fn default_subtitle_font_size() -> u32 {
+    24
+}
+
+fn default_subtitle_colour() -> [u8; 3] {
+    [255, 255, 255]
+}
+
+impl Default for Subtitle {
+    fn default() -> Self {
+        Self {
+            path: None,
+            format: SubtitleFormat::default(),
+            font_size: default_subtitle_font_size(),
+            colour: default_subtitle_colour(),
+            position: SubtitlePosition::default(),
+        }
+    }
+}
+
+impl Subtitle {
+    /// `true` when a subtitle file is set.
+    pub fn is_active(&self) -> bool {
+        self.path.is_some()
+    }
+}
+
 #[derive(Clone, PartialEq)]
 pub struct TimelineClip {
     pub source_index: usize,
@@ -905,6 +1001,8 @@ pub struct TimelineClip {
     pub transform: Transform,
     /// Per-clip image overlay (watermark / logo). Default: none.
     pub overlay: Overlay,
+    /// Per-clip burned-in subtitle (SRT / ASS). Default: none.
+    pub subtitle: Subtitle,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -669,6 +669,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 video_effects: state::VideoEffects::default(),
                 transform: state::Transform::default(),
                 overlay: state::Overlay::default(),
+                subtitle: state::Subtitle::default(),
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -415,6 +415,85 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                         .on_hover_text("Overlay size as a percentage of the image's native size.");
                     });
                         });
+                    egui::CollapsingHeader::new("Subtitles")
+                        .id_salt("clip_subtitles")
+                        .default_open(false)
+                        .show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        let name = clip
+                            .subtitle
+                            .path
+                            .as_ref()
+                            .and_then(|p| p.file_name())
+                            .and_then(|n| n.to_str())
+                            .unwrap_or("(none)")
+                            .to_owned();
+                        if ui.button("Choose SRT/ASS…").clicked()
+                            && let Some(path) = rfd::FileDialog::new()
+                                .add_filter("Subtitles", &["srt", "ass", "ssa"])
+                                .pick_file()
+                        {
+                            let ext = path
+                                .extension()
+                                .and_then(|e| e.to_str())
+                                .unwrap_or("")
+                                .to_ascii_lowercase();
+                            clip.subtitle.format = if ext == "ass" || ext == "ssa" {
+                                state::SubtitleFormat::Ass
+                            } else {
+                                state::SubtitleFormat::Srt
+                            };
+                            clip.subtitle.path = Some(path);
+                        }
+                        if ui
+                            .add_enabled(clip.subtitle.is_active(), egui::Button::new("Remove"))
+                            .clicked()
+                        {
+                            clip.subtitle.path = None;
+                        }
+                        ui.label(name);
+                    });
+                    if clip.subtitle.is_active() {
+                        match clip.subtitle.format {
+                            state::SubtitleFormat::Srt => {
+                                ui.horizontal(|ui| {
+                                    ui.label("Font size");
+                                    ui.add(
+                                        egui::DragValue::new(&mut clip.subtitle.font_size)
+                                            .range(8..=200),
+                                    );
+                                });
+                                ui.horizontal(|ui| {
+                                    ui.label("Colour");
+                                    ui.color_edit_button_srgb(&mut clip.subtitle.colour);
+                                });
+                                ui.horizontal(|ui| {
+                                    ui.label("Position");
+                                    egui::ComboBox::from_id_salt("clip_subtitle_pos")
+                                        .selected_text(clip.subtitle.position.label())
+                                        .show_ui(ui, |ui| {
+                                            for pos in state::SubtitlePosition::ALL {
+                                                ui.selectable_value(
+                                                    &mut clip.subtitle.position,
+                                                    pos,
+                                                    pos.label(),
+                                                );
+                                            }
+                                        });
+                                });
+                            }
+                            state::SubtitleFormat::Ass => {
+                                ui.weak(
+                                    "ASS/SSA uses the file's embedded styles \
+                                     (font / colour / position ignored).",
+                                );
+                            }
+                        }
+                    }
+                    ui.weak(
+                        "Burned in per clip — subtitle timing is relative to this clip's start.",
+                    );
+                        });
                     egui::CollapsingHeader::new("Color Grading")
                         .id_salt("clip_color_grading")
                         .default_open(true)
@@ -793,6 +872,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         video_effects: tc.video_effects,
                         transform: tc.transform,
                         overlay: tc.overlay.clone(),
+                        subtitle: tc.subtitle.clone(),
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -1272,6 +1352,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 video_effects: tc.video_effects,
                 transform: tc.transform,
                 overlay: tc.overlay.clone(),
+                subtitle: tc.subtitle.clone(),
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -1363,6 +1444,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             video_effects: tc.video_effects,
                             transform: tc.transform,
                             overlay: tc.overlay.clone(),
+                            subtitle: tc.subtitle.clone(),
                         };
                         let tracks = &state.timeline.tracks;
                         let audio_start = state.timeline.audio_track_start();
@@ -3199,6 +3281,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 video_effects: tc.video_effects,
                 transform: tc.transform,
                 overlay: tc.overlay.clone(),
+                subtitle: tc.subtitle.clone(),
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -3300,6 +3383,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             video_effects: state::VideoEffects::default(),
             transform: state::Transform::default(),
             overlay: state::Overlay::default(),
+            subtitle: state::Subtitle::default(),
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -3443,6 +3527,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 video_effects: state.timeline.tracks[ti].clips[ci].video_effects,
                 transform: state.timeline.tracks[ti].clips[ci].transform,
                 overlay: state.timeline.tracks[ti].clips[ci].overlay.clone(),
+                subtitle: state.timeline.tracks[ti].clips[ci].subtitle.clone(),
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }


### PR DESCRIPTION
## Summary

Adds per-clip subtitle burn-in: pick an `.srt` / `.ass` file in the clip inspector and composite it over the clip via avio's `subtitles` / `ass` filters (the per-clip effect chain), so it shows identically in the monitor preview and the export. SRT subtitles support font size / colour / position overrides (via avio `SubtitlesSrt.force_style`); ASS uses the file's own embedded styles.

## Changes

- **State** (`state.rs`): `Subtitle` (`path` / `format` / `font_size` / `colour` / `position`), `SubtitleFormat { Srt, Ass }` (inferred from extension), `SubtitlePosition { Bottom, Middle, Top }` (→ ASS `Alignment` 2/5/8); `subtitle` field on `TimelineClip`.
- **avio mapping** (`export.rs`): `apply_subtitle()` emits `FilterStep::SubtitlesSrt { force_style }` (SRT — `build_force_style` produces `Fontsize=…,PrimaryColour=&H00BBGGRR&,Alignment=…`) or `SubtitlesAss` (ASS). Applied after `apply_overlay` (on top of the final framed image); no-op when unset. `subtitle` on `ExportClip`.
- **Preview** (`player.rs`): `subtitle` on `TrackClipData`; `make_clip` calls `apply_subtitle`, matching export.
- **UI** (`ui/timeline.rs`): "Subtitles" inspector section — Choose SRT/ASS… / Remove; for SRT: font size, colour, position; for ASS: an embedded-styles note. Threaded through the export snapshot, the 3 preview spawn sites, and the drop/split constructors.
- **Persistence** (`project.rs`) + placement default (`clip_browser.rs`).
- **Tests**: `apply_subtitle` no-op when unset; SRT emits `SubtitlesSrt` with the expected force_style; ASS emits `SubtitlesAss`.

Verified end-to-end (preview == export) for both SRT and ASS. Requires an FFmpeg built with libass (the `subtitles`/`ass` filters); subtitle timing is clip-relative (per-clip effect chain).

## Related Issues

Closes #138

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes