### PR TITLE
feat(timeline): per-clip opacity keyframe animation

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -78,6 +78,8 @@ pub struct ExportClip {
     pub keying: crate::state::Keying,
     /// Per-clip region-composite mask.
     pub mask: crate::state::Mask,
+    /// Per-clip keyframe animation (opacity now; more properties in later phases).
+    pub animation: crate::state::ClipAnimation,
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -704,6 +706,59 @@ pub fn apply_mask(clip: avio::Clip, m: &crate::state::Mask, src_w: u32, src_h: u
     }
 }
 
+/// Maps a demo [`KeyEasing`](crate::state::KeyEasing) to the avio easing.
+fn easing_to_avio(e: crate::state::KeyEasing) -> avio::Easing {
+    use crate::state::KeyEasing;
+    match e {
+        KeyEasing::Linear => avio::Easing::Linear,
+        KeyEasing::EaseIn => avio::Easing::EaseIn,
+        KeyEasing::EaseOut => avio::Easing::EaseOut,
+        KeyEasing::EaseInOut => avio::Easing::EaseInOut,
+        KeyEasing::Hold => avio::Easing::Hold,
+    }
+}
+
+/// Converts a clip-local demo [`KeyTrack`](crate::state::KeyTrack) into a
+/// timeline-global `avio::AnimationTrack`: each key's clip-local `t_secs` is offset
+/// by the clip's `start` on the timeline (avio evaluates tracks at the composition
+/// graph's output PTS), and values are clamped to `[lo, hi]`.
+fn keytrack_to_avio(
+    kt: &crate::state::KeyTrack,
+    start: Duration,
+    lo: f64,
+    hi: f64,
+) -> avio::AnimationTrack<f64> {
+    let mut track = avio::AnimationTrack::new();
+    for k in &kt.keys {
+        let ts = start + Duration::from_secs_f64(k.t_secs.max(0.0));
+        track = track.push(avio::Keyframe::new(
+            ts,
+            k.value.clamp(lo, hi),
+            easing_to_avio(k.easing),
+        ));
+    }
+    track
+}
+
+/// Attaches per-clip keyframe animation to the avio `Clip`.
+///
+/// D1 wires the **opacity** track: clip-local keyframe times are offset by
+/// `start_on_track` into the timeline-global track avio evaluates, and applied via
+/// `Clip::with_opacity_track` (drives the `colorchannelmixer` alpha per frame). No-op
+/// when the track is empty. Shared by export and preview so both match. (Opacity
+/// animates in export now via avio #1291; preview parity lands with avio #1292.)
+pub fn apply_animation(
+    clip: avio::Clip,
+    anim: &crate::state::ClipAnimation,
+    start_on_track: Duration,
+) -> avio::Clip {
+    if anim.opacity.is_active() {
+        clip.with_opacity_track(keytrack_to_avio(&anim.opacity, start_on_track, 0.0, 1.0))
+    } else {
+        clip
+    }
+}
+
 fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio::Clip> {
     clips
         .into_iter()
@@ -792,6 +847,9 @@ fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio
             // Region-composite mask (garbage matte) — shapes the final alpha.
             // Shared with the preview. No-op when no mask shape is selected.
             let clip = apply_mask(clip, &c.mask, c.width, c.height);
+            // Per-clip keyframe animation (opacity). Sets an opacity track that takes
+            // precedence over the static opacity below. Shared with the preview.
+            let clip = apply_animation(clip, &c.animation, c.start_on_track);
             #[allow(clippy::float_cmp)]
             let clip = if c.opacity != 1.0 {
                 clip.with_opacity(c.opacity)
@@ -2027,6 +2085,89 @@ mod tests {
         assert_eq!(
             OverlayPosition::BottomCentre.to_exprs(15),
             ("(W-w)/2".to_string(), "H-h-15".to_string())
+        );
+    }
+
+    /// An empty animation attaches no opacity track.
+    #[test]
+    fn animation_empty_is_noop() {
+        use super::apply_animation;
+
+        let anim = crate::state::ClipAnimation::default();
+        let clip = apply_animation(avio::Clip::new("t.mp4"), &anim, std::time::Duration::ZERO);
+        assert!(clip.opacity_track.is_none());
+    }
+
+    /// The opacity track is offset from clip-local to timeline-global time by the
+    /// clip's `start_on_track`, and interpolates linearly between keys.
+    #[test]
+    fn animation_opacity_track_is_offset_to_global_time() {
+        use super::apply_animation;
+        use crate::state::{ClipAnimation, KeyEasing};
+        use std::time::Duration;
+
+        let mut anim = ClipAnimation::default();
+        anim.opacity.insert(0.0, 0.0, KeyEasing::Linear);
+        anim.opacity.insert(1.0, 1.0, KeyEasing::Linear);
+        // Clip placed at 2s on the timeline.
+        let clip = apply_animation(avio::Clip::new("t.mp4"), &anim, Duration::from_secs(2));
+        let track = clip.opacity_track.expect("opacity track set");
+        // Held at the first value before the clip's global start.
+        assert!(track.value_at(Duration::from_secs(2)).abs() < 1e-9);
+        // Clip-local 0.5s → global 2.5s → linear midpoint 0.5.
+        assert!((track.value_at(Duration::from_millis(2500)) - 0.5).abs() < 1e-9);
+        // Held at the last value after the clip-local end (global 3s+).
+        assert!((track.value_at(Duration::from_secs(3)) - 1.0).abs() < 1e-9);
+    }
+
+    /// Per-key easing survives the demo→avio conversion, and the SEGMENT uses the
+    /// preceding (earlier) key's easing — so easing must sit on the first key.
+    #[test]
+    fn animation_opacity_segment_uses_first_key_easing() {
+        use super::apply_animation;
+        use crate::state::{ClipAnimation, KeyEasing};
+        use std::time::Duration;
+
+        // EaseInOut on the FIRST key → S-curve: below linear at the quarter point.
+        let mut ease = ClipAnimation::default();
+        ease.opacity.insert(0.0, 0.0, KeyEasing::EaseInOut);
+        ease.opacity.insert(2.0, 1.0, KeyEasing::Linear);
+        let et = apply_animation(avio::Clip::new("t.mp4"), &ease, Duration::ZERO)
+            .opacity_track
+            .expect("track");
+        let q = et.value_at(Duration::from_millis(500)); // t=0.5s of a 2s ramp
+        assert!(
+            q < 0.24,
+            "EaseInOut should ease below linear (0.25) at quarter, got {q}"
+        );
+        assert!((et.value_at(Duration::from_secs(1)) - 0.5).abs() < 1e-6);
+
+        // Easing on the SECOND (last) key is ignored by avio → segment stays linear.
+        let mut on_last = ClipAnimation::default();
+        on_last.opacity.insert(0.0, 0.0, KeyEasing::Linear);
+        on_last.opacity.insert(2.0, 1.0, KeyEasing::EaseInOut);
+        let lt = apply_animation(avio::Clip::new("t.mp4"), &on_last, Duration::ZERO)
+            .opacity_track
+            .expect("track");
+        assert!(
+            (lt.value_at(Duration::from_millis(500)) - 0.25).abs() < 1e-6,
+            "easing on the last key must not change the segment (stays linear)"
+        );
+
+        // Hold on the first key holds the start value across the segment, then snaps.
+        let mut hold = ClipAnimation::default();
+        hold.opacity.insert(0.0, 0.0, KeyEasing::Hold);
+        hold.opacity.insert(2.0, 1.0, KeyEasing::Linear);
+        let ht = apply_animation(avio::Clip::new("t.mp4"), &hold, Duration::ZERO)
+            .opacity_track
+            .expect("track");
+        assert!(
+            ht.value_at(Duration::from_secs(1)).abs() < 1e-9,
+            "Hold holds start mid-segment"
+        );
+        assert!(
+            (ht.value_at(Duration::from_secs(2)) - 1.0).abs() < 1e-9,
+            "Hold snaps at end"
         );
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -69,6 +69,8 @@ pub struct TrackClipData {
     pub keying: crate::state::Keying,
     /// Per-clip region-composite mask.
     pub mask: crate::state::Mask,
+    /// Per-clip keyframe animation (opacity now; more properties in later phases).
+    pub animation: crate::state::ClipAnimation,
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -495,6 +497,9 @@ pub fn spawn_timeline_player(
             c = crate::export::apply_subtitle(c, &tc.subtitle);
             // Region-composite mask — shapes the final alpha, matches export.
             c = crate::export::apply_mask(c, &tc.mask, tc.width, tc.height);
+            // Per-clip keyframe animation (opacity) — matches export. Opacity animates
+            // in the preview once avio #1292 lands; export animates now (avio #1291).
+            c = crate::export::apply_animation(c, &tc.animation, tc.start_on_track);
             #[allow(clippy::float_cmp)]
             if tc.opacity != 1.0 {
                 c = c.with_opacity(tc.opacity);

--- a/src/project.rs
+++ b/src/project.rs
@@ -89,6 +89,8 @@ pub struct ProjectTimelineClip {
     pub keying: crate::state::Keying,
     #[serde(default)]
     pub mask: crate::state::Mask,
+    #[serde(default)]
+    pub animation: crate::state::ClipAnimation,
 }
 
 fn default_wb_temperature() -> u32 {
@@ -258,6 +260,7 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         subtitle: tc.subtitle.clone(),
         keying: tc.keying,
         mask: tc.mask.clone(),
+        animation: tc.animation.clone(),
     }
 }
 
@@ -307,6 +310,7 @@ fn project_to_timeline_clip(
         subtitle: ptc.subtitle.clone(),
         keying: ptc.keying,
         mask: ptc.mask.clone(),
+        animation: ptc.animation.clone(),
     })
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1115,6 +1115,146 @@ impl Mask {
     }
 }
 
+/// Easing applied for a keyframe segment (from this key to the next). A demo-facing
+/// subset of `avio::Easing` (no Bézier) so [`ClipAnimation`] can derive `PartialEq`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub enum KeyEasing {
+    /// Constant-rate interpolation.
+    #[default]
+    Linear,
+    /// Cubic ease-in (slow start).
+    EaseIn,
+    /// Cubic ease-out (slow end).
+    EaseOut,
+    /// Cubic ease-in-out (slow at both ends).
+    EaseInOut,
+    /// Snap to the next value (no interpolation).
+    Hold,
+}
+
+impl KeyEasing {
+    /// All variants, for UI selectors.
+    pub const ALL: [KeyEasing; 5] = [
+        KeyEasing::Linear,
+        KeyEasing::EaseIn,
+        KeyEasing::EaseOut,
+        KeyEasing::EaseInOut,
+        KeyEasing::Hold,
+    ];
+
+    /// Human-readable label.
+    pub fn label(self) -> &'static str {
+        match self {
+            KeyEasing::Linear => "Linear",
+            KeyEasing::EaseIn => "Ease In",
+            KeyEasing::EaseOut => "Ease Out",
+            KeyEasing::EaseInOut => "Ease In-Out",
+            KeyEasing::Hold => "Hold",
+        }
+    }
+}
+
+/// One keyframe: a **clip-local** time (seconds from the clip's start on the track),
+/// a value, and the easing applied from this key to the next.
+#[derive(Clone, Copy, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Key {
+    /// Clip-local time in seconds (`0.0` = the clip's start on the timeline).
+    pub t_secs: f64,
+    /// Property value at this keyframe.
+    pub value: f64,
+    /// Easing from this keyframe to the next.
+    #[serde(default)]
+    pub easing: KeyEasing,
+}
+
+/// A keyframe track for a single property. Empty = static (no animation).
+#[derive(Clone, PartialEq, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct KeyTrack {
+    /// Keyframes, kept sorted by `t_secs`.
+    #[serde(default)]
+    pub keys: Vec<Key>,
+}
+
+impl KeyTrack {
+    /// `true` when the track drives an animation (has at least one key).
+    pub fn is_active(&self) -> bool {
+        !self.keys.is_empty()
+    }
+
+    /// Inserts a keyframe at `t_secs`, replacing any existing key at the same time
+    /// and keeping the list sorted by time.
+    pub fn insert(&mut self, t_secs: f64, value: f64, easing: KeyEasing) {
+        let key = Key {
+            t_secs,
+            value,
+            easing,
+        };
+        match self
+            .keys
+            .iter()
+            .position(|k| (k.t_secs - t_secs).abs() < 1e-6)
+        {
+            Some(i) => self.keys[i] = key,
+            None => {
+                let pos = self.keys.partition_point(|k| k.t_secs < t_secs);
+                self.keys.insert(pos, key);
+            }
+        }
+    }
+}
+
+/// Per-clip keyframe animation of transform / opacity properties.
+///
+/// Empty tracks are static (no-op). Keyframe times are **clip-local**;
+/// `export::apply_animation` offsets them by the clip's `start_on_track` into the
+/// timeline-global tracks avio evaluates at the composition graph's output PTS.
+///
+/// D1 wires `opacity` end-to-end (export via avio #1291; preview parity lands with
+/// avio #1292). `pos_x`/`pos_y`/`scale`/`rotation` are reserved for later phases.
+#[derive(Clone, PartialEq, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct ClipAnimation {
+    /// Opacity track (`0.0`..=`1.0`).
+    #[serde(default)]
+    pub opacity: KeyTrack,
+    /// Overlay X-position track (pixels). Reserved (avio #1293).
+    #[serde(default)]
+    pub pos_x: KeyTrack,
+    /// Overlay Y-position track (pixels). Reserved (avio #1293).
+    #[serde(default)]
+    pub pos_y: KeyTrack,
+    /// Scale track (`1.0` = 100%). Reserved (avio #1297).
+    #[serde(default)]
+    pub scale: KeyTrack,
+    /// Rotation track (degrees). Reserved (avio #1296).
+    #[serde(default)]
+    pub rotation: KeyTrack,
+}
+
+impl ClipAnimation {
+    /// `true` when any property track is animated.
+    pub fn is_active(&self) -> bool {
+        self.opacity.is_active()
+            || self.pos_x.is_active()
+            || self.pos_y.is_active()
+            || self.scale.is_active()
+            || self.rotation.is_active()
+    }
+
+    /// Active `(label, track)` pairs, for timeline visualization and tooltips.
+    pub fn active_tracks(&self) -> Vec<(&'static str, &KeyTrack)> {
+        [
+            ("Opacity", &self.opacity),
+            ("Position X", &self.pos_x),
+            ("Position Y", &self.pos_y),
+            ("Scale", &self.scale),
+            ("Rotation", &self.rotation),
+        ]
+        .into_iter()
+        .filter(|(_, t)| t.is_active())
+        .collect()
+    }
+}
+
 #[derive(Clone, PartialEq)]
 pub struct TimelineClip {
     pub source_index: usize,
@@ -1197,6 +1337,8 @@ pub struct TimelineClip {
     pub keying: Keying,
     /// Per-clip region-composite mask. Default: none.
     pub mask: Mask,
+    /// Per-clip keyframe animation (opacity now; position/scale/rotation reserved).
+    pub animation: ClipAnimation,
 }
 
 pub struct TimelineState {

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -672,6 +672,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 subtitle: state::Subtitle::default(),
                 keying: state::Keying::default(),
                 mask: state::Mask::default(),
+                animation: state::ClipAnimation::default(),
             });
         }
         let can_trim = clip.in_point.is_some() && clip.out_point.is_some();

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -198,6 +198,9 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
             .and_then(|n| n.to_str())
             .unwrap_or("(clip)")
             .to_owned();
+        // Captured before the mutable clip borrow below; used to place opacity
+        // keyframes at the current playhead (converted to clip-local time).
+        let playhead_secs = state.timeline_playhead_secs;
         if let Some(clip) = state
             .timeline
             .tracks
@@ -240,6 +243,95 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                             clip.opacity = (opacity_pct / 100.0).clamp(0.0, 1.0);
                         }
                     });
+                    // ── Opacity keyframes ──────────────────────────────────────
+                    // Animate opacity over time. Keys are authored at the playhead
+                    // (clip-local time) with the current opacity value; both preview
+                    // and export animate (avio #1291 / #1292). A key's easing controls
+                    // the segment FROM that key TO the next one, so it is shown only on
+                    // keys that have a following segment (the last key's easing is unused).
+                    egui::CollapsingHeader::new("Opacity Keyframes")
+                        .id_salt("clip_opacity_keys")
+                        .default_open(clip.animation.opacity.is_active())
+                        .show(ui, |ui| {
+                            let clip_local =
+                                (playhead_secs - clip.start_on_track.as_secs_f64()).max(0.0);
+                            ui.horizontal(|ui| {
+                                if ui
+                                    .button("＋ Key @ playhead")
+                                    .on_hover_text(format!(
+                                        "Add an opacity key at {clip_local:.2}s (clip-local) \
+                                         = {:.0}%",
+                                        clip.opacity * 100.0
+                                    ))
+                                    .clicked()
+                                {
+                                    clip.animation.opacity.insert(
+                                        clip_local,
+                                        f64::from(clip.opacity),
+                                        state::KeyEasing::Linear,
+                                    );
+                                }
+                                if clip.animation.opacity.is_active()
+                                    && ui.button("Clear").clicked()
+                                {
+                                    clip.animation.opacity.keys.clear();
+                                }
+                            });
+                            if clip.animation.opacity.is_active() {
+                                ui.weak(
+                                    "Easing is the ramp to the NEXT key. Re-play to preview edits.",
+                                );
+                                let n = clip.animation.opacity.keys.len();
+                                let mut to_delete: Option<usize> = None;
+                                for (i, k) in
+                                    clip.animation.opacity.keys.iter_mut().enumerate()
+                                {
+                                    ui.horizontal(|ui| {
+                                        ui.label(format!("{:.2}s", k.t_secs));
+                                        let mut v_pct = k.value * 100.0;
+                                        if ui
+                                            .add(
+                                                egui::DragValue::new(&mut v_pct)
+                                                    .range(0.0..=100.0)
+                                                    .suffix(" %")
+                                                    .fixed_decimals(0),
+                                            )
+                                            .changed()
+                                        {
+                                            k.value = (v_pct / 100.0).clamp(0.0, 1.0);
+                                        }
+                                        // Easing drives the segment to the next key; the
+                                        // last key has none, so hide its selector.
+                                        if i + 1 < n {
+                                            egui::ComboBox::from_id_salt((
+                                                "opacity_key_ease",
+                                                i,
+                                            ))
+                                            .selected_text(k.easing.label())
+                                            .show_ui(ui, |ui| {
+                                                for e in state::KeyEasing::ALL {
+                                                    ui.selectable_value(
+                                                        &mut k.easing,
+                                                        e,
+                                                        e.label(),
+                                                    );
+                                                }
+                                            });
+                                        } else {
+                                            ui.weak("→ end");
+                                        }
+                                        if ui.button("✖").clicked() {
+                                            to_delete = Some(i);
+                                        }
+                                    });
+                                }
+                                if let Some(i) = to_delete {
+                                    clip.animation.opacity.keys.remove(i);
+                                }
+                            } else {
+                                ui.weak("No keys — opacity is static.");
+                            }
+                        });
                     // Blend mode is only meaningful for overlay (V2+) clips.
                     if ti >= 1 {
                         ui.horizontal(|ui| {
@@ -1049,6 +1141,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         subtitle: tc.subtitle.clone(),
                         keying: tc.keying,
                         mask: tc.mask.clone(),
+                        animation: tc.animation.clone(),
                     }
                 };
                 let tracks = &state.timeline.tracks;
@@ -1531,6 +1624,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 subtitle: tc.subtitle.clone(),
                 keying: tc.keying,
                 mask: tc.mask.clone(),
+                animation: tc.animation.clone(),
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -1625,6 +1719,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             subtitle: tc.subtitle.clone(),
                             keying: tc.keying,
                             mask: tc.mask.clone(),
+                            animation: tc.animation.clone(),
                         };
                         let tracks = &state.timeline.tracks;
                         let audio_start = state.timeline.audio_track_start();
@@ -2351,6 +2446,61 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                     egui::Color32::WHITE,
                                 );
 
+                                // Keyframe lane (industry-standard: Premiere/FCP/CapCut
+                                // show diamonds at each key's TIME on a strip inside the
+                                // clip). Because diamonds are positioned per key-time, a
+                                // cut clip only shows the keys that belong to it. FCP-style
+                                // double diamond marks a time where >1 property is keyed.
+                                if tc.animation.is_active() {
+                                    let lane_h = 7.0_f32;
+                                    let lane = egui::Rect::from_min_max(
+                                        egui::pos2(cr.left(), cr.bottom() - lane_h),
+                                        egui::pos2(cr.right(), cr.bottom()),
+                                    )
+                                    .intersect(cr);
+                                    let clipped =
+                                        ui.painter().with_clip_rect(lane.intersect(lane_rect));
+                                    clipped.rect_filled(
+                                        lane,
+                                        0.0,
+                                        egui::Color32::from_black_alpha(140),
+                                    );
+                                    let cy = lane.center().y;
+                                    // Group key times (ms) across all animated properties.
+                                    let mut counts: std::collections::BTreeMap<i64, u32> =
+                                        std::collections::BTreeMap::new();
+                                    for (_, track) in tc.animation.active_tracks() {
+                                        for k in &track.keys {
+                                            *counts
+                                                .entry((k.t_secs * 1000.0).round() as i64)
+                                                .or_insert(0) += 1;
+                                        }
+                                    }
+                                    let diamond = |cx: f32, r: f32| {
+                                        vec![
+                                            egui::pos2(cx, cy - r),
+                                            egui::pos2(cx + r, cy),
+                                            egui::pos2(cx, cy + r),
+                                            egui::pos2(cx - r, cy),
+                                        ]
+                                    };
+                                    for (ms, count) in counts {
+                                        let x = cr.left() + (ms as f32 / 1000.0) * pps;
+                                        clipped.add(egui::Shape::convex_polygon(
+                                            diamond(x, 3.5),
+                                            egui::Color32::WHITE,
+                                            egui::Stroke::new(1.0, egui::Color32::BLACK),
+                                        ));
+                                        if count > 1 {
+                                            clipped.add(egui::Shape::convex_polygon(
+                                                diamond(x, 5.5),
+                                                egui::Color32::TRANSPARENT,
+                                                egui::Stroke::new(1.0, egui::Color32::WHITE),
+                                            ));
+                                        }
+                                    }
+                                }
+
                                 // Silence region overlays — audio tracks only
                                 if track.kind == state::TrackKind::Audio {
                                     for &(start, end) in &source.silence_regions {
@@ -2433,6 +2583,34 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                 let clip_id = egui::Id::new(("tl_clip", track_idx, clip_i));
                                 let clip_resp =
                                     ui.interact(cr, clip_id, egui::Sense::click_and_drag());
+
+                                // Hover popup: which keyframe animations this clip carries.
+                                if tc.animation.is_active() {
+                                    clip_resp.clone().on_hover_ui(|ui| {
+                                        ui.strong("◆ Keyframe Animation");
+                                        for (label, track) in tc.animation.active_tracks() {
+                                            ui.label(format!(
+                                                "{label} ({} keys)",
+                                                track.keys.len()
+                                            ));
+                                            let n = track.keys.len();
+                                            for (i, k) in track.keys.iter().enumerate() {
+                                                // Opacity values are 0..1 → show as %.
+                                                let val = if label == "Opacity" {
+                                                    format!("{:.0}%", k.value * 100.0)
+                                                } else {
+                                                    format!("{:.2}", k.value)
+                                                };
+                                                let ease = if i + 1 < n {
+                                                    format!("  →{}", k.easing.label())
+                                                } else {
+                                                    String::new()
+                                                };
+                                                ui.weak(format!("  {:.2}s  {val}{ease}", k.t_secs));
+                                            }
+                                        }
+                                    });
+                                }
 
                                 // Cursor change and edge-proximity flag for trim handles
                                 let near_trim_edge = clip_resp.hovered()
@@ -3464,6 +3642,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 subtitle: tc.subtitle.clone(),
                 keying: tc.keying,
                 mask: tc.mask.clone(),
+                animation: tc.animation.clone(),
             };
             let tracks = &state.timeline.tracks;
             let audio_start = state.timeline.audio_track_start();
@@ -3568,6 +3747,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             subtitle: state::Subtitle::default(),
             keying: state::Keying::default(),
             mask: state::Mask::default(),
+            animation: state::ClipAnimation::default(),
         };
         // Sorted insert so that out-of-order drops don't corrupt array order.
         let track = &mut state.timeline.tracks[track_idx].clips;
@@ -3714,6 +3894,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 subtitle: state.timeline.tracks[ti].clips[ci].subtitle.clone(),
                 keying: state.timeline.tracks[ti].clips[ci].keying,
                 mask: state.timeline.tracks[ti].clips[ci].mask.clone(),
+                animation: state.timeline.tracks[ti].clips[ci].animation.clone(),
             };
             state.timeline.tracks[ti].clips.insert(ci + 1, right);
         }


### PR DESCRIPTION
## Summary

Adds per-clip **opacity keyframe animation** — the first phase of #131 (keyframe animation & Ken Burns). Opacity can be keyframed over time with Linear / Ease / Hold interpolation, animating identically in the export and the realtime preview. Animated clips are marked on the timeline with an industry-standard keyframe strip so it is clear, per clip, which carry animation.

## Changes

- **Data model** (`src/state.rs`): `ClipAnimation { opacity, pos_x, pos_y, scale, rotation: KeyTrack }` on `TimelineClip`, with `Key { t_secs, value, easing }` and a `KeyEasing` enum (Linear / EaseIn / EaseOut / EaseInOut / Hold). Only `opacity` is wired this phase; the other tracks are reserved for later phases.
- **Shared mapping** (`src/export.rs`): `apply_animation` converts a clip-local `KeyTrack` into a timeline-global `avio::AnimationTrack` (offset by `start_on_track`) and attaches it via `Clip::with_opacity_track` (avio #1291/#1292). Called identically from the export (`clips_to_avio`) and the preview (`player.rs::make_clip`), so both match.
- **Inspector UI** (`src/ui/timeline.rs`): an "Opacity Keyframes" panel — add key at playhead, per-key value + easing, delete/clear. A key's easing controls the ramp to the next key, so the easing selector is shown only on keys that have a following segment (the last key's easing is unused).
- **Timeline visualization** (`src/ui/timeline.rs`): a keyframe strip with diamond markers at each key's time inside the clip (double-diamond when >1 property is keyed at the same time), plus a hover popup listing the animated properties and their keys. Positioned per key-time, so a cut clip shows only its own keys.
- serde persistence (`src/project.rs`) and defaults at every clip construction site.

## Related Issues

Part of #131

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes