### PR TITLE
feat(timeline): per-clip freeze frame and reverse

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -32,6 +32,10 @@ pub struct ExportClip {
     pub saturation: f32,
     /// Per-clip speed multiplier. `1.0` = normal. Applied by trimming `out_point` (avio gap — docs/issue41.md).
     pub speed: f32,
+    /// Reverse playback (video + audio), export-only. avio `Reverse` / `AReverse`. #143.
+    pub reverse: bool,
+    /// Freeze-frame spec (hold + extend clip length). avio `FreezeFrame`. #143.
+    pub freeze: Option<crate::state::Freeze>,
     /// Per-clip opacity (`1.0` = fully opaque). Forwarded to `Clip::with_opacity`.
     pub opacity: f32,
     /// Per-clip blend mode. Forwarded to `Clip::with_blend_mode`.
@@ -844,6 +848,29 @@ pub fn apply_animation(
     clip
 }
 
+/// Reverse the whole clip (video + audio). Export-only — avio buffers the clip, which
+/// does not fit the streaming realtime preview (see demo #178). #143.
+pub fn apply_reverse(clip: avio::Clip, reverse: bool) -> avio::Clip {
+    if reverse {
+        clip.with_video_effect(avio::FilterStep::Reverse)
+            .with_audio_effect(avio::FilterStep::AReverse)
+    } else {
+        clip
+    }
+}
+
+/// Hold the frame at `at_secs` for `hold_secs`, extending the clip length. Applied in
+/// both preview and export so the clip lengths match. #143.
+pub fn apply_freeze(clip: avio::Clip, freeze: Option<crate::state::Freeze>) -> avio::Clip {
+    match freeze {
+        Some(f) => clip.with_video_effect(avio::FilterStep::FreezeFrame {
+            pts: f.at_secs,
+            duration: f.hold_secs,
+        }),
+        None => clip,
+    }
+}
+
 fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio::Clip> {
     clips
         .into_iter()
@@ -883,6 +910,10 @@ fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio
                 Some(kind) => clip.with_transition(kind, c.transition_duration),
                 None => clip,
             };
+            // Reverse (export only) + freeze frame. Reverse plays forward in the preview
+            // (#178); freeze is applied in both so clip lengths match.
+            let clip = apply_reverse(clip, c.reverse);
+            let clip = apply_freeze(clip, c.freeze);
             // Chroma key first — key the original colours before any transform /
             // grade / scale, producing alpha the composer reveals through. Shared
             // with preview. No-op when disabled.
@@ -2423,5 +2454,43 @@ mod tests {
         assert!((track.value_at(Duration::from_secs(1)) - 0.0).abs() < 1e-6);
         assert!((track.value_at(Duration::from_secs(2)) - (-6.0)).abs() < 1e-6);
         assert!((track.value_at(Duration::from_secs(3)) - (-12.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn reverse_and_freeze_map_to_filter_steps() {
+        use super::{apply_freeze, apply_reverse};
+        use crate::state::Freeze;
+
+        // Off / none → no effects added.
+        let plain = apply_freeze(apply_reverse(avio::Clip::new("t.mp4"), false), None);
+        assert!(plain.video_effect_chain().is_empty());
+        assert!(plain.audio_effects.is_empty());
+
+        // Reverse on → Reverse (video) + AReverse (audio).
+        let rev = apply_reverse(avio::Clip::new("t.mp4"), true);
+        assert!(
+            rev.video_effect_chain()
+                .iter()
+                .any(|s| matches!(s, avio::FilterStep::Reverse))
+        );
+        assert!(
+            rev.audio_effects
+                .iter()
+                .any(|s| matches!(s, avio::FilterStep::AReverse))
+        );
+
+        // Freeze → FreezeFrame with the given pts/duration.
+        let frz = apply_freeze(
+            avio::Clip::new("t.mp4"),
+            Some(Freeze {
+                at_secs: 1.5,
+                hold_secs: 2.0,
+            }),
+        );
+        let step = frz.video_effect_chain().into_iter().find_map(|s| match s {
+            avio::FilterStep::FreezeFrame { pts, duration } => Some((pts, duration)),
+            _ => None,
+        });
+        assert_eq!(step, Some((1.5, 2.0)));
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -41,6 +41,8 @@ pub struct TrackClipData {
     pub lut_path: Option<PathBuf>,
     /// Per-clip playback speed multiplier. `1.0` = normal speed.
     pub speed: f32,
+    /// Freeze-frame spec, applied in preview + export so clip lengths match. #143.
+    pub freeze: Option<crate::state::Freeze>,
     /// Per-clip opacity (`1.0` = fully opaque). Forwarded to `Clip::with_opacity`.
     pub opacity: f32,
     /// Per-clip blend mode. Forwarded to `Clip::with_blend_mode`.
@@ -454,6 +456,9 @@ pub fn spawn_timeline_player(
             if let Some(kind) = tc.transition {
                 c = c.with_transition(kind, tc.transition_duration);
             }
+            // Freeze frame — applied in preview too so the clip length matches export.
+            // (Reverse is export-only; the preview plays forward.) #143.
+            c = crate::export::apply_freeze(c, tc.freeze);
             // Chroma key first — key original colours before transform/grade,
             // producing alpha the composer reveals through. Matches export.
             c = crate::export::apply_keying(c, &tc.keying);

--- a/src/project.rs
+++ b/src/project.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::state::{
-    AppState, ExportFilterDraft, HAlign, ImportedClip, TimelineClip, TitleClip, Track, TrackKind,
-    VAlign,
+    AppState, ExportFilterDraft, Freeze, HAlign, ImportedClip, TimelineClip, TitleClip, Track,
+    TrackKind, VAlign,
 };
 
 // ── Serializable project structs ─────────────────────────────────────────────
@@ -51,6 +51,10 @@ pub struct ProjectTimelineClip {
     pub contrast: f32,
     pub saturation: f32,
     pub speed: f32,
+    #[serde(default)]
+    pub reverse: bool,
+    #[serde(default)]
+    pub freeze: Option<Freeze>,
     pub opacity: f32,
     pub blend_mode: String,
     #[serde(default)]
@@ -247,6 +251,8 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         contrast: tc.contrast,
         saturation: tc.saturation,
         speed: tc.speed,
+        reverse: tc.reverse,
+        freeze: tc.freeze,
         opacity: tc.opacity,
         blend_mode: blend_mode_to_str(tc.blend_mode).to_string(),
         position_x: tc.position_x,
@@ -303,6 +309,8 @@ fn project_to_timeline_clip(
         contrast: ptc.contrast,
         saturation: ptc.saturation,
         speed: ptc.speed,
+        reverse: ptc.reverse,
+        freeze: ptc.freeze,
         opacity: ptc.opacity,
         blend_mode: blend_mode_from_str(&ptc.blend_mode),
         position_x: ptc.position_x,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1260,6 +1260,17 @@ impl ClipAnimation {
     }
 }
 
+/// Freeze-frame spec: hold the frame at `at_secs` (clip-local) for `hold_secs`,
+/// extending the clip's timeline length by `hold_secs`. Maps to avio
+/// `FilterStep::FreezeFrame`. avio #143.
+#[derive(Clone, Copy, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Freeze {
+    /// Clip-local time (seconds) of the frame to hold. `>= 0.0`.
+    pub at_secs: f64,
+    /// Hold duration (seconds). `> 0.0`.
+    pub hold_secs: f64,
+}
+
 #[derive(Clone, PartialEq)]
 pub struct TimelineClip {
     pub source_index: usize,
@@ -1293,6 +1304,11 @@ pub struct TimelineClip {
     /// avio gap: `Clip` has no speed field; fast motion is approximated by trimming
     /// `out_point = in_point + source_dur / speed`. Slow motion is unsupported — docs/issue41.md.
     pub speed: f32,
+    /// Reverse playback (video + audio). Applied on **export only**; the realtime
+    /// preview plays forward. Maps to avio `FilterStep::Reverse` / `AReverse`. #143.
+    pub reverse: bool,
+    /// Optional freeze-frame: hold a frame for N seconds, extending the clip length. #143.
+    pub freeze: Option<Freeze>,
     /// Overlay opacity for V2 clips. Range: 0.0 (transparent)..=1.0 (fully opaque). Default: 1.0.
     /// avio gap: `Clip` has no opacity field; `TimelineBuilder` exposes per-track opacity via
     /// animation only — per-clip opacity is not supported (docs/issue43.md).

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -652,6 +652,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 contrast: 1.0,
                 saturation: 1.0,
                 speed: 1.0,
+                reverse: false,
+                freeze: None,
                 opacity: 1.0,
                 blend_mode: avio::BlendMode::Normal,
                 position_x: 0.0,

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -69,7 +69,7 @@ fn snap_trim_edge(
                 (Some(i), None) => src.info.duration().saturating_sub(i).as_secs_f32(),
                 _ => src.info.duration().as_secs_f32(),
             };
-            let dur = src_dur / clip.speed;
+            let dur = src_dur / clip.speed + freeze_extra_secs(clip.freeze);
             let c_left = lane_left + clip.start_on_track.as_secs_f32() * pps;
             let c_right = c_left + dur * pps;
 
@@ -117,7 +117,7 @@ fn snap_clip_start(
                             (Some(i), None) => s.info.duration().saturating_sub(i).as_secs_f32(),
                             _ => s.info.duration().as_secs_f32(),
                         };
-                        let dur = src_dur / c.speed;
+                        let dur = src_dur / c.speed + freeze_extra_secs(c.freeze);
                         let cs = c.start_on_track.as_secs_f32();
                         (cs, cs + dur)
                     })
@@ -180,6 +180,12 @@ fn snap_clip_start(
 /// clip-local playhead time), and the key list with per-key value + easing. Mirrors
 /// the opacity keyframe panel; a key's easing controls the ramp to the next key, so it
 /// is shown only on keys that have a following segment.
+/// Extra timeline seconds a clip occupies because of a freeze-frame hold. #143.
+fn freeze_extra_secs(freeze: Option<state::Freeze>) -> f32 {
+    #[allow(clippy::cast_possible_truncation)]
+    freeze.map_or(0.0, |f| f.hold_secs as f32)
+}
+
 fn position_keyframe_panel(
     ui: &mut egui::Ui,
     id: &str,
@@ -318,6 +324,41 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                             .changed()
                         {
                             clip.speed = (speed_pct / 100.0).clamp(0.1, 4.0);
+                        }
+                    });
+                    // Reverse (export-only) + Freeze frame (hold + extend). #143.
+                    ui.horizontal(|ui| {
+                        ui.checkbox(&mut clip.reverse, "Reverse").on_hover_text(
+                            "Plays backward on export; the preview plays forward (see #178).",
+                        );
+                    });
+                    ui.horizontal(|ui| {
+                        let clip_local =
+                            (playhead_secs - clip.start_on_track.as_secs_f64()).max(0.0);
+                        let mut freeze_on = clip.freeze.is_some();
+                        if ui.checkbox(&mut freeze_on, "Freeze frame").changed() {
+                            clip.freeze = freeze_on.then_some(state::Freeze {
+                                at_secs: clip_local,
+                                hold_secs: 1.0,
+                            });
+                        }
+                        if let Some(f) = clip.freeze.as_mut() {
+                            ui.label("at");
+                            ui.add(
+                                egui::DragValue::new(&mut f.at_secs)
+                                    .speed(0.1)
+                                    .suffix(" s")
+                                    .fixed_decimals(2),
+                            );
+                            ui.label("hold");
+                            ui.add(
+                                egui::DragValue::new(&mut f.hold_secs)
+                                    .speed(0.1)
+                                    .suffix(" s")
+                                    .fixed_decimals(2),
+                            );
+                            f.at_secs = f.at_secs.max(0.0);
+                            f.hold_secs = f.hold_secs.max(0.1);
                         }
                     });
                     ui.horizontal(|ui| {
@@ -1256,6 +1297,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         contrast: tc.contrast,
                         saturation: tc.saturation,
                         speed: tc.speed,
+                        reverse: tc.reverse,
+                        freeze: tc.freeze,
                         opacity: tc.opacity,
                         blend_mode: tc.blend_mode,
                         position_x: tc.position_x,
@@ -1746,6 +1789,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 gamma_b: tc.gamma_b,
                 lut_path: tc.lut_path.clone(),
                 speed: tc.speed,
+                freeze: tc.freeze,
                 opacity: tc.opacity,
                 blend_mode: tc.blend_mode,
                 position_x: tc.position_x,
@@ -1844,6 +1888,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             gamma_b: tc.gamma_b,
                             lut_path: tc.lut_path.clone(),
                             speed: tc.speed,
+                            freeze: tc.freeze,
                             opacity: tc.opacity,
                             blend_mode: tc.blend_mode,
                             position_x: tc.position_x,
@@ -1968,7 +2013,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     (Some(i), None) => c.info.duration().saturating_sub(i),
                     _ => c.info.duration(),
                 };
-                tc.start_on_track.as_secs_f32() + src_dur.as_secs_f32() / tc.speed
+                tc.start_on_track.as_secs_f32()
+                    + src_dur.as_secs_f32() / tc.speed
+                    + freeze_extra_secs(tc.freeze)
             })
         })
         .fold(0.0f32, f32::max);
@@ -3342,7 +3389,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                     }
                                     _ => s.info.duration().as_secs_f32(),
                                 };
-                                src_dur / tc.speed
+                                src_dur / tc.speed + freeze_extra_secs(tc.freeze)
                             })
                         })
                         .unwrap_or(1.0);
@@ -3770,6 +3817,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 gamma_b: tc.gamma_b,
                 lut_path: tc.lut_path.clone(),
                 speed: tc.speed,
+                freeze: tc.freeze,
                 opacity: tc.opacity,
                 blend_mode: tc.blend_mode,
                 position_x: tc.position_x,
@@ -3881,6 +3929,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             contrast: 1.0,
             saturation: 1.0,
             speed: 1.0,
+            reverse: false,
+            freeze: None,
             opacity: 1.0,
             blend_mode: avio::BlendMode::Normal,
             position_x: 0.0,
@@ -4031,6 +4081,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 contrast: state.timeline.tracks[ti].clips[ci].contrast,
                 saturation: state.timeline.tracks[ti].clips[ci].saturation,
                 speed: state.timeline.tracks[ti].clips[ci].speed,
+                reverse: state.timeline.tracks[ti].clips[ci].reverse,
+                freeze: None,
                 opacity: state.timeline.tracks[ti].clips[ci].opacity,
                 blend_mode: state.timeline.tracks[ti].clips[ci].blend_mode,
                 position_x: state.timeline.tracks[ti].clips[ci].position_x,


### PR DESCRIPTION
## Summary

Adds two per-clip retiming features from #143: **freeze frame** (hold a frame for N seconds, extending the clip) and **reverse** (play video + audio backward). Both use avio's existing `FilterStep`s via the clip effect chain — **no avio change**. The third feature, **speed ramping**, is split out to #177 (it needs new avio variable-speed support: `docs/issue79.md`, `docs/issue80.md`).

## Changes

- **`src/state.rs`**: `TimelineClip.reverse: bool` + `freeze: Option<Freeze { at_secs, hold_secs }>` (new `Freeze` struct, serde).
- **`src/export.rs`**: `apply_reverse` (video `Reverse` + audio `AReverse`, **export-only**) and `apply_freeze` (`FreezeFrame { pts, duration }`, applied in **both** preview and export so clip lengths match); wired into `clips_to_avio`. New test `reverse_and_freeze_map_to_filter_steps`.
- **`src/player.rs`**: preview `make_clip` applies `apply_freeze` (freeze visible in preview); reverse is export-only.
- **`src/ui/timeline.rs`**: `freeze_extra_secs` helper extends timeline occupancy by the freeze hold at the layout sites; inspector gains a **Reverse** checkbox and **Freeze frame** (at / hold) controls.
- **`src/project.rs`** / **`src/ui/clip_browser.rs`**: thread the new fields through the project serde DTO and clip constructors.

## Notes / limitations (documented in code)

- **Reverse** plays forward in the realtime preview (avio buffers the whole clip for reverse — streaming preview can't); it reverses on export. Buffered reverse preview is tracked in #178.
- **Freeze** holds video only — audio is not held during the freeze (may run ahead by `hold_secs`); candidate follow-up.

## Related Issues

Part of #143
Follow-ups: #177 (speed ramping), #178 (buffered reverse preview)

## Test Plan

- [x] `cargo test` passes (41)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] Manual: reverse → exported video/audio play backward (preview forward); freeze at 1s/2s → clip grows 2s and holds the frame.