### PR TITLE
feat(timeline): per-clip audio volume keyframes

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -836,6 +836,11 @@ pub fn apply_animation(
             }
         }
     }
+    // Audio volume envelope (dB), offset to timeline-global. Overrides the static
+    // gain when active (mirrors the video track-over-static precedence). avio #1316.
+    if anim.volume.is_active() {
+        clip = clip.with_volume_track(keytrack_to_avio(&anim.volume, start_on_track, None));
+    }
     clip
 }
 
@@ -858,7 +863,8 @@ fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio
             } else {
                 clip
             };
-            let clip = if c.gain_db != 0.0 {
+            // A volume envelope (animation.volume) overrides the static gain.
+            let clip = if c.gain_db != 0.0 && !c.animation.volume.is_active() {
                 clip.volume(c.gain_db as f64)
             } else {
                 clip
@@ -2381,5 +2387,41 @@ mod tests {
         assert!((w.value_at(Duration::from_secs(1)) - 1000.0).abs() < 1e-6);
         assert!((w.value_at(Duration::from_secs(3)) - 500.0).abs() < 1e-6);
         assert!((h.value_at(Duration::from_secs(1)) - 500.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn animation_volume_track_maps_to_volume_track() {
+        use super::apply_animation;
+        use crate::state::{ClipAnimation, KeyEasing};
+        use std::time::Duration;
+
+        // No volume keys → no volume_track (the static gain path stays in effect).
+        let none = apply_animation(
+            avio::Clip::new("t.mp4"),
+            &ClipAnimation::default(),
+            Duration::ZERO,
+            (0.0, 0.0),
+            100.0,
+            (1920, 1080),
+        );
+        assert!(none.volume_track.is_none());
+
+        // Volume envelope 0 → -12 dB over 2s, clip placed at 1s on the track.
+        let mut a = ClipAnimation::default();
+        a.volume.insert(0.0, 0.0, KeyEasing::Linear);
+        a.volume.insert(2.0, -12.0, KeyEasing::Linear);
+        let clip = apply_animation(
+            avio::Clip::new("t.mp4"),
+            &a,
+            Duration::from_secs(1),
+            (0.0, 0.0),
+            100.0,
+            (1920, 1080),
+        );
+        let track = clip.volume_track.expect("volume track present");
+        // Clip-local 0 → global 1s → 0 dB; local 2s → global 3s → -12 dB; mid 2s → -6 dB.
+        assert!((track.value_at(Duration::from_secs(1)) - 0.0).abs() < 1e-6);
+        assert!((track.value_at(Duration::from_secs(2)) - (-6.0)).abs() < 1e-6);
+        assert!((track.value_at(Duration::from_secs(3)) - (-12.0)).abs() < 1e-6);
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -441,7 +441,8 @@ pub fn spawn_timeline_player(
             if tc.speed != 1.0 {
                 c = c.with_speed(tc.speed as f64);
             }
-            if tc.gain_db != 0.0 {
+            // A volume envelope (animation.volume) overrides the static gain.
+            if tc.gain_db != 0.0 && !tc.animation.volume.is_active() {
                 c = c.volume(tc.gain_db as f64);
             }
             if tc.fade_in > Duration::ZERO {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1228,6 +1228,9 @@ pub struct ClipAnimation {
     /// Rotation track (degrees). Reserved (avio #1296).
     #[serde(default)]
     pub rotation: KeyTrack,
+    /// Audio volume track (dB). avio #1316 (`Clip::with_volume_track`).
+    #[serde(default)]
+    pub volume: KeyTrack,
 }
 
 impl ClipAnimation {
@@ -1238,6 +1241,7 @@ impl ClipAnimation {
             || self.pos_y.is_active()
             || self.scale.is_active()
             || self.rotation.is_active()
+            || self.volume.is_active()
     }
 
     /// Active `(label, track)` pairs, for timeline visualization and tooltips.
@@ -1248,6 +1252,7 @@ impl ClipAnimation {
             ("Position Y", &self.pos_y),
             ("Scale", &self.scale),
             ("Rotation", &self.rotation),
+            ("Volume", &self.volume),
         ]
         .into_iter()
         .filter(|(_, t)| t.is_active())

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -284,6 +284,14 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
         // Captured before the mutable clip borrow below; used to place opacity
         // keyframes at the current playhead (converted to clip-local time).
         let playhead_secs = state.timeline_playhead_secs;
+        // Whether this clip's source carries audio — gates the Volume envelope panel.
+        let has_audio = state
+            .timeline
+            .tracks
+            .get(ti)
+            .and_then(|t| t.clips.get(ci))
+            .and_then(|c| state.clips.get(c.source_index))
+            .is_some_and(|s| s.info.primary_audio().is_some());
         if let Some(clip) = state
             .timeline
             .tracks
@@ -449,6 +457,21 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                             &mut clip.animation.scale,
                             clip_local,
                             "%",
+                        );
+                    }
+                    // ── Volume envelope (dB) — any audio-bearing clip. Overrides the
+                    // static per-clip gain when keyed. avio #1316. ──
+                    if has_audio {
+                        let clip_local =
+                            (playhead_secs - clip.start_on_track.as_secs_f64()).max(0.0);
+                        position_keyframe_panel(
+                            ui,
+                            "clip_volume_keys",
+                            "Volume Keyframes",
+                            &mut clip.gain_db,
+                            &mut clip.animation.volume,
+                            clip_local,
+                            "dB",
                         );
                     }
                     // Blend mode is only meaningful for overlay (V2+) clips.


### PR DESCRIPTION
## Summary

Adds per-clip **audio volume automation** (a dB envelope) editable as keyframes, driven identically in the realtime preview and the export via avio's per-clip `volume_track` (avio #1316). Volume can rise/fall within a single clip and coexists with the static gain and fades.

## Changes

- **`src/state.rs`**: `ClipAnimation.volume: KeyTrack` (dB) + inclusion in `is_active()` / `active_tracks()`.
- **`src/export.rs`**: `apply_animation` maps an active `volume` track → `Clip::with_volume_track` (clip-local → timeline-global). A volume envelope **overrides** the static per-clip gain (both preview and export skip the static gain when the track is active → preview == export). New test `animation_volume_track_maps_to_volume_track`.
- **`src/player.rs`**: same gain-override in the preview `make_clip` path.
- **`src/ui/timeline.rs`**: "Volume Keyframes" inspector panel (dB) via the shared `position_keyframe_panel`, shown for audio-bearing clips.

## Notes / scope

- The inspector panel is shown for **audio-bearing clips in the video-clip inspector** (video clips with embedded audio). Audio-only (A1/A2) clips are fully supported by the backend but their editing UI is the deferred rubber-band lane (#175).
- **Depends on avio #1316** (`Clip::with_volume_track` + realtime preview parity).

## Related Issues

Closes #141
Follow-up: #175 (audio-lane rubber-band UI)

## Test Plan

- [x] `cargo test` passes (40)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] Manual: volume keyframes (0 → −30 → 0 dB) — dip audible in preview and present in the export