### PR TITLE
feat(timeline): per-clip chroma key (green screen)

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -74,6 +74,8 @@ pub struct ExportClip {
     pub overlay: crate::state::Overlay,
     /// Per-clip burned-in subtitle (SRT / ASS).
     pub subtitle: crate::state::Subtitle,
+    /// Per-clip chroma key (green/blue screen).
+    pub keying: crate::state::Keying,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -603,6 +605,43 @@ pub fn apply_subtitle(clip: avio::Clip, sub: &crate::state::Subtitle) -> avio::C
     }
 }
 
+/// Attaches a per-clip chroma key (green/blue screen) as avio
+/// `FilterStep::ChromaKey` / `ColorKey` (+ optional `SpillSuppress`), applied
+/// *first* in the clip video chain so it keys the original colours before any
+/// grade/scale. The key colour becomes transparent, revealing the track below
+/// when composited (most useful on a V2 overlay). No-op when disabled. Shared by
+/// export and the timeline preview so both match.
+#[allow(clippy::float_cmp)]
+pub fn apply_keying(clip: avio::Clip, k: &crate::state::Keying) -> avio::Clip {
+    if !k.enabled {
+        return clip;
+    }
+    let [r, g, b] = k.color;
+    let color = format!("0x{r:02X}{g:02X}{b:02X}");
+    let similarity = k.similarity.clamp(0.0, 1.0);
+    let blend = k.blend.clamp(0.0, 1.0);
+    let clip = match k.mode {
+        crate::state::KeyMode::Chroma => clip.with_video_effect(avio::FilterStep::ChromaKey {
+            color: color.clone(),
+            similarity,
+            blend,
+        }),
+        crate::state::KeyMode::Color => clip.with_video_effect(avio::FilterStep::ColorKey {
+            color: color.clone(),
+            similarity,
+            blend,
+        }),
+    };
+    if k.spill > 0.0 {
+        clip.with_video_effect(avio::FilterStep::SpillSuppress {
+            key_color: color,
+            strength: k.spill.clamp(0.0, 1.0),
+        })
+    } else {
+        clip
+    }
+}
+
 fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio::Clip> {
     clips
         .into_iter()
@@ -641,6 +680,10 @@ fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio
                 Some(kind) => clip.with_transition(kind, c.transition_duration),
                 None => clip,
             };
+            // Chroma key first — key the original colours before any transform /
+            // grade / scale, producing alpha the composer reveals through. Shared
+            // with preview. No-op when disabled.
+            let clip = apply_keying(clip, &c.keying);
             // Geometric transform (crop → flip → rotate) applied before the grade
             // so grading/effects act on the transformed image. Shared with preview.
             let clip = apply_transform(clip, &c.transform, c.width, c.height);
@@ -1724,6 +1767,79 @@ mod tests {
         match &steps[0] {
             avio::FilterStep::SubtitlesAss { path } => assert_eq!(path, "ep1.ass"),
             other => panic!("expected SubtitlesAss, got {other:?}"),
+        }
+    }
+
+    /// Disabled keying attaches no step.
+    #[test]
+    fn keying_disabled_produces_no_step() {
+        use super::apply_keying;
+
+        let k = crate::state::Keying::default(); // enabled: false
+        let steps = apply_keying(avio::Clip::new("test.mp4"), &k).video_effect_chain();
+        assert!(steps.is_empty());
+    }
+
+    /// Chroma mode emits a `ChromaKey` with the `0xRRGGBB` colour and params; a
+    /// non-zero spill appends a `SpillSuppress`.
+    #[test]
+    fn keying_chroma_emits_chromakey_and_spill() {
+        use super::apply_keying;
+        use crate::state::{KeyMode, Keying};
+
+        let k = Keying {
+            enabled: true,
+            mode: KeyMode::Chroma,
+            color: [0, 255, 0],
+            similarity: 0.3,
+            blend: 0.1,
+            spill: 0.5,
+        };
+        let steps = apply_keying(avio::Clip::new("test.mp4"), &k).video_effect_chain();
+        assert_eq!(steps.len(), 2);
+        match &steps[0] {
+            avio::FilterStep::ChromaKey {
+                color,
+                similarity,
+                blend,
+            } => {
+                assert_eq!(color, "0x00FF00");
+                assert!((*similarity - 0.3).abs() < 1e-6);
+                assert!((*blend - 0.1).abs() < 1e-6);
+            }
+            other => panic!("expected ChromaKey, got {other:?}"),
+        }
+        match &steps[1] {
+            avio::FilterStep::SpillSuppress {
+                key_color,
+                strength,
+            } => {
+                assert_eq!(key_color, "0x00FF00");
+                assert!((*strength - 0.5).abs() < 1e-6);
+            }
+            other => panic!("expected SpillSuppress, got {other:?}"),
+        }
+    }
+
+    /// Color mode emits a `ColorKey`; zero spill emits no `SpillSuppress`.
+    #[test]
+    fn keying_color_mode_no_spill() {
+        use super::apply_keying;
+        use crate::state::{KeyMode, Keying};
+
+        let k = Keying {
+            enabled: true,
+            mode: KeyMode::Color,
+            color: [0, 0, 255],
+            similarity: 0.2,
+            blend: 0.05,
+            spill: 0.0,
+        };
+        let steps = apply_keying(avio::Clip::new("test.mp4"), &k).video_effect_chain();
+        assert_eq!(steps.len(), 1);
+        match &steps[0] {
+            avio::FilterStep::ColorKey { color, .. } => assert_eq!(color, "0x0000FF"),
+            other => panic!("expected ColorKey, got {other:?}"),
         }
     }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -65,6 +65,8 @@ pub struct TrackClipData {
     pub overlay: crate::state::Overlay,
     /// Per-clip burned-in subtitle (SRT / ASS).
     pub subtitle: crate::state::Subtitle,
+    /// Per-clip chroma key (green/blue screen).
+    pub keying: crate::state::Keying,
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -442,6 +444,9 @@ pub fn spawn_timeline_player(
             if let Some(kind) = tc.transition {
                 c = c.with_transition(kind, tc.transition_duration);
             }
+            // Chroma key first — key original colours before transform/grade,
+            // producing alpha the composer reveals through. Matches export.
+            c = crate::export::apply_keying(c, &tc.keying);
             // Geometric transform (crop → flip → rotate) applied before the grade,
             // matching export so the monitor reflects the rendered geometry.
             c = crate::export::apply_transform(c, &tc.transform, tc.width, tc.height);

--- a/src/project.rs
+++ b/src/project.rs
@@ -85,6 +85,8 @@ pub struct ProjectTimelineClip {
     pub overlay: crate::state::Overlay,
     #[serde(default)]
     pub subtitle: crate::state::Subtitle,
+    #[serde(default)]
+    pub keying: crate::state::Keying,
 }
 
 fn default_wb_temperature() -> u32 {
@@ -252,6 +254,7 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         transform: tc.transform,
         overlay: tc.overlay.clone(),
         subtitle: tc.subtitle.clone(),
+        keying: tc.keying,
     }
 }
 
@@ -299,6 +302,7 @@ fn project_to_timeline_clip(
         transform: ptc.transform,
         overlay: ptc.overlay.clone(),
         subtitle: ptc.subtitle.clone(),
+        keying: ptc.keying,
     })
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -925,6 +925,82 @@ impl Subtitle {
     }
 }
 
+/// Chroma-key filter selection: `Chroma` uses avio `ChromaKey` (YUV `chromakey`,
+/// best for video green screen); `Color` uses `ColorKey` (RGB `colorkey`).
+#[derive(Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum KeyMode {
+    #[default]
+    Chroma,
+    Color,
+}
+
+impl KeyMode {
+    pub fn label(self) -> &'static str {
+        match self {
+            KeyMode::Chroma => "Chroma (YUV)",
+            KeyMode::Color => "Color (RGB)",
+        }
+    }
+}
+
+/// Per-clip chroma key (green/blue screen). Neutral when `enabled` is `false`.
+/// Applied via avio `FilterStep::ChromaKey` / `ColorKey` (+ optional
+/// `SpillSuppress`) in the clip effect chain, so the keyed transparency shows
+/// identically in the preview and the export. Most useful on a V2 overlay clip
+/// (the key colour becomes transparent, revealing the track below).
+#[derive(Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Keying {
+    /// Whether keying is active.
+    pub enabled: bool,
+    /// Which key filter to use.
+    #[serde(default)]
+    pub mode: KeyMode,
+    /// Key colour (default green). Converted to an FFmpeg `0xRRGGBB` string.
+    #[serde(default = "default_key_colour")]
+    pub color: [u8; 3],
+    /// Match radius `0.0..=1.0`; higher removes more pixels.
+    #[serde(default = "default_key_similarity")]
+    pub similarity: f32,
+    /// Edge softness / feather `0.0..=1.0`; `0.0` = hard edge.
+    #[serde(default = "default_key_blend")]
+    pub blend: f32,
+    /// Spill suppression `0.0..=1.0`; `0.0` = off. Maps to avio `SpillSuppress`.
+    #[serde(default)]
+    pub spill: f32,
+}
+
+fn default_key_colour() -> [u8; 3] {
+    [0, 255, 0]
+}
+
+fn default_key_similarity() -> f32 {
+    0.30
+}
+
+fn default_key_blend() -> f32 {
+    0.10
+}
+
+impl Default for Keying {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            mode: KeyMode::default(),
+            color: default_key_colour(),
+            similarity: default_key_similarity(),
+            blend: default_key_blend(),
+            spill: 0.0,
+        }
+    }
+}
+
+impl Keying {
+    /// `true` when keying is active.
+    pub fn is_active(&self) -> bool {
+        self.enabled
+    }
+}
+
 #[derive(Clone, PartialEq)]
 pub struct TimelineClip {
     pub source_index: usize,
@@ -1003,6 +1079,8 @@ pub struct TimelineClip {
     pub overlay: Overlay,
     /// Per-clip burned-in subtitle (SRT / ASS). Default: none.
     pub subtitle: Subtitle,
+    /// Per-clip chroma key (green/blue screen). Default: disabled.
+    pub keying: Keying,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -670,6 +670,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 transform: state::Transform::default(),
                 overlay: state::Overlay::default(),
                 subtitle: state::Subtitle::default(),
+                keying: state::Keying::default(),
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -494,6 +494,61 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                         "Burned in per clip — subtitle timing is relative to this clip's start.",
                     );
                         });
+                    egui::CollapsingHeader::new("Chroma Key")
+                        .id_salt("clip_chroma_key")
+                        .default_open(false)
+                        .show(ui, |ui| {
+                    ui.checkbox(&mut clip.keying.enabled, "Enable chroma key")
+                        .on_hover_text(
+                            "Most useful on a V2+ overlay clip: the key colour becomes \
+                             transparent, revealing the track below.",
+                        );
+                    ui.add_enabled_ui(clip.keying.is_active(), |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label("Mode");
+                            ui.selectable_value(
+                                &mut clip.keying.mode,
+                                state::KeyMode::Chroma,
+                                state::KeyMode::Chroma.label(),
+                            );
+                            ui.selectable_value(
+                                &mut clip.keying.mode,
+                                state::KeyMode::Color,
+                                state::KeyMode::Color.label(),
+                            );
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("Key colour");
+                            ui.color_edit_button_srgb(&mut clip.keying.color);
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("Similarity");
+                            ui.add(
+                                egui::Slider::new(&mut clip.keying.similarity, 0.0..=1.0)
+                                    .fixed_decimals(2),
+                            );
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("Blend (feather)");
+                            ui.add(
+                                egui::Slider::new(&mut clip.keying.blend, 0.0..=1.0)
+                                    .fixed_decimals(2),
+                            );
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("Spill");
+                            ui.add(
+                                egui::Slider::new(&mut clip.keying.spill, 0.0..=1.0)
+                                    .fixed_decimals(2),
+                            );
+                        })
+                        .response
+                        .on_hover_text(
+                            "Spill suppression is an approximation (global desaturation via \
+                             hue), not limited to the key hue.",
+                        );
+                    });
+                        });
                     egui::CollapsingHeader::new("Color Grading")
                         .id_salt("clip_color_grading")
                         .default_open(true)
@@ -873,6 +928,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         transform: tc.transform,
                         overlay: tc.overlay.clone(),
                         subtitle: tc.subtitle.clone(),
+                        keying: tc.keying,
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -1353,6 +1409,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 transform: tc.transform,
                 overlay: tc.overlay.clone(),
                 subtitle: tc.subtitle.clone(),
+                keying: tc.keying,
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -1445,6 +1502,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             transform: tc.transform,
                             overlay: tc.overlay.clone(),
                             subtitle: tc.subtitle.clone(),
+                            keying: tc.keying,
                         };
                         let tracks = &state.timeline.tracks;
                         let audio_start = state.timeline.audio_track_start();
@@ -3282,6 +3340,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 transform: tc.transform,
                 overlay: tc.overlay.clone(),
                 subtitle: tc.subtitle.clone(),
+                keying: tc.keying,
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -3384,6 +3443,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             transform: state::Transform::default(),
             overlay: state::Overlay::default(),
             subtitle: state::Subtitle::default(),
+            keying: state::Keying::default(),
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -3528,6 +3588,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 transform: state.timeline.tracks[ti].clips[ci].transform,
                 overlay: state.timeline.tracks[ti].clips[ci].overlay.clone(),
                 subtitle: state.timeline.tracks[ti].clips[ci].subtitle.clone(),
+                keying: state.timeline.tracks[ti].clips[ci].keying,
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }


### PR DESCRIPTION
## Summary

Adds per-clip chroma keying (green/blue screen): enable it on a clip, pick the key colour, and tune similarity / blend (edge feather) / spill. Applied via avio's `ChromaKey` / `ColorKey` (+ optional `SpillSuppress`) in the per-clip effect chain, so the keyed transparency shows identically in the monitor preview and the export. Most useful on a V2 overlay clip — the key colour becomes transparent, revealing the track below. avio already had these filters, so this is a demo-only change.

## Changes

- **State** (`state.rs`): `Keying { enabled, mode, color, similarity, blend, spill }` and `KeyMode { Chroma (YUV), Color (RGB) }`; `keying` field on `TimelineClip`.
- **avio mapping** (`export.rs`): `apply_keying()` builds the key colour as `0xRRGGBB`, emits `FilterStep::ChromaKey` or `ColorKey { color, similarity, blend }`, and appends `SpillSuppress` when spill > 0. Applied **first** in the clip video chain (before transform/grade) so it keys the original colours; the produced alpha flows through to compositing. `keying` on `ExportClip`.
- **Preview** (`player.rs`): `keying` on `TrackClipData`; `make_clip` applies it first, matching export.
- **UI** (`ui/timeline.rs`): "Chroma Key" inspector section — Enable, Mode (Chroma/Color), key colour, similarity, blend (feather), spill; with a note that it's most useful on V2+ overlays and that spill is an approximation. Threaded through the export snapshot, the 3 preview spawn sites, and the drop/split constructors.
- **Persistence** (`project.rs`) + placement default (`clip_browser.rs`).
- **Tests**: disabled → no step; Chroma → `ChromaKey` (+ `SpillSuppress` when spill > 0); Color → `ColorKey`.

Verified in the app: keying removes the green (transparent) in preview. `blend` = edge feather. Spill suppress uses avio's `SpillSuppress` (a global hue-desaturation approximation), noted in the UI.

## Related Issues

Closes #133

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes