### PR TITLE
feat(timeline): per-clip scale (PiP resize) keyframe animation

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -39,6 +39,8 @@ pub struct ExportClip {
     /// Static overlay position (canvas px) for a PiP (V2+) clip. `Clip::with_position`.
     pub position_x: f32,
     pub position_y: f32,
+    /// Static uniform scale (% of source) for a PiP (V2+) clip. `FilterStep::ScaleAnimated`.
+    pub scale_pct: f32,
     /// Optional proxy file to decode from. When `Some`, forwarded to `Clip::proxy`
     /// so avio renders from the proxy and scales up to the original resolution.
     pub proxy_path: Option<PathBuf>,
@@ -743,22 +745,44 @@ fn keytrack_to_avio(
     track
 }
 
-/// Attaches per-clip static position + keyframe animation to the avio `Clip`.
+/// Converts a clip-local demo scale [`KeyTrack`](crate::state::KeyTrack) (values in
+/// percent of source) into a timeline-global `avio::AnimationTrack` in pixels for one
+/// axis: `px = dim * pct / 100`, clamped to ≥ 1 (`scale` needs a positive size).
+fn scale_track_to_avio(
+    kt: &crate::state::KeyTrack,
+    start: Duration,
+    dim: u32,
+) -> avio::AnimationTrack<f64> {
+    let mut track = avio::AnimationTrack::new();
+    for k in &kt.keys {
+        let ts = start + Duration::from_secs_f64(k.t_secs.max(0.0));
+        let px = (f64::from(dim) * (k.value / 100.0)).max(1.0);
+        track = track.push(avio::Keyframe::new(ts, px, easing_to_avio(k.easing)));
+    }
+    track
+}
+
+/// Attaches per-clip static transform + keyframe animation to the avio `Clip`.
 ///
 /// - Static overlay position (`position` px) → `Clip::with_position` (baseline;
 ///   a per-axis track overrides it in avio).
 /// - `opacity` track → `Clip::with_opacity_track` (drives `colorchannelmixer` alpha).
 /// - `pos_x`/`pos_y` tracks → `Clip::with_x_track`/`with_y_track` (drive `overlay`
 ///   x/y, avio #1293).
+/// - Static `scale_pct` or the `scale` track → `FilterStep::ScaleAnimated` (self-
+///   animating `scale=eval=frame`, avio #1297). `src` is the clip's source size,
+///   used to turn a percentage into pixels.
 ///
 /// Clip-local keyframe times are offset by `start_on_track` into the timeline-global
-/// tracks avio evaluates. No-op for empty tracks / zero position. Shared by export and
+/// tracks avio evaluates. No-op for empty tracks / neutral values. Shared by export and
 /// preview so both match.
 pub fn apply_animation(
     clip: avio::Clip,
     anim: &crate::state::ClipAnimation,
     start_on_track: Duration,
     position: (f32, f32),
+    scale_pct: f32,
+    src: (u32, u32),
 ) -> avio::Clip {
     let mut clip = clip;
     #[allow(clippy::float_cmp)]
@@ -777,6 +801,40 @@ pub fn apply_animation(
     }
     if anim.pos_y.is_active() {
         clip = clip.with_y_track(keytrack_to_avio(&anim.pos_y, start_on_track, None));
+    }
+    // Scale (PiP resize / zoom) as a self-animating `scale` effect. Uniform on both
+    // axes (preserves aspect). Applied after the other transforms.
+    let (src_w, src_h) = src;
+    // Lanczos: high-quality downscale — fast_bilinear aliases badly when a PiP shrinks.
+    // The scaled output is small, so the per-frame cost stays modest.
+    const SCALE_ALGO: avio::ScaleAlgorithm = avio::ScaleAlgorithm::Lanczos;
+    if src_w > 0 && src_h > 0 {
+        if anim.scale.is_active() {
+            clip = clip.with_video_effect(avio::FilterStep::ScaleAnimated {
+                width: avio::AnimatedValue::Track(scale_track_to_avio(
+                    &anim.scale,
+                    start_on_track,
+                    src_w,
+                )),
+                height: avio::AnimatedValue::Track(scale_track_to_avio(
+                    &anim.scale,
+                    start_on_track,
+                    src_h,
+                )),
+                algorithm: SCALE_ALGO,
+            });
+        } else {
+            #[allow(clippy::float_cmp)]
+            if scale_pct != 100.0 {
+                let w = (f64::from(src_w) * (f64::from(scale_pct) / 100.0)).max(1.0);
+                let h = (f64::from(src_h) * (f64::from(scale_pct) / 100.0)).max(1.0);
+                clip = clip.with_video_effect(avio::FilterStep::ScaleAnimated {
+                    width: avio::AnimatedValue::Static(w),
+                    height: avio::AnimatedValue::Static(h),
+                    algorithm: SCALE_ALGO,
+                });
+            }
+        }
     }
     clip
 }
@@ -869,13 +927,15 @@ fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio
             // Region-composite mask (garbage matte) — shapes the final alpha.
             // Shared with the preview. No-op when no mask shape is selected.
             let clip = apply_mask(clip, &c.mask, c.width, c.height);
-            // Per-clip static position + keyframe animation (opacity, position). Tracks
-            // take precedence over the static opacity/position. Shared with the preview.
+            // Per-clip static transform + keyframe animation (opacity, position, scale).
+            // Tracks take precedence over the static values. Shared with the preview.
             let clip = apply_animation(
                 clip,
                 &c.animation,
                 c.start_on_track,
                 (c.position_x, c.position_y),
+                c.scale_pct,
+                (c.width, c.height),
             );
             #[allow(clippy::float_cmp)]
             let clip = if c.opacity != 1.0 {
@@ -2126,6 +2186,8 @@ mod tests {
             &anim,
             std::time::Duration::ZERO,
             (0.0, 0.0),
+            100.0,
+            (0, 0),
         );
         assert!(clip.opacity_track.is_none());
     }
@@ -2147,6 +2209,8 @@ mod tests {
             &anim,
             Duration::from_secs(2),
             (0.0, 0.0),
+            100.0,
+            (0, 0),
         );
         let track = clip.opacity_track.expect("opacity track set");
         // Held at the first value before the clip's global start.
@@ -2169,9 +2233,16 @@ mod tests {
         let mut ease = ClipAnimation::default();
         ease.opacity.insert(0.0, 0.0, KeyEasing::EaseInOut);
         ease.opacity.insert(2.0, 1.0, KeyEasing::Linear);
-        let et = apply_animation(avio::Clip::new("t.mp4"), &ease, Duration::ZERO, (0.0, 0.0))
-            .opacity_track
-            .expect("track");
+        let et = apply_animation(
+            avio::Clip::new("t.mp4"),
+            &ease,
+            Duration::ZERO,
+            (0.0, 0.0),
+            100.0,
+            (0, 0),
+        )
+        .opacity_track
+        .expect("track");
         let q = et.value_at(Duration::from_millis(500)); // t=0.5s of a 2s ramp
         assert!(
             q < 0.24,
@@ -2188,6 +2259,8 @@ mod tests {
             &on_last,
             Duration::ZERO,
             (0.0, 0.0),
+            100.0,
+            (0, 0),
         )
         .opacity_track
         .expect("track");
@@ -2200,9 +2273,16 @@ mod tests {
         let mut hold = ClipAnimation::default();
         hold.opacity.insert(0.0, 0.0, KeyEasing::Hold);
         hold.opacity.insert(2.0, 1.0, KeyEasing::Linear);
-        let ht = apply_animation(avio::Clip::new("t.mp4"), &hold, Duration::ZERO, (0.0, 0.0))
-            .opacity_track
-            .expect("track");
+        let ht = apply_animation(
+            avio::Clip::new("t.mp4"),
+            &hold,
+            Duration::ZERO,
+            (0.0, 0.0),
+            100.0,
+            (0, 0),
+        )
+        .opacity_track
+        .expect("track");
         assert!(
             ht.value_at(Duration::from_secs(1)).abs() < 1e-9,
             "Hold holds start mid-segment"
@@ -2223,7 +2303,14 @@ mod tests {
 
         // Static position, no tracks.
         let anim = ClipAnimation::default();
-        let clip = apply_animation(avio::Clip::new("t.mp4"), &anim, Duration::ZERO, (100.0, 50.0));
+        let clip = apply_animation(
+            avio::Clip::new("t.mp4"),
+            &anim,
+            Duration::ZERO,
+            (100.0, 50.0),
+            100.0,
+            (0, 0),
+        );
         assert_eq!((clip.x, clip.y), (100.0, 50.0));
         assert!(clip.x_track.is_none() && clip.y_track.is_none());
 
@@ -2233,11 +2320,66 @@ mod tests {
         a.pos_x.insert(2.0, 640.0, KeyEasing::Linear);
         a.pos_y.insert(0.0, 0.0, KeyEasing::Linear);
         a.pos_y.insert(2.0, 360.0, KeyEasing::Linear);
-        let clip = apply_animation(avio::Clip::new("t.mp4"), &a, Duration::from_secs(1), (0.0, 0.0));
+        let clip = apply_animation(
+            avio::Clip::new("t.mp4"),
+            &a,
+            Duration::from_secs(1),
+            (0.0, 0.0),
+            100.0,
+            (0, 0),
+        );
         let xt = clip.x_track.expect("x track");
         let yt = clip.y_track.expect("y track");
         // Clip-local 1s → global 2s → midpoint: x=320, y=180.
         assert!((xt.value_at(Duration::from_secs(2)) - 320.0).abs() < 1e-9);
         assert!((yt.value_at(Duration::from_secs(2)) - 180.0).abs() < 1e-9);
+    }
+
+    /// Static scale % → a `ScaleAnimated` effect sized in source pixels; a scale track
+    /// → animated width/height tracks (px), offset to timeline-global time.
+    #[test]
+    fn animation_scale_static_and_track() {
+        use super::apply_animation;
+        use crate::state::{ClipAnimation, KeyEasing};
+        use std::time::Duration;
+
+        let scale_effect = |clip: avio::Clip| {
+            clip.video_effect_chain().into_iter().find_map(|s| match s {
+                avio::FilterStep::ScaleAnimated { width, height, .. } => Some((width, height)),
+                _ => None,
+            })
+        };
+
+        // Static 50% of 1920x1080 → 960x540.
+        let anim = ClipAnimation::default();
+        let clip = apply_animation(
+            avio::Clip::new("t.mp4"),
+            &anim,
+            Duration::ZERO,
+            (0.0, 0.0),
+            50.0,
+            (1920, 1080),
+        );
+        let (w, h) = scale_effect(clip).expect("static ScaleAnimated present");
+        assert!((w.value_at(Duration::ZERO) - 960.0).abs() < 1e-6);
+        assert!((h.value_at(Duration::ZERO) - 540.0).abs() < 1e-6);
+
+        // Scale track 100%→50% over 2s, clip placed at 1s; source 1000x500.
+        let mut a = ClipAnimation::default();
+        a.scale.insert(0.0, 100.0, KeyEasing::Linear);
+        a.scale.insert(2.0, 50.0, KeyEasing::Linear);
+        let clip = apply_animation(
+            avio::Clip::new("t.mp4"),
+            &a,
+            Duration::from_secs(1),
+            (0.0, 0.0),
+            100.0,
+            (1000, 500),
+        );
+        let (w, h) = scale_effect(clip).expect("animated ScaleAnimated present");
+        // Clip-local 0 → global 1s → 100% → 1000; clip-local 2s → global 3s → 50% → 500.
+        assert!((w.value_at(Duration::from_secs(1)) - 1000.0).abs() < 1e-6);
+        assert!((w.value_at(Duration::from_secs(3)) - 500.0).abs() < 1e-6);
+        assert!((h.value_at(Duration::from_secs(1)) - 500.0).abs() < 1e-6);
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -48,6 +48,8 @@ pub struct TrackClipData {
     /// Static overlay position (canvas px) for a PiP (V2+) clip. `Clip::with_position`.
     pub position_x: f32,
     pub position_y: f32,
+    /// Static uniform scale (% of source) for a PiP (V2+) clip. `FilterStep::ScaleAnimated`.
+    pub scale_pct: f32,
     /// Vignette strength percentage (`0.0` = off) and normalized centre X/Y (%).
     pub vignette: f32,
     pub vignette_x: f32,
@@ -500,13 +502,15 @@ pub fn spawn_timeline_player(
             c = crate::export::apply_subtitle(c, &tc.subtitle);
             // Region-composite mask — shapes the final alpha, matches export.
             c = crate::export::apply_mask(c, &tc.mask, tc.width, tc.height);
-            // Per-clip keyframe animation (opacity) — matches export. Opacity animates
-            // in the preview once avio #1292 lands; export animates now (avio #1291).
+            // Per-clip static transform + keyframe animation (opacity, position, scale)
+            // — matches export so the monitor reflects the rendered output.
             c = crate::export::apply_animation(
                 c,
                 &tc.animation,
                 tc.start_on_track,
                 (tc.position_x, tc.position_y),
+                tc.scale_pct,
+                (tc.width, tc.height),
             );
             #[allow(clippy::float_cmp)]
             if tc.opacity != 1.0 {

--- a/src/project.rs
+++ b/src/project.rs
@@ -57,6 +57,8 @@ pub struct ProjectTimelineClip {
     pub position_x: f32,
     #[serde(default)]
     pub position_y: f32,
+    #[serde(default = "default_scale_pct")]
+    pub scale_pct: f32,
     #[serde(default)]
     pub lut_path: Option<String>,
     #[serde(default = "default_wb_temperature")]
@@ -107,6 +109,10 @@ fn default_vignette_centre() -> f32 {
 
 fn default_gamma() -> f32 {
     1.0
+}
+
+fn default_scale_pct() -> f32 {
+    100.0
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -245,6 +251,7 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         blend_mode: blend_mode_to_str(tc.blend_mode).to_string(),
         position_x: tc.position_x,
         position_y: tc.position_y,
+        scale_pct: tc.scale_pct,
         lut_path: tc
             .lut_path
             .as_ref()
@@ -300,6 +307,7 @@ fn project_to_timeline_clip(
         blend_mode: blend_mode_from_str(&ptc.blend_mode),
         position_x: ptc.position_x,
         position_y: ptc.position_y,
+        scale_pct: ptc.scale_pct,
         lut_path: ptc.lut_path.as_ref().map(PathBuf::from),
         wb_temperature: ptc.wb_temperature,
         wb_tint: ptc.wb_tint,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1302,6 +1302,10 @@ pub struct TimelineClip {
     pub position_x: f32,
     /// Static overlay Y position in canvas pixels (see [`position_x`](Self::position_x)).
     pub position_y: f32,
+    /// Static uniform scale as a percentage of the clip's source size (100.0 = full).
+    /// For a PiP (V2+) clip. Maps to `avio::FilterStep::ScaleAnimated`; superseded by
+    /// `animation.scale`.
+    pub scale_pct: f32,
     /// Per-clip 3D LUT (.cube) file path. `None` = no LUT.
     /// Applied on export via `avio::Clip::with_video_effect(FilterStep::Lut3d)`.
     /// Export-only: not shown in the monitor preview (v1).

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -656,6 +656,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 blend_mode: avio::BlendMode::Normal,
                 position_x: 0.0,
                 position_y: 0.0,
+                scale_pct: 100.0,
                 lut_path: None,
                 wb_temperature: state::WB_NEUTRAL_TEMP,
                 wb_tint: 0.0,

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -184,26 +184,31 @@ fn position_keyframe_panel(
     ui: &mut egui::Ui,
     id: &str,
     label: &str,
-    static_px: &mut f32,
+    static_val: &mut f32,
     track: &mut state::KeyTrack,
     clip_local: f64,
+    unit: &str,
 ) {
     egui::CollapsingHeader::new(label)
         .id_salt(id)
         .default_open(track.is_active())
         .show(ui, |ui| {
             ui.horizontal(|ui| {
-                ui.label("px");
-                ui.add(egui::DragValue::new(static_px).speed(1.0).fixed_decimals(0));
+                ui.label(unit);
+                ui.add(
+                    egui::DragValue::new(static_val)
+                        .speed(1.0)
+                        .fixed_decimals(0),
+                );
                 if ui
                     .button("＋ Key @ playhead")
                     .on_hover_text(format!(
-                        "Add a key at {clip_local:.2}s (clip-local) = {:.0}px",
-                        *static_px
+                        "Add a key at {clip_local:.2}s (clip-local) = {:.0}{unit}",
+                        *static_val
                     ))
                     .clicked()
                 {
-                    track.insert(clip_local, f64::from(*static_px), state::KeyEasing::Linear);
+                    track.insert(clip_local, f64::from(*static_val), state::KeyEasing::Linear);
                 }
                 if track.is_active() && ui.button("Clear").clicked() {
                     track.keys.clear();
@@ -221,7 +226,7 @@ fn position_keyframe_panel(
                             .add(
                                 egui::DragValue::new(&mut v)
                                     .speed(1.0)
-                                    .suffix(" px")
+                                    .suffix(format!(" {unit}"))
                                     .fixed_decimals(0),
                             )
                             .changed()
@@ -248,7 +253,7 @@ fn position_keyframe_panel(
                     track.keys.remove(i);
                 }
             } else {
-                ui.weak("No keys — position is static.");
+                ui.weak("No keys — value is static.");
             }
         });
 }
@@ -410,10 +415,11 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                                 ui.weak("No keys — opacity is static.");
                             }
                         });
-                    // ── Position keyframes (PiP move) — overlay (V2+) clips only ──
-                    // Base-layer (V1) position is export-only in the realtime preview
-                    // (nothing composites behind the base), so position keyframes are
-                    // restricted to overlay tracks to keep preview == export.
+                    // ── Position & Scale keyframes (PiP) — overlay (V2+) clips only ──
+                    // Base-layer (V1) position/scale is export-only in the realtime
+                    // preview (nothing composites behind the base, and scaling V1 would
+                    // change the output size per frame), so these are restricted to
+                    // overlay tracks to keep preview == export.
                     if ti >= 1 {
                         let clip_local =
                             (playhead_secs - clip.start_on_track.as_secs_f64()).max(0.0);
@@ -424,6 +430,7 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                             &mut clip.position_x,
                             &mut clip.animation.pos_x,
                             clip_local,
+                            "px",
                         );
                         position_keyframe_panel(
                             ui,
@@ -432,6 +439,16 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                             &mut clip.position_y,
                             &mut clip.animation.pos_y,
                             clip_local,
+                            "px",
+                        );
+                        position_keyframe_panel(
+                            ui,
+                            "clip_scale_keys",
+                            "Scale Keyframes",
+                            &mut clip.scale_pct,
+                            &mut clip.animation.scale,
+                            clip_local,
+                            "%",
                         );
                     }
                     // Blend mode is only meaningful for overlay (V2+) clips.
@@ -1220,6 +1237,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         blend_mode: tc.blend_mode,
                         position_x: tc.position_x,
                         position_y: tc.position_y,
+                        scale_pct: tc.scale_pct,
                         proxy_path: if use_proxies {
                             src.proxy_path.clone()
                         } else {
@@ -1709,6 +1727,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 blend_mode: tc.blend_mode,
                 position_x: tc.position_x,
                 position_y: tc.position_y,
+                scale_pct: tc.scale_pct,
                 vignette: tc.vignette,
                 vignette_x: tc.vignette_x,
                 vignette_y: tc.vignette_y,
@@ -1806,6 +1825,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             blend_mode: tc.blend_mode,
                             position_x: tc.position_x,
                             position_y: tc.position_y,
+                            scale_pct: tc.scale_pct,
                             vignette: tc.vignette,
                             vignette_x: tc.vignette_x,
                             vignette_y: tc.vignette_y,
@@ -3731,6 +3751,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 blend_mode: tc.blend_mode,
                 position_x: tc.position_x,
                 position_y: tc.position_y,
+                scale_pct: tc.scale_pct,
                 vignette: tc.vignette,
                 vignette_x: tc.vignette_x,
                 vignette_y: tc.vignette_y,
@@ -3841,6 +3862,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             blend_mode: avio::BlendMode::Normal,
             position_x: 0.0,
             position_y: 0.0,
+            scale_pct: 100.0,
             lut_path: None,
             wb_temperature: state::WB_NEUTRAL_TEMP,
             wb_tint: 0.0,
@@ -3990,6 +4012,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 blend_mode: state.timeline.tracks[ti].clips[ci].blend_mode,
                 position_x: state.timeline.tracks[ti].clips[ci].position_x,
                 position_y: state.timeline.tracks[ti].clips[ci].position_y,
+                scale_pct: state.timeline.tracks[ti].clips[ci].scale_pct,
                 lut_path: state.timeline.tracks[ti].clips[ci].lut_path.clone(),
                 wb_temperature: state.timeline.tracks[ti].clips[ci].wb_temperature,
                 wb_tint: state.timeline.tracks[ti].clips[ci].wb_tint,


### PR DESCRIPTION
## Summary

Adds per-clip **scale (PiP resize / zoom) keyframe animation** — the third transform phase of #131 — consuming avio #1297 (`ScaleAnimated`). A V2 (overlay) clip can be shrunk/grown over time with Linear / Ease / Hold interpolation, animating identically in the export and the realtime preview. Combined with position (D2), this gives a real Picture-in-Picture that moves and resizes.

## Changes

- **Data model** (`src/state.rs`): `TimelineClip.scale_pct` (static, % of source; 100 = full). `ClipAnimation.scale` track was already present.
- **Shared mapping** (`src/export.rs`): `apply_animation` gains `scale_pct` + source dims and attaches `avio::FilterStep::ScaleAnimated` — static when only `scale_pct` is set, or an animated width/height track built from the `scale` track (`px = dim * pct / 100`, offset to timeline-global time). Uses **Lanczos** resampling (fast_bilinear aliases badly on downscale).
- **Inspector UI** (`src/ui/timeline.rs`): the position keyframe panel is generalized with a `unit` argument and reused for a new "Scale Keyframes" panel (%). Gated to V2+ clips (scaling the V1 base would change the output size per frame).
- **Visualization**: the keyframe-diamond strip and hover popup already cover `scale` (double-diamond when scale shares a keyframe time with position).
- serde persistence and defaults at every clip construction site.

## Related Issues

Part of #131

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes