### PR TITLE
fix(monitor): preview keyed transparency over black to match export

### DIFF
--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -423,6 +423,12 @@ fn show_frame_fitted(
     let scale = (video_size.x / tex_size.x).min(video_size.y / tex_size.y);
     let disp = tex_size * scale;
     let img_rect = egui::Rect::from_center_size(area.center(), disp);
+    // Fill the frame rect with black before painting the (possibly alpha-carrying)
+    // frame, so transparent areas — e.g. from a chroma key / mask on a base clip —
+    // composite over black, matching the export's black canvas. Without this the
+    // egui panel background shows through and preview ≠ export.
+    ui.painter()
+        .rect_filled(img_rect, 0.0, egui::Color32::BLACK);
     egui::Image::new(egui::load::SizedTexture::new(tex.id(), disp)).paint_at(ui, img_rect);
     img_rect
 }


### PR DESCRIPTION
## Summary

Chroma-key (and any alpha-producing effect) on a base clip looked different in the preview vs the export: the monitor painted the RGBA frame straight onto the egui panel, so transparent areas showed the light panel background, while the export composites onto a black canvas. The keyed alpha was identical — only the background behind it differed. This paints the preview frame over black so transparent/keyed areas match the export.

## Changes

- **Root cause**: `show_frame_fitted` (`src/ui/monitor.rs`) painted the frame texture with `Image::paint_at` and no backing, so egui alpha-blended the frame over the panel background. Keyed/masked transparency therefore showed the panel colour in preview but black (avio's canvas) in export.
- **Fix**: fill `img_rect` with black (`painter().rect_filled`) before painting the frame, so transparent areas composite over black — matching the export canvas. No effect on opaque frames (the black is fully covered); over black, premultiplied/straight alpha give the same result.

Verified in the app: with a chroma key on a base clip, the preview transparent background is now black and matches the exported frame.

## Related Issues

Follow-up to #133 (chroma key preview/export parity).

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes