### PR TITLE
feat(timeline): per-clip masks (rectangle / luma / polygon)

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -76,6 +76,8 @@ pub struct ExportClip {
     pub subtitle: crate::state::Subtitle,
     /// Per-clip chroma key (green/blue screen).
     pub keying: crate::state::Keying,
+    /// Per-clip region-composite mask.
+    pub mask: crate::state::Mask,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -642,6 +644,66 @@ pub fn apply_keying(clip: avio::Clip, k: &crate::state::Keying) -> avio::Clip {
     }
 }
 
+/// Attaches a per-clip region-composite mask as avio `RectMask` / `LumaKey` /
+/// `PolygonMatte` (+ optional `FeatherMask`), shaping the clip's alpha so the
+/// region is kept and the rest becomes transparent. `src_w`/`src_h` convert the
+/// rectangle's percentages to pixels. No-op when `shape == None` or the region is
+/// degenerate. Shared by export and the preview so both match.
+pub fn apply_mask(clip: avio::Clip, m: &crate::state::Mask, src_w: u32, src_h: u32) -> avio::Clip {
+    use crate::state::MaskShape;
+    let clip = match m.shape {
+        MaskShape::None => return clip,
+        MaskShape::Rectangle => {
+            if src_w == 0 || src_h == 0 {
+                return clip;
+            }
+            let x = ((m.rect_x / 100.0) * src_w as f32).round().max(0.0) as u32;
+            let y = ((m.rect_y / 100.0) * src_h as f32).round().max(0.0) as u32;
+            let w = ((m.rect_w / 100.0) * src_w as f32).round().max(0.0) as u32;
+            let h = ((m.rect_h / 100.0) * src_h as f32).round().max(0.0) as u32;
+            // Clamp the rectangle inside the frame; skip if it rounds away.
+            let w = w.min(src_w.saturating_sub(x));
+            let h = h.min(src_h.saturating_sub(y));
+            if w < 1 || h < 1 {
+                return clip;
+            }
+            clip.with_video_effect(avio::FilterStep::RectMask {
+                x,
+                y,
+                width: w,
+                height: h,
+                invert: m.invert,
+            })
+        }
+        MaskShape::Luma => clip.with_video_effect(avio::FilterStep::LumaKey {
+            threshold: m.luma_threshold.clamp(0.0, 1.0),
+            tolerance: m.luma_tolerance.clamp(0.0, 1.0),
+            softness: m.luma_softness.clamp(0.0, 1.0),
+            invert: m.invert,
+        }),
+        MaskShape::Polygon => {
+            // PolygonMatte needs 3–16 vertices, each in [0,1].
+            if !(3..=16).contains(&m.polygon.len()) {
+                return clip;
+            }
+            let vertices: Vec<(f32, f32)> = m
+                .polygon
+                .iter()
+                .map(|&(x, y)| (x.clamp(0.0, 1.0), y.clamp(0.0, 1.0)))
+                .collect();
+            clip.with_video_effect(avio::FilterStep::PolygonMatte {
+                vertices,
+                invert: m.invert,
+            })
+        }
+    };
+    if m.feather > 0 {
+        clip.with_video_effect(avio::FilterStep::FeatherMask { radius: m.feather })
+    } else {
+        clip
+    }
+}
+
 fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio::Clip> {
     clips
         .into_iter()
@@ -727,6 +789,9 @@ fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio
             // Burned-in subtitle — on top of the overlay. Shared with the preview.
             // No-op when no subtitle file is set.
             let clip = apply_subtitle(clip, &c.subtitle);
+            // Region-composite mask (garbage matte) — shapes the final alpha.
+            // Shared with the preview. No-op when no mask shape is selected.
+            let clip = apply_mask(clip, &c.mask, c.width, c.height);
             #[allow(clippy::float_cmp)]
             let clip = if c.opacity != 1.0 {
                 clip.with_opacity(c.opacity)
@@ -1840,6 +1905,105 @@ mod tests {
         match &steps[0] {
             avio::FilterStep::ColorKey { color, .. } => assert_eq!(color, "0x0000FF"),
             other => panic!("expected ColorKey, got {other:?}"),
+        }
+    }
+
+    /// A `None`-shape mask attaches no step.
+    #[test]
+    fn mask_none_produces_no_step() {
+        use super::apply_mask;
+
+        let m = crate::state::Mask::default();
+        let steps = apply_mask(avio::Clip::new("test.mp4"), &m, 1920, 1080).video_effect_chain();
+        assert!(steps.is_empty());
+    }
+
+    /// Rectangle mask converts % to pixels and emits `RectMask`; feather appends
+    /// a `FeatherMask`.
+    #[test]
+    fn mask_rectangle_emits_rectmask_with_feather() {
+        use super::apply_mask;
+        use crate::state::{Mask, MaskShape};
+
+        let m = Mask {
+            shape: MaskShape::Rectangle,
+            invert: true,
+            feather: 8,
+            rect_x: 10.0,
+            rect_y: 20.0,
+            rect_w: 50.0,
+            rect_h: 25.0,
+            ..Default::default()
+        };
+        let steps = apply_mask(avio::Clip::new("test.mp4"), &m, 1920, 1080).video_effect_chain();
+        assert_eq!(steps.len(), 2);
+        match &steps[0] {
+            avio::FilterStep::RectMask {
+                x,
+                y,
+                width,
+                height,
+                invert,
+            } => {
+                assert_eq!(*x, 192); // 10% of 1920
+                assert_eq!(*y, 216); // 20% of 1080
+                assert_eq!(*width, 960); // 50% of 1920
+                assert_eq!(*height, 270); // 25% of 1080
+                assert!(*invert);
+            }
+            other => panic!("expected RectMask, got {other:?}"),
+        }
+        match &steps[1] {
+            avio::FilterStep::FeatherMask { radius } => assert_eq!(*radius, 8),
+            other => panic!("expected FeatherMask, got {other:?}"),
+        }
+    }
+
+    /// Luma mask emits `LumaKey` carrying the params.
+    #[test]
+    fn mask_luma_emits_lumakey() {
+        use super::apply_mask;
+        use crate::state::{Mask, MaskShape};
+
+        let m = Mask {
+            shape: MaskShape::Luma,
+            luma_threshold: 0.6,
+            luma_tolerance: 0.2,
+            luma_softness: 0.1,
+            ..Default::default()
+        };
+        let steps = apply_mask(avio::Clip::new("test.mp4"), &m, 1920, 1080).video_effect_chain();
+        assert_eq!(steps.len(), 1);
+        assert!(matches!(steps[0], avio::FilterStep::LumaKey { .. }));
+    }
+
+    /// A polygon with < 3 vertices is inactive; ≥ 3 emits `PolygonMatte`.
+    #[test]
+    fn mask_polygon_needs_three_vertices() {
+        use super::apply_mask;
+        use crate::state::{Mask, MaskShape};
+
+        let two = Mask {
+            shape: MaskShape::Polygon,
+            polygon: vec![(0.1, 0.1), (0.9, 0.1)],
+            ..Default::default()
+        };
+        assert!(
+            apply_mask(avio::Clip::new("t.mp4"), &two, 1920, 1080)
+                .video_effect_chain()
+                .is_empty()
+        );
+
+        let quad = Mask {
+            shape: MaskShape::Polygon,
+            polygon: crate::state::Mask::default_quad(),
+            ..Default::default()
+        };
+        let steps = apply_mask(avio::Clip::new("t.mp4"), &quad, 1920, 1080).video_effect_chain();
+        assert_eq!(steps.len(), 1);
+        match &steps[0] {
+            avio::FilterStep::PolygonMatte { vertices, .. } => assert_eq!(vertices.len(), 4),
+            other => panic!("expected PolygonMatte, got {other:?}"),
         }
     }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -67,6 +67,8 @@ pub struct TrackClipData {
     pub subtitle: crate::state::Subtitle,
     /// Per-clip chroma key (green/blue screen).
     pub keying: crate::state::Keying,
+    /// Per-clip region-composite mask.
+    pub mask: crate::state::Mask,
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -491,6 +493,8 @@ pub fn spawn_timeline_player(
             c = crate::export::apply_overlay(c, &tc.overlay);
             // Burned-in subtitle — on top of the overlay, matches export.
             c = crate::export::apply_subtitle(c, &tc.subtitle);
+            // Region-composite mask — shapes the final alpha, matches export.
+            c = crate::export::apply_mask(c, &tc.mask, tc.width, tc.height);
             #[allow(clippy::float_cmp)]
             if tc.opacity != 1.0 {
                 c = c.with_opacity(tc.opacity);

--- a/src/project.rs
+++ b/src/project.rs
@@ -87,6 +87,8 @@ pub struct ProjectTimelineClip {
     pub subtitle: crate::state::Subtitle,
     #[serde(default)]
     pub keying: crate::state::Keying,
+    #[serde(default)]
+    pub mask: crate::state::Mask,
 }
 
 fn default_wb_temperature() -> u32 {
@@ -255,6 +257,7 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         overlay: tc.overlay.clone(),
         subtitle: tc.subtitle.clone(),
         keying: tc.keying,
+        mask: tc.mask.clone(),
     }
 }
 
@@ -303,6 +306,7 @@ fn project_to_timeline_clip(
         overlay: ptc.overlay.clone(),
         subtitle: ptc.subtitle.clone(),
         keying: ptc.keying,
+        mask: ptc.mask.clone(),
     })
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1001,6 +1001,120 @@ impl Keying {
     }
 }
 
+/// Per-clip mask shape. `None` = no mask.
+#[derive(Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum MaskShape {
+    #[default]
+    None,
+    /// Rectangular region (avio `RectMask`).
+    Rectangle,
+    /// Luminance key (avio `LumaKey`).
+    Luma,
+    /// Polygon region (avio `PolygonMatte`).
+    Polygon,
+}
+
+impl MaskShape {
+    pub fn label(self) -> &'static str {
+        match self {
+            MaskShape::None => "None",
+            MaskShape::Rectangle => "Rectangle",
+            MaskShape::Luma => "Luma",
+            MaskShape::Polygon => "Polygon",
+        }
+    }
+
+    pub const ALL: [MaskShape; 4] = [
+        MaskShape::None,
+        MaskShape::Rectangle,
+        MaskShape::Luma,
+        MaskShape::Polygon,
+    ];
+}
+
+/// Per-clip region-composite mask (garbage matte): shapes the clip's alpha so the
+/// region is kept and the rest becomes transparent (revealing the track below).
+/// Applied via avio `RectMask` / `LumaKey` / `PolygonMatte` (+ optional
+/// `FeatherMask`) in the clip effect chain, so it shows identically in preview and
+/// export. Neutral when `shape == None`.
+#[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Mask {
+    /// Mask shape (or `None`).
+    #[serde(default)]
+    pub shape: MaskShape,
+    /// Invert the mask (keep the outside instead of the inside).
+    #[serde(default)]
+    pub invert: bool,
+    /// Feather radius in pixels (`0` = hard edge). Maps to avio `FeatherMask`.
+    #[serde(default)]
+    pub feather: u32,
+    /// Rectangle region as percentages of the frame (`0..100`).
+    #[serde(default = "default_mask_rect_pos")]
+    pub rect_x: f32,
+    #[serde(default = "default_mask_rect_pos")]
+    pub rect_y: f32,
+    #[serde(default = "default_mask_rect_size")]
+    pub rect_w: f32,
+    #[serde(default = "default_mask_rect_size")]
+    pub rect_h: f32,
+    /// Luma key: cutoff / match radius / edge softness (`0..1`).
+    #[serde(default = "default_mask_luma_threshold")]
+    pub luma_threshold: f32,
+    #[serde(default = "default_mask_luma_tolerance")]
+    pub luma_tolerance: f32,
+    #[serde(default)]
+    pub luma_softness: f32,
+    /// Polygon vertices in normalised `[0,1]` frame coordinates (3–16 to be active).
+    #[serde(default)]
+    pub polygon: Vec<(f32, f32)>,
+}
+
+fn default_mask_rect_pos() -> f32 {
+    10.0
+}
+
+fn default_mask_rect_size() -> f32 {
+    80.0
+}
+
+fn default_mask_luma_threshold() -> f32 {
+    0.5
+}
+
+fn default_mask_luma_tolerance() -> f32 {
+    0.1
+}
+
+impl Default for Mask {
+    fn default() -> Self {
+        Self {
+            shape: MaskShape::None,
+            invert: false,
+            feather: 0,
+            rect_x: default_mask_rect_pos(),
+            rect_y: default_mask_rect_pos(),
+            rect_w: default_mask_rect_size(),
+            rect_h: default_mask_rect_size(),
+            luma_threshold: default_mask_luma_threshold(),
+            luma_tolerance: default_mask_luma_tolerance(),
+            luma_softness: 0.0,
+            polygon: Vec::new(),
+        }
+    }
+}
+
+impl Mask {
+    /// `true` when a mask shape is selected.
+    pub fn is_active(&self) -> bool {
+        self.shape != MaskShape::None
+    }
+
+    /// Seeds a centred quad polygon (used when starting polygon editing).
+    pub fn default_quad() -> Vec<(f32, f32)> {
+        vec![(0.25, 0.25), (0.75, 0.25), (0.75, 0.75), (0.25, 0.75)]
+    }
+}
+
 #[derive(Clone, PartialEq)]
 pub struct TimelineClip {
     pub source_index: usize,
@@ -1081,6 +1195,8 @@ pub struct TimelineClip {
     pub subtitle: Subtitle,
     /// Per-clip chroma key (green/blue screen). Default: disabled.
     pub keying: Keying,
+    /// Per-clip region-composite mask. Default: none.
+    pub mask: Mask,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -671,6 +671,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 overlay: state::Overlay::default(),
                 subtitle: state::Subtitle::default(),
                 keying: state::Keying::default(),
+                mask: state::Mask::default(),
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -37,15 +37,21 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
     let video_size = egui::vec2(available.x, (available.y - ctrl_height).max(0.0));
 
     if timeline_is_active {
+        let mut poly_rect = None;
         if let Some(tex) = &state.preview_texture {
             let img_rect = show_frame_fitted(ui, tex, video_size);
             draw_title_overlays(state, ui, img_rect);
+            poly_rect = Some(img_rect);
         } else {
             ui.allocate_ui(video_size, |ui| {
                 ui.centered_and_justified(|ui| {
                     ui.label("Loading…");
                 });
             });
+        }
+        // Polygon-mask vertex editing overlay (after the texture borrow ends).
+        if let Some(img_rect) = poly_rect {
+            edit_polygon_mask(state, ui, img_rect);
         }
     } else if state.monitor_clip_index.is_some() {
         let is_audio_only = state
@@ -431,6 +437,130 @@ fn show_frame_fitted(
         .rect_filled(img_rect, 0.0, egui::Color32::BLACK);
     egui::Image::new(egui::load::SizedTexture::new(tex.id(), disp)).paint_at(ui, img_rect);
     img_rect
+}
+
+/// Draws draggable handles for the selected clip's polygon mask over `img_rect`.
+/// Vertices are stored normalised (`[0,1]`); drag moves them, right-click removes
+/// one (keeping at least 3). No-op unless the selected timeline clip has a polygon
+/// mask. Best used while paused (the last frame stays in the preview texture).
+fn edit_polygon_mask(state: &mut state::AppState, ui: &egui::Ui, img_rect: egui::Rect) {
+    let Some((ti, ci)) = state.timeline_selected else {
+        return;
+    };
+    let Some(clip) = state
+        .timeline
+        .tracks
+        .get_mut(ti)
+        .and_then(|t| t.clips.get_mut(ci))
+    else {
+        return;
+    };
+    if clip.mask.shape != state::MaskShape::Polygon || clip.mask.polygon.is_empty() {
+        return;
+    }
+
+    let to_screen = |(nx, ny): (f32, f32)| {
+        egui::pos2(
+            img_rect.min.x + nx * img_rect.width(),
+            img_rect.min.y + ny * img_rect.height(),
+        )
+    };
+
+    // Outline (closed loop).
+    if clip.mask.polygon.len() >= 2 {
+        let mut pts: Vec<egui::Pos2> = clip.mask.polygon.iter().map(|&v| to_screen(v)).collect();
+        if let Some(&first) = pts.first() {
+            pts.push(first);
+        }
+        ui.painter().add(egui::Shape::line(
+            pts,
+            egui::Stroke::new(1.5, egui::Color32::from_rgb(255, 220, 0)),
+        ));
+    }
+
+    // Background click area for double-click-to-add. Registered before the handles
+    // so the handles stay on top for drags / right-clicks.
+    let bg = ui.interact(
+        img_rect,
+        ui.id().with(("poly_bg", ti, ci)),
+        egui::Sense::click(),
+    );
+
+    // Draggable handles; right-click removes (min 3 vertices).
+    let n = clip.mask.polygon.len();
+    let mut remove: Option<usize> = None;
+    for i in 0..n {
+        let p = to_screen(clip.mask.polygon[i]);
+        let handle = egui::Rect::from_center_size(p, egui::vec2(12.0, 12.0));
+        let resp = ui.interact(
+            handle,
+            ui.id().with(("poly_vertex", ti, ci, i)),
+            egui::Sense::click_and_drag(),
+        );
+        let color = if resp.hovered() || resp.dragged() {
+            egui::Color32::WHITE
+        } else {
+            egui::Color32::from_rgb(255, 220, 0)
+        };
+        ui.painter().circle_filled(p, 5.0, color);
+        ui.painter()
+            .circle_stroke(p, 5.0, egui::Stroke::new(1.0, egui::Color32::BLACK));
+        if resp.dragged() && img_rect.width() > 0.0 && img_rect.height() > 0.0 {
+            let np = p + resp.drag_delta();
+            let nx = ((np.x - img_rect.min.x) / img_rect.width()).clamp(0.0, 1.0);
+            let ny = ((np.y - img_rect.min.y) / img_rect.height()).clamp(0.0, 1.0);
+            clip.mask.polygon[i] = (nx, ny);
+        }
+        if resp.secondary_clicked() && n > 3 {
+            remove = Some(i);
+        }
+    }
+    if let Some(i) = remove {
+        clip.mask.polygon.remove(i);
+    }
+
+    // Double-click on empty area inserts a vertex on the nearest edge (max 16).
+    if bg.double_clicked()
+        && clip.mask.polygon.len() < 16
+        && img_rect.width() > 0.0
+        && img_rect.height() > 0.0
+        && let Some(pos) = bg.interact_pointer_pos()
+    {
+        let v = (
+            ((pos.x - img_rect.min.x) / img_rect.width()).clamp(0.0, 1.0),
+            ((pos.y - img_rect.min.y) / img_rect.height()).clamp(0.0, 1.0),
+        );
+        let poly = &mut clip.mask.polygon;
+        if poly.len() < 2 {
+            poly.push(v);
+        } else {
+            let m = poly.len();
+            let mut best = (f32::MAX, 0usize);
+            for i in 0..m {
+                let d = dist_point_seg(v, poly[i], poly[(i + 1) % m]);
+                if d < best.0 {
+                    best = (d, i);
+                }
+            }
+            poly.insert(best.1 + 1, v);
+        }
+    }
+}
+
+/// Distance from point `p` to segment `a`–`b` (all normalised coordinates).
+fn dist_point_seg(p: (f32, f32), a: (f32, f32), b: (f32, f32)) -> f32 {
+    let (px, py) = p;
+    let (ax, ay) = a;
+    let (bx, by) = b;
+    let (dx, dy) = (bx - ax, by - ay);
+    let len2 = dx * dx + dy * dy;
+    let t = if len2 <= 0.0 {
+        0.0
+    } else {
+        (((px - ax) * dx + (py - ay) * dy) / len2).clamp(0.0, 1.0)
+    };
+    let (cx, cy) = (ax + t * dx, ay + t * dy);
+    ((px - cx).powi(2) + (py - cy).powi(2)).sqrt()
 }
 
 /// Draws active T1 title clips as egui text on top of the preview image rect.

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -549,6 +549,125 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                         );
                     });
                         });
+                    egui::CollapsingHeader::new("Mask")
+                        .id_salt("clip_mask")
+                        .default_open(false)
+                        .show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label("Shape");
+                        egui::ComboBox::from_id_salt("clip_mask_shape")
+                            .selected_text(clip.mask.shape.label())
+                            .show_ui(ui, |ui| {
+                                for s in state::MaskShape::ALL {
+                                    ui.selectable_value(&mut clip.mask.shape, s, s.label());
+                                }
+                            });
+                    });
+                    if clip.mask.is_active() {
+                        ui.horizontal(|ui| {
+                            ui.checkbox(&mut clip.mask.invert, "Invert");
+                            ui.separator();
+                            ui.label("Feather");
+                            ui.add(
+                                egui::DragValue::new(&mut clip.mask.feather)
+                                    .range(0..=200)
+                                    .suffix(" px"),
+                            );
+                        });
+                        match clip.mask.shape {
+                            state::MaskShape::Rectangle => {
+                                ui.horizontal_wrapped(|ui| {
+                                    ui.label("X");
+                                    ui.add(
+                                        egui::Slider::new(&mut clip.mask.rect_x, 0.0..=100.0)
+                                            .suffix(" %")
+                                            .fixed_decimals(0),
+                                    );
+                                    ui.separator();
+                                    ui.label("Y");
+                                    ui.add(
+                                        egui::Slider::new(&mut clip.mask.rect_y, 0.0..=100.0)
+                                            .suffix(" %")
+                                            .fixed_decimals(0),
+                                    );
+                                });
+                                ui.horizontal_wrapped(|ui| {
+                                    ui.label("W");
+                                    ui.add(
+                                        egui::Slider::new(&mut clip.mask.rect_w, 1.0..=100.0)
+                                            .suffix(" %")
+                                            .fixed_decimals(0),
+                                    );
+                                    ui.separator();
+                                    ui.label("H");
+                                    ui.add(
+                                        egui::Slider::new(&mut clip.mask.rect_h, 1.0..=100.0)
+                                            .suffix(" %")
+                                            .fixed_decimals(0),
+                                    );
+                                });
+                            }
+                            state::MaskShape::Luma => {
+                                ui.horizontal(|ui| {
+                                    ui.label("Threshold");
+                                    ui.add(
+                                        egui::Slider::new(
+                                            &mut clip.mask.luma_threshold,
+                                            0.0..=1.0,
+                                        )
+                                        .fixed_decimals(2),
+                                    );
+                                });
+                                ui.horizontal(|ui| {
+                                    ui.label("Tolerance");
+                                    ui.add(
+                                        egui::Slider::new(
+                                            &mut clip.mask.luma_tolerance,
+                                            0.0..=1.0,
+                                        )
+                                        .fixed_decimals(2),
+                                    );
+                                });
+                                ui.horizontal(|ui| {
+                                    ui.label("Softness");
+                                    ui.add(
+                                        egui::Slider::new(
+                                            &mut clip.mask.luma_softness,
+                                            0.0..=1.0,
+                                        )
+                                        .fixed_decimals(2),
+                                    );
+                                });
+                            }
+                            state::MaskShape::Polygon => {
+                                ui.horizontal(|ui| {
+                                    if ui.button("Reset to quad").clicked() {
+                                        clip.mask.polygon = state::Mask::default_quad();
+                                    }
+                                    if ui
+                                        .add_enabled(
+                                            !clip.mask.polygon.is_empty(),
+                                            egui::Button::new("Clear"),
+                                        )
+                                        .clicked()
+                                    {
+                                        clip.mask.polygon.clear();
+                                    }
+                                    ui.label(format!("{} pts", clip.mask.polygon.len()));
+                                });
+                                ui.weak(
+                                    "On the monitor (paused): drag vertices, double-click to add, \
+                                     right-click to remove. Needs 3–16 points.",
+                                );
+                            }
+                            state::MaskShape::None => {}
+                        }
+                        ui.weak(
+                            "Region-composite (garbage matte): keeps the region, rest transparent. \
+                             Most useful on a V2 overlay clip.",
+                        );
+                    }
+                        });
                     egui::CollapsingHeader::new("Color Grading")
                         .id_salt("clip_color_grading")
                         .default_open(true)
@@ -929,6 +1048,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         overlay: tc.overlay.clone(),
                         subtitle: tc.subtitle.clone(),
                         keying: tc.keying,
+                        mask: tc.mask.clone(),
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -1410,6 +1530,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 overlay: tc.overlay.clone(),
                 subtitle: tc.subtitle.clone(),
                 keying: tc.keying,
+                mask: tc.mask.clone(),
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -1503,6 +1624,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             overlay: tc.overlay.clone(),
                             subtitle: tc.subtitle.clone(),
                             keying: tc.keying,
+                            mask: tc.mask.clone(),
                         };
                         let tracks = &state.timeline.tracks;
                         let audio_start = state.timeline.audio_track_start();
@@ -3341,6 +3463,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 overlay: tc.overlay.clone(),
                 subtitle: tc.subtitle.clone(),
                 keying: tc.keying,
+                mask: tc.mask.clone(),
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -3444,6 +3567,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             overlay: state::Overlay::default(),
             subtitle: state::Subtitle::default(),
             keying: state::Keying::default(),
+            mask: state::Mask::default(),
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -3589,6 +3713,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 overlay: state.timeline.tracks[ti].clips[ci].overlay.clone(),
                 subtitle: state.timeline.tracks[ti].clips[ci].subtitle.clone(),
                 keying: state.timeline.tracks[ti].clips[ci].keying,
+                mask: state.timeline.tracks[ti].clips[ci].mask.clone(),
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }


### PR DESCRIPTION
## Summary

Adds per-clip region-composite masks (garbage matte): pick a Rectangle, Luma, or Polygon shape in the clip inspector to keep a region and make the rest transparent, so the clip composites as a region over the track below. Includes Invert and Feather, and on-monitor polygon vertex editing. Applied via avio's `RectMask` / `LumaKey` / `PolygonMatte` (+ `FeatherMask`) in the per-clip effect chain, so preview matches export. This is Phase A (region masks); "apply an effect only inside a mask" is a documented follow-up needing an avio compound primitive.

## Changes

- **State** (`state.rs`): `Mask { shape, invert, feather, rect_x/y/w/h (%), luma_threshold/tolerance/softness, polygon (normalised) }` and `MaskShape { None, Rectangle, Luma, Polygon }`; `mask` field on `TimelineClip`.
- **avio mapping** (`export.rs`): `apply_mask()` → `%`→px `RectMask` / `LumaKey` / `PolygonMatte` (3–16 verts) + optional `FeatherMask`, applied after the subtitle step; no-op when shape is None. `mask` on `ExportClip`.
- **Preview** (`player.rs`): `mask` on `TrackClipData`; `make_clip` calls `apply_mask`, matching export.
- **UI** (`ui/timeline.rs`): "Mask" inspector — Shape / Invert / Feather; Rectangle X/Y/W/H %, Luma threshold/tolerance/softness, Polygon Reset-to-quad / Clear / vertex count.
- **Polygon editing** (`ui/monitor.rs`): draggable vertex handles over the preview when a polygon-mask clip is selected — drag to move, double-click to add (nearest edge), right-click to remove (min 3).
- **Persistence** (`project.rs`) + placement default (`clip_browser.rs`).
- **Tests**: `apply_mask` no-op when None; Rectangle emits `RectMask` (px from %) + `FeatherMask`; Luma emits `LumaKey`; Polygon needs ≥3 vertices → `PolygonMatte`.

Verified in the app: all mask types show identically in preview and export (a batch of avio fixes — PolygonMatte geq, export-overlay alpha, LumaKey invert, geq→rgba — landed to make masks/keys composite consistently on render). Most useful on a V2 overlay (masked region reveals V1).

## Related Issues

Closes #137

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes