### PR TITLE
feat(timeline): per-clip position (X/Y) keyframe animation

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -36,6 +36,9 @@ pub struct ExportClip {
     pub opacity: f32,
     /// Per-clip blend mode. Forwarded to `Clip::with_blend_mode`.
     pub blend_mode: avio::BlendMode,
+    /// Static overlay position (canvas px) for a PiP (V2+) clip. `Clip::with_position`.
+    pub position_x: f32,
+    pub position_y: f32,
     /// Optional proxy file to decode from. When `Some`, forwarded to `Clip::proxy`
     /// so avio renders from the proxy and scales up to the original resolution.
     pub proxy_path: Option<PathBuf>,
@@ -721,42 +724,61 @@ fn easing_to_avio(e: crate::state::KeyEasing) -> avio::Easing {
 /// Converts a clip-local demo [`KeyTrack`](crate::state::KeyTrack) into a
 /// timeline-global `avio::AnimationTrack`: each key's clip-local `t_secs` is offset
 /// by the clip's `start` on the timeline (avio evaluates tracks at the composition
-/// graph's output PTS), and values are clamped to `[lo, hi]`.
+/// graph's output PTS). When `clamp` is `Some((lo, hi))` values are clamped to that
+/// range (e.g. opacity `0..1`); position tracks pass `None`.
 fn keytrack_to_avio(
     kt: &crate::state::KeyTrack,
     start: Duration,
-    lo: f64,
-    hi: f64,
+    clamp: Option<(f64, f64)>,
 ) -> avio::AnimationTrack<f64> {
     let mut track = avio::AnimationTrack::new();
     for k in &kt.keys {
         let ts = start + Duration::from_secs_f64(k.t_secs.max(0.0));
-        track = track.push(avio::Keyframe::new(
-            ts,
-            k.value.clamp(lo, hi),
-            easing_to_avio(k.easing),
-        ));
+        let v = match clamp {
+            Some((lo, hi)) => k.value.clamp(lo, hi),
+            None => k.value,
+        };
+        track = track.push(avio::Keyframe::new(ts, v, easing_to_avio(k.easing)));
     }
     track
 }
 
-/// Attaches per-clip keyframe animation to the avio `Clip`.
+/// Attaches per-clip static position + keyframe animation to the avio `Clip`.
 ///
-/// D1 wires the **opacity** track: clip-local keyframe times are offset by
-/// `start_on_track` into the timeline-global track avio evaluates, and applied via
-/// `Clip::with_opacity_track` (drives the `colorchannelmixer` alpha per frame). No-op
-/// when the track is empty. Shared by export and preview so both match. (Opacity
-/// animates in export now via avio #1291; preview parity lands with avio #1292.)
+/// - Static overlay position (`position` px) → `Clip::with_position` (baseline;
+///   a per-axis track overrides it in avio).
+/// - `opacity` track → `Clip::with_opacity_track` (drives `colorchannelmixer` alpha).
+/// - `pos_x`/`pos_y` tracks → `Clip::with_x_track`/`with_y_track` (drive `overlay`
+///   x/y, avio #1293).
+///
+/// Clip-local keyframe times are offset by `start_on_track` into the timeline-global
+/// tracks avio evaluates. No-op for empty tracks / zero position. Shared by export and
+/// preview so both match.
 pub fn apply_animation(
     clip: avio::Clip,
     anim: &crate::state::ClipAnimation,
     start_on_track: Duration,
+    position: (f32, f32),
 ) -> avio::Clip {
-    if anim.opacity.is_active() {
-        clip.with_opacity_track(keytrack_to_avio(&anim.opacity, start_on_track, 0.0, 1.0))
-    } else {
-        clip
+    let mut clip = clip;
+    #[allow(clippy::float_cmp)]
+    if position.0 != 0.0 || position.1 != 0.0 {
+        clip = clip.with_position(f64::from(position.0), f64::from(position.1));
     }
+    if anim.opacity.is_active() {
+        clip = clip.with_opacity_track(keytrack_to_avio(
+            &anim.opacity,
+            start_on_track,
+            Some((0.0, 1.0)),
+        ));
+    }
+    if anim.pos_x.is_active() {
+        clip = clip.with_x_track(keytrack_to_avio(&anim.pos_x, start_on_track, None));
+    }
+    if anim.pos_y.is_active() {
+        clip = clip.with_y_track(keytrack_to_avio(&anim.pos_y, start_on_track, None));
+    }
+    clip
 }
 
 fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio::Clip> {
@@ -847,9 +869,14 @@ fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio
             // Region-composite mask (garbage matte) — shapes the final alpha.
             // Shared with the preview. No-op when no mask shape is selected.
             let clip = apply_mask(clip, &c.mask, c.width, c.height);
-            // Per-clip keyframe animation (opacity). Sets an opacity track that takes
-            // precedence over the static opacity below. Shared with the preview.
-            let clip = apply_animation(clip, &c.animation, c.start_on_track);
+            // Per-clip static position + keyframe animation (opacity, position). Tracks
+            // take precedence over the static opacity/position. Shared with the preview.
+            let clip = apply_animation(
+                clip,
+                &c.animation,
+                c.start_on_track,
+                (c.position_x, c.position_y),
+            );
             #[allow(clippy::float_cmp)]
             let clip = if c.opacity != 1.0 {
                 clip.with_opacity(c.opacity)
@@ -2094,7 +2121,12 @@ mod tests {
         use super::apply_animation;
 
         let anim = crate::state::ClipAnimation::default();
-        let clip = apply_animation(avio::Clip::new("t.mp4"), &anim, std::time::Duration::ZERO);
+        let clip = apply_animation(
+            avio::Clip::new("t.mp4"),
+            &anim,
+            std::time::Duration::ZERO,
+            (0.0, 0.0),
+        );
         assert!(clip.opacity_track.is_none());
     }
 
@@ -2110,7 +2142,12 @@ mod tests {
         anim.opacity.insert(0.0, 0.0, KeyEasing::Linear);
         anim.opacity.insert(1.0, 1.0, KeyEasing::Linear);
         // Clip placed at 2s on the timeline.
-        let clip = apply_animation(avio::Clip::new("t.mp4"), &anim, Duration::from_secs(2));
+        let clip = apply_animation(
+            avio::Clip::new("t.mp4"),
+            &anim,
+            Duration::from_secs(2),
+            (0.0, 0.0),
+        );
         let track = clip.opacity_track.expect("opacity track set");
         // Held at the first value before the clip's global start.
         assert!(track.value_at(Duration::from_secs(2)).abs() < 1e-9);
@@ -2132,7 +2169,7 @@ mod tests {
         let mut ease = ClipAnimation::default();
         ease.opacity.insert(0.0, 0.0, KeyEasing::EaseInOut);
         ease.opacity.insert(2.0, 1.0, KeyEasing::Linear);
-        let et = apply_animation(avio::Clip::new("t.mp4"), &ease, Duration::ZERO)
+        let et = apply_animation(avio::Clip::new("t.mp4"), &ease, Duration::ZERO, (0.0, 0.0))
             .opacity_track
             .expect("track");
         let q = et.value_at(Duration::from_millis(500)); // t=0.5s of a 2s ramp
@@ -2146,9 +2183,14 @@ mod tests {
         let mut on_last = ClipAnimation::default();
         on_last.opacity.insert(0.0, 0.0, KeyEasing::Linear);
         on_last.opacity.insert(2.0, 1.0, KeyEasing::EaseInOut);
-        let lt = apply_animation(avio::Clip::new("t.mp4"), &on_last, Duration::ZERO)
-            .opacity_track
-            .expect("track");
+        let lt = apply_animation(
+            avio::Clip::new("t.mp4"),
+            &on_last,
+            Duration::ZERO,
+            (0.0, 0.0),
+        )
+        .opacity_track
+        .expect("track");
         assert!(
             (lt.value_at(Duration::from_millis(500)) - 0.25).abs() < 1e-6,
             "easing on the last key must not change the segment (stays linear)"
@@ -2158,7 +2200,7 @@ mod tests {
         let mut hold = ClipAnimation::default();
         hold.opacity.insert(0.0, 0.0, KeyEasing::Hold);
         hold.opacity.insert(2.0, 1.0, KeyEasing::Linear);
-        let ht = apply_animation(avio::Clip::new("t.mp4"), &hold, Duration::ZERO)
+        let ht = apply_animation(avio::Clip::new("t.mp4"), &hold, Duration::ZERO, (0.0, 0.0))
             .opacity_track
             .expect("track");
         assert!(
@@ -2169,5 +2211,33 @@ mod tests {
             (ht.value_at(Duration::from_secs(2)) - 1.0).abs() < 1e-9,
             "Hold snaps at end"
         );
+    }
+
+    /// Static position maps to `Clip::with_position`; pos_x/pos_y tracks map to
+    /// x/y tracks (px, unclamped) offset to timeline-global time.
+    #[test]
+    fn animation_position_static_and_tracks() {
+        use super::apply_animation;
+        use crate::state::{ClipAnimation, KeyEasing};
+        use std::time::Duration;
+
+        // Static position, no tracks.
+        let anim = ClipAnimation::default();
+        let clip = apply_animation(avio::Clip::new("t.mp4"), &anim, Duration::ZERO, (100.0, 50.0));
+        assert_eq!((clip.x, clip.y), (100.0, 50.0));
+        assert!(clip.x_track.is_none() && clip.y_track.is_none());
+
+        // Position tracks: offset by start_on_track (1s), unclamped px.
+        let mut a = ClipAnimation::default();
+        a.pos_x.insert(0.0, 0.0, KeyEasing::Linear);
+        a.pos_x.insert(2.0, 640.0, KeyEasing::Linear);
+        a.pos_y.insert(0.0, 0.0, KeyEasing::Linear);
+        a.pos_y.insert(2.0, 360.0, KeyEasing::Linear);
+        let clip = apply_animation(avio::Clip::new("t.mp4"), &a, Duration::from_secs(1), (0.0, 0.0));
+        let xt = clip.x_track.expect("x track");
+        let yt = clip.y_track.expect("y track");
+        // Clip-local 1s → global 2s → midpoint: x=320, y=180.
+        assert!((xt.value_at(Duration::from_secs(2)) - 320.0).abs() < 1e-9);
+        assert!((yt.value_at(Duration::from_secs(2)) - 180.0).abs() < 1e-9);
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -45,6 +45,9 @@ pub struct TrackClipData {
     pub opacity: f32,
     /// Per-clip blend mode. Forwarded to `Clip::with_blend_mode`.
     pub blend_mode: avio::BlendMode,
+    /// Static overlay position (canvas px) for a PiP (V2+) clip. `Clip::with_position`.
+    pub position_x: f32,
+    pub position_y: f32,
     /// Vignette strength percentage (`0.0` = off) and normalized centre X/Y (%).
     pub vignette: f32,
     pub vignette_x: f32,
@@ -499,7 +502,12 @@ pub fn spawn_timeline_player(
             c = crate::export::apply_mask(c, &tc.mask, tc.width, tc.height);
             // Per-clip keyframe animation (opacity) — matches export. Opacity animates
             // in the preview once avio #1292 lands; export animates now (avio #1291).
-            c = crate::export::apply_animation(c, &tc.animation, tc.start_on_track);
+            c = crate::export::apply_animation(
+                c,
+                &tc.animation,
+                tc.start_on_track,
+                (tc.position_x, tc.position_y),
+            );
             #[allow(clippy::float_cmp)]
             if tc.opacity != 1.0 {
                 c = c.with_opacity(tc.opacity);

--- a/src/project.rs
+++ b/src/project.rs
@@ -54,6 +54,10 @@ pub struct ProjectTimelineClip {
     pub opacity: f32,
     pub blend_mode: String,
     #[serde(default)]
+    pub position_x: f32,
+    #[serde(default)]
+    pub position_y: f32,
+    #[serde(default)]
     pub lut_path: Option<String>,
     #[serde(default = "default_wb_temperature")]
     pub wb_temperature: u32,
@@ -239,6 +243,8 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         speed: tc.speed,
         opacity: tc.opacity,
         blend_mode: blend_mode_to_str(tc.blend_mode).to_string(),
+        position_x: tc.position_x,
+        position_y: tc.position_y,
         lut_path: tc
             .lut_path
             .as_ref()
@@ -292,6 +298,8 @@ fn project_to_timeline_clip(
         speed: ptc.speed,
         opacity: ptc.opacity,
         blend_mode: blend_mode_from_str(&ptc.blend_mode),
+        position_x: ptc.position_x,
+        position_y: ptc.position_y,
         lut_path: ptc.lut_path.as_ref().map(PathBuf::from),
         wb_temperature: ptc.wb_temperature,
         wb_tint: ptc.wb_tint,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1297,6 +1297,11 @@ pub struct TimelineClip {
     /// overlay tracks — `FilterGraphBuilder::blend()` is not wired into the `Clip` pipeline
     /// (docs/issue43.md).
     pub blend_mode: avio::BlendMode,
+    /// Static overlay X position in canvas pixels for a Picture-in-Picture (V2+) clip.
+    /// Default 0.0. Maps to `avio::Clip::with_position`; superseded by `animation.pos_x`.
+    pub position_x: f32,
+    /// Static overlay Y position in canvas pixels (see [`position_x`](Self::position_x)).
+    pub position_y: f32,
     /// Per-clip 3D LUT (.cube) file path. `None` = no LUT.
     /// Applied on export via `avio::Clip::with_video_effect(FilterStep::Lut3d)`.
     /// Export-only: not shown in the monitor preview (v1).

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -654,6 +654,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 speed: 1.0,
                 opacity: 1.0,
                 blend_mode: avio::BlendMode::Normal,
+                position_x: 0.0,
+                position_y: 0.0,
                 lut_path: None,
                 wb_temperature: state::WB_NEUTRAL_TEMP,
                 wb_tint: 0.0,

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -175,6 +175,84 @@ fn snap_clip_start(
 
 /// Renders the clip / title inspector (Clip Properties, Title Properties).
 /// Shown in the right side panel; empty when nothing is selected.
+/// Renders a single-axis position keyframe panel (canvas pixels): a static value
+/// DragValue, an "add key at playhead" button (captures the static value at the
+/// clip-local playhead time), and the key list with per-key value + easing. Mirrors
+/// the opacity keyframe panel; a key's easing controls the ramp to the next key, so it
+/// is shown only on keys that have a following segment.
+fn position_keyframe_panel(
+    ui: &mut egui::Ui,
+    id: &str,
+    label: &str,
+    static_px: &mut f32,
+    track: &mut state::KeyTrack,
+    clip_local: f64,
+) {
+    egui::CollapsingHeader::new(label)
+        .id_salt(id)
+        .default_open(track.is_active())
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("px");
+                ui.add(egui::DragValue::new(static_px).speed(1.0).fixed_decimals(0));
+                if ui
+                    .button("＋ Key @ playhead")
+                    .on_hover_text(format!(
+                        "Add a key at {clip_local:.2}s (clip-local) = {:.0}px",
+                        *static_px
+                    ))
+                    .clicked()
+                {
+                    track.insert(clip_local, f64::from(*static_px), state::KeyEasing::Linear);
+                }
+                if track.is_active() && ui.button("Clear").clicked() {
+                    track.keys.clear();
+                }
+            });
+            if track.is_active() {
+                ui.weak("Easing is the ramp to the NEXT key. Re-play to preview edits.");
+                let n = track.keys.len();
+                let mut to_delete: Option<usize> = None;
+                for (i, k) in track.keys.iter_mut().enumerate() {
+                    ui.horizontal(|ui| {
+                        ui.label(format!("{:.2}s", k.t_secs));
+                        let mut v = k.value;
+                        if ui
+                            .add(
+                                egui::DragValue::new(&mut v)
+                                    .speed(1.0)
+                                    .suffix(" px")
+                                    .fixed_decimals(0),
+                            )
+                            .changed()
+                        {
+                            k.value = v;
+                        }
+                        if i + 1 < n {
+                            egui::ComboBox::from_id_salt((id, "ease", i))
+                                .selected_text(k.easing.label())
+                                .show_ui(ui, |ui| {
+                                    for e in state::KeyEasing::ALL {
+                                        ui.selectable_value(&mut k.easing, e, e.label());
+                                    }
+                                });
+                        } else {
+                            ui.weak("→ end");
+                        }
+                        if ui.button("✖").clicked() {
+                            to_delete = Some(i);
+                        }
+                    });
+                }
+                if let Some(i) = to_delete {
+                    track.keys.remove(i);
+                }
+            } else {
+                ui.weak("No keys — position is static.");
+            }
+        });
+}
+
 pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
     ui.heading("Inspector");
     if state.timeline_selected.is_none() && state.selected_title_clip.is_none() {
@@ -332,6 +410,30 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                                 ui.weak("No keys — opacity is static.");
                             }
                         });
+                    // ── Position keyframes (PiP move) — overlay (V2+) clips only ──
+                    // Base-layer (V1) position is export-only in the realtime preview
+                    // (nothing composites behind the base), so position keyframes are
+                    // restricted to overlay tracks to keep preview == export.
+                    if ti >= 1 {
+                        let clip_local =
+                            (playhead_secs - clip.start_on_track.as_secs_f64()).max(0.0);
+                        position_keyframe_panel(
+                            ui,
+                            "clip_pos_x_keys",
+                            "Position X Keyframes",
+                            &mut clip.position_x,
+                            &mut clip.animation.pos_x,
+                            clip_local,
+                        );
+                        position_keyframe_panel(
+                            ui,
+                            "clip_pos_y_keys",
+                            "Position Y Keyframes",
+                            &mut clip.position_y,
+                            &mut clip.animation.pos_y,
+                            clip_local,
+                        );
+                    }
                     // Blend mode is only meaningful for overlay (V2+) clips.
                     if ti >= 1 {
                         ui.horizontal(|ui| {
@@ -1116,6 +1218,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         speed: tc.speed,
                         opacity: tc.opacity,
                         blend_mode: tc.blend_mode,
+                        position_x: tc.position_x,
+                        position_y: tc.position_y,
                         proxy_path: if use_proxies {
                             src.proxy_path.clone()
                         } else {
@@ -1603,6 +1707,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 speed: tc.speed,
                 opacity: tc.opacity,
                 blend_mode: tc.blend_mode,
+                position_x: tc.position_x,
+                position_y: tc.position_y,
                 vignette: tc.vignette,
                 vignette_x: tc.vignette_x,
                 vignette_y: tc.vignette_y,
@@ -1698,6 +1804,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             speed: tc.speed,
                             opacity: tc.opacity,
                             blend_mode: tc.blend_mode,
+                            position_x: tc.position_x,
+                            position_y: tc.position_y,
                             vignette: tc.vignette,
                             vignette_x: tc.vignette_x,
                             vignette_y: tc.vignette_y,
@@ -3621,6 +3729,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 speed: tc.speed,
                 opacity: tc.opacity,
                 blend_mode: tc.blend_mode,
+                position_x: tc.position_x,
+                position_y: tc.position_y,
                 vignette: tc.vignette,
                 vignette_x: tc.vignette_x,
                 vignette_y: tc.vignette_y,
@@ -3729,6 +3839,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             speed: 1.0,
             opacity: 1.0,
             blend_mode: avio::BlendMode::Normal,
+            position_x: 0.0,
+            position_y: 0.0,
             lut_path: None,
             wb_temperature: state::WB_NEUTRAL_TEMP,
             wb_tint: 0.0,
@@ -3876,6 +3988,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 speed: state.timeline.tracks[ti].clips[ci].speed,
                 opacity: state.timeline.tracks[ti].clips[ci].opacity,
                 blend_mode: state.timeline.tracks[ti].clips[ci].blend_mode,
+                position_x: state.timeline.tracks[ti].clips[ci].position_x,
+                position_y: state.timeline.tracks[ti].clips[ci].position_y,
                 lut_path: state.timeline.tracks[ti].clips[ci].lut_path.clone(),
                 wb_temperature: state.timeline.tracks[ti].clips[ci].wb_temperature,
                 wb_tint: state.timeline.tracks[ti].clips[ci].wb_tint,


### PR DESCRIPTION
## Summary

Adds per-clip **overlay position (X/Y) keyframe animation** — the second phase of #131 — for Picture-in-Picture moves. Position can be keyframed over time with Linear / Ease / Hold interpolation, animating identically in the export and the realtime preview (consumes avio #1293). Restricted to overlay (V2+) clips.

## Changes

- **Data model** (`src/state.rs`): `TimelineClip.position_x/position_y` (static canvas px). `ClipAnimation.pos_x/pos_y` tracks were already present.
- **Shared mapping** (`src/export.rs`): `apply_animation` now also applies a static position (`Clip::with_position`) and the `pos_x`/`pos_y` tracks (`Clip::with_x_track`/`with_y_track`, unclamped px, offset to timeline-global time); `keytrack_to_avio` clamp is now optional. Called identically from export and preview.
- **Inspector UI** (`src/ui/timeline.rs`): `position_keyframe_panel` helper → "Position X/Y Keyframes" panels with a static px value, add-key-at-playhead, per-key value + easing. Gated to V2+ clips (base-layer position is export-only in the preview).
- **Visualization**: the existing keyframe-diamond strip and hover popup already cover `pos_x`/`pos_y` (double-diamond when X and Y are keyed at the same time).
- serde persistence and defaults at every clip construction site.

## Related Issues

Part of #131

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes