### PR TITLE
feat(timeline): linear speed ramp (video, export-only MVP)

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -36,6 +36,10 @@ pub struct ExportClip {
     pub reverse: bool,
     /// Freeze-frame spec (hold + extend clip length). avio `FreezeFrame`. #143.
     pub freeze: Option<crate::state::Freeze>,
+    /// Optional linear speed ramp (video only; audio muted; export-only). #177.
+    pub speed_ramp: Option<crate::state::SpeedRamp>,
+    /// Source playable duration (seconds) — the span the speed ramp covers. #177.
+    pub src_dur_secs: f64,
     /// Per-clip opacity (`1.0` = fully opaque). Forwarded to `Clip::with_opacity`.
     pub opacity: f32,
     /// Per-clip blend mode. Forwarded to `Clip::with_blend_mode`.
@@ -871,6 +875,41 @@ pub fn apply_freeze(clip: avio::Clip, freeze: Option<crate::state::Freeze>) -> a
     }
 }
 
+/// Log-mean of two positive speed factors — the constant speed whose duration equals the
+/// linear ramp's integral `∫ 1/s dt`, so avio's scalar `clip_dur` stays correct. #177.
+pub fn log_mean(a: f64, b: f64) -> f64 {
+    if (a - b).abs() < 1e-9 {
+        a
+    } else {
+        (b - a) / (b / a).ln()
+    }
+}
+
+/// Apply a linear video speed ramp. Sets the scalar speed to the log-mean (for correct
+/// duration) and mutes audio. On **export** also attaches the `SpeedRampVideo` `setpts`
+/// effect; the preview omits it and plays at the average (log-mean) speed. #177.
+pub fn apply_speed_ramp(
+    clip: avio::Clip,
+    ramp: Option<crate::state::SpeedRamp>,
+    src_dur_secs: f64,
+    is_export: bool,
+) -> avio::Clip {
+    let Some(r) = ramp else { return clip };
+    let a = f64::from(r.start_pct) / 100.0;
+    let b = f64::from(r.end_pct) / 100.0;
+    // Log-mean scalar speed (correct output duration) + mute audio.
+    let clip = clip.with_speed(log_mean(a, b)).volume(-120.0);
+    if is_export {
+        clip.with_video_effect(avio::FilterStep::SpeedRampVideo {
+            start_factor: a,
+            end_factor: b,
+            clip_dur_secs: src_dur_secs,
+        })
+    } else {
+        clip
+    }
+}
+
 fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio::Clip> {
     clips
         .into_iter()
@@ -914,6 +953,9 @@ fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio
             // (#178); freeze is applied in both so clip lengths match.
             let clip = apply_reverse(clip, c.reverse);
             let clip = apply_freeze(clip, c.freeze);
+            // Linear speed ramp (video only): overrides the static speed, mutes audio, and
+            // (export) attaches the SpeedRampVideo setpts. #177.
+            let clip = apply_speed_ramp(clip, c.speed_ramp, c.src_dur_secs, true);
             // Chroma key first — key the original colours before any transform /
             // grade / scale, producing alpha the composer reveals through. Shared
             // with preview. No-op when disabled.
@@ -2492,5 +2534,128 @@ mod tests {
             _ => None,
         });
         assert_eq!(step, Some((1.5, 2.0)));
+    }
+
+    #[test]
+    fn speed_ramp_maps_to_setpts_and_mutes() {
+        use super::{apply_speed_ramp, log_mean};
+        use crate::state::SpeedRamp;
+
+        // None → unchanged.
+        let plain = apply_speed_ramp(avio::Clip::new("t.mp4"), None, 4.0, true);
+        assert!(plain.video_effect_chain().is_empty());
+
+        let r = Some(SpeedRamp {
+            start_pct: 100.0,
+            end_pct: 400.0,
+        });
+
+        // Export ramp 100%→400% over 4s → SpeedRampVideo + log-mean speed + muted.
+        let ex = apply_speed_ramp(avio::Clip::new("t.mp4"), r, 4.0, true);
+        let step = ex.video_effect_chain().into_iter().find_map(|s| match s {
+            avio::FilterStep::SpeedRampVideo {
+                start_factor,
+                end_factor,
+                clip_dur_secs,
+            } => Some((start_factor, end_factor, clip_dur_secs)),
+            _ => None,
+        });
+        assert_eq!(step, Some((1.0, 4.0, 4.0)));
+        assert!((ex.speed - log_mean(1.0, 4.0)).abs() < 1e-9);
+        assert!(ex.volume_db < -100.0, "audio should be muted");
+
+        // Preview (is_export=false) → log-mean speed + mute, but no SpeedRampVideo.
+        let pv = apply_speed_ramp(avio::Clip::new("t.mp4"), r, 0.0, false);
+        assert!(pv.video_effect_chain().is_empty());
+        assert!((pv.speed - log_mean(1.0, 4.0)).abs() < 1e-9);
+        assert!(pv.volume_db < -100.0);
+    }
+
+    // Builds a defaults-everywhere ExportClip carrying a speed ramp, to verify the FULL
+    // export mapping (`clips_to_avio`) — not just `apply_speed_ramp` in isolation — keeps
+    // the SpeedRampVideo effect (correct clip_dur) and the log-mean speed. #177.
+    #[test]
+    fn clips_to_avio_preserves_speed_ramp() {
+        use crate::state::SpeedRamp;
+        use std::time::Duration;
+
+        let mk = |ramp: Option<SpeedRamp>, speed: f32| super::ExportClip {
+            path: std::path::PathBuf::from("t.mp4"),
+            start_on_track: Duration::ZERO,
+            in_point: Some(Duration::ZERO),
+            out_point: Some(Duration::from_secs(6)),
+            transition: None,
+            transition_duration: Duration::ZERO,
+            source_duration: Duration::from_secs(6),
+            fps: 30.0,
+            has_audio: false,
+            gain_db: 0.0,
+            fade_in: Duration::ZERO,
+            fade_out: Duration::ZERO,
+            brightness: 0.0,
+            contrast: 1.0,
+            saturation: 1.0,
+            speed,
+            reverse: false,
+            freeze: None,
+            speed_ramp: ramp,
+            src_dur_secs: 6.0,
+            opacity: 1.0,
+            blend_mode: avio::BlendMode::Normal,
+            position_x: 0.0,
+            position_y: 0.0,
+            scale_pct: 100.0,
+            proxy_path: None,
+            lut_path: None,
+            wb_temperature: crate::state::WB_NEUTRAL_TEMP,
+            wb_tint: 0.0,
+            hue_degrees: 0.0,
+            gamma_r: 1.0,
+            gamma_g: 1.0,
+            gamma_b: 1.0,
+            vignette: 0.0,
+            vignette_x: 50.0,
+            vignette_y: 50.0,
+            width: 640,
+            height: 360,
+            curves: Default::default(),
+            wheels: Default::default(),
+            video_effects: Default::default(),
+            transform: Default::default(),
+            overlay: Default::default(),
+            subtitle: Default::default(),
+            keying: Default::default(),
+            mask: Default::default(),
+            animation: Default::default(),
+        };
+
+        let ramp = mk(
+            Some(SpeedRamp {
+                start_pct: 100.0,
+                end_pct: 800.0,
+            }),
+            1.0,
+        );
+        let out = super::clips_to_avio(vec![ramp], None);
+        let clip = &out[0];
+        let step = clip.video_effect_chain().into_iter().find_map(|s| match s {
+            avio::FilterStep::SpeedRampVideo {
+                start_factor,
+                end_factor,
+                clip_dur_secs,
+            } => Some((start_factor, end_factor, clip_dur_secs)),
+            _ => None,
+        });
+        assert_eq!(
+            step,
+            Some((1.0, 8.0, 6.0)),
+            "clips_to_avio must keep SpeedRampVideo with the source duration"
+        );
+        assert!(
+            (clip.speed - super::log_mean(1.0, 8.0)).abs() < 1e-9,
+            "scalar speed must be the log-mean, got {}",
+            clip.speed
+        );
+        assert!(clip.volume_db < -100.0, "ramped clip audio must be muted");
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -43,6 +43,8 @@ pub struct TrackClipData {
     pub speed: f32,
     /// Freeze-frame spec, applied in preview + export so clip lengths match. #143.
     pub freeze: Option<crate::state::Freeze>,
+    /// Optional linear speed ramp (video only; audio muted). #177.
+    pub speed_ramp: Option<crate::state::SpeedRamp>,
     /// Per-clip opacity (`1.0` = fully opaque). Forwarded to `Clip::with_opacity`.
     pub opacity: f32,
     /// Per-clip blend mode. Forwarded to `Clip::with_blend_mode`.
@@ -459,6 +461,9 @@ pub fn spawn_timeline_player(
             // Freeze frame — applied in preview too so the clip length matches export.
             // (Reverse is export-only; the preview plays forward.) #143.
             c = crate::export::apply_freeze(c, tc.freeze);
+            // Speed ramp — preview plays at the average (log-mean) speed with audio muted;
+            // the ramp itself (SpeedRampVideo) is export-only. #177.
+            c = crate::export::apply_speed_ramp(c, tc.speed_ramp, 0.0, false);
             // Chroma key first — key original colours before transform/grade,
             // producing alpha the composer reveals through. Matches export.
             c = crate::export::apply_keying(c, &tc.keying);

--- a/src/project.rs
+++ b/src/project.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::state::{
-    AppState, ExportFilterDraft, Freeze, HAlign, ImportedClip, TimelineClip, TitleClip, Track,
-    TrackKind, VAlign,
+    AppState, ExportFilterDraft, Freeze, HAlign, ImportedClip, SpeedRamp, TimelineClip, TitleClip,
+    Track, TrackKind, VAlign,
 };
 
 // ── Serializable project structs ─────────────────────────────────────────────
@@ -55,6 +55,8 @@ pub struct ProjectTimelineClip {
     pub reverse: bool,
     #[serde(default)]
     pub freeze: Option<Freeze>,
+    #[serde(default)]
+    pub speed_ramp: Option<SpeedRamp>,
     pub opacity: f32,
     pub blend_mode: String,
     #[serde(default)]
@@ -253,6 +255,7 @@ fn timeline_clip_to_project(tc: &TimelineClip, clips: &[ImportedClip]) -> Projec
         speed: tc.speed,
         reverse: tc.reverse,
         freeze: tc.freeze,
+        speed_ramp: tc.speed_ramp,
         opacity: tc.opacity,
         blend_mode: blend_mode_to_str(tc.blend_mode).to_string(),
         position_x: tc.position_x,
@@ -311,6 +314,7 @@ fn project_to_timeline_clip(
         speed: ptc.speed,
         reverse: ptc.reverse,
         freeze: ptc.freeze,
+        speed_ramp: ptc.speed_ramp,
         opacity: ptc.opacity,
         blend_mode: blend_mode_from_str(&ptc.blend_mode),
         position_x: ptc.position_x,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1271,6 +1271,17 @@ pub struct Freeze {
     pub hold_secs: f64,
 }
 
+/// Linear speed ramp: playback speed goes from `start_pct` to `end_pct` (% of normal)
+/// across the clip — video only, audio muted, export-only. Maps to avio
+/// `FilterStep::SpeedRampVideo`. #177.
+#[derive(Clone, Copy, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SpeedRamp {
+    /// Speed at the clip start, percent of normal (10–400).
+    pub start_pct: f32,
+    /// Speed at the clip end, percent of normal (10–400).
+    pub end_pct: f32,
+}
+
 #[derive(Clone, PartialEq)]
 pub struct TimelineClip {
     pub source_index: usize,
@@ -1309,6 +1320,8 @@ pub struct TimelineClip {
     pub reverse: bool,
     /// Optional freeze-frame: hold a frame for N seconds, extending the clip length. #143.
     pub freeze: Option<Freeze>,
+    /// Optional linear speed ramp (video only; audio muted; export-only). #177.
+    pub speed_ramp: Option<SpeedRamp>,
     /// Overlay opacity for V2 clips. Range: 0.0 (transparent)..=1.0 (fully opaque). Default: 1.0.
     /// avio gap: `Clip` has no opacity field; `TimelineBuilder` exposes per-track opacity via
     /// animation only — per-clip opacity is not supported (docs/issue43.md).

--- a/src/ui/clip_browser.rs
+++ b/src/ui/clip_browser.rs
@@ -654,6 +654,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui, ctx: &egui::Context)
                 speed: 1.0,
                 reverse: false,
                 freeze: None,
+                speed_ramp: None,
                 opacity: 1.0,
                 blend_mode: avio::BlendMode::Normal,
                 position_x: 0.0,

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -69,7 +69,8 @@ fn snap_trim_edge(
                 (Some(i), None) => src.info.duration().saturating_sub(i).as_secs_f32(),
                 _ => src.info.duration().as_secs_f32(),
             };
-            let dur = src_dur / clip.speed + freeze_extra_secs(clip.freeze);
+            let dur = src_dur / effective_speed(clip.speed, clip.speed_ramp)
+                + freeze_extra_secs(clip.freeze);
             let c_left = lane_left + clip.start_on_track.as_secs_f32() * pps;
             let c_right = c_left + dur * pps;
 
@@ -117,7 +118,8 @@ fn snap_clip_start(
                             (Some(i), None) => s.info.duration().saturating_sub(i).as_secs_f32(),
                             _ => s.info.duration().as_secs_f32(),
                         };
-                        let dur = src_dur / c.speed + freeze_extra_secs(c.freeze);
+                        let dur = src_dur / effective_speed(c.speed, c.speed_ramp)
+                            + freeze_extra_secs(c.freeze);
                         let cs = c.start_on_track.as_secs_f32();
                         (cs, cs + dur)
                     })
@@ -181,6 +183,23 @@ fn snap_clip_start(
 /// the opacity keyframe panel; a key's easing controls the ramp to the next key, so it
 /// is shown only on keys that have a following segment.
 /// Extra timeline seconds a clip occupies because of a freeze-frame hold. #143.
+/// Effective constant playback speed of a clip: a linear speed ramp's log-mean (so its
+/// timeline length is correct), else the static speed. #177.
+fn effective_speed(speed: f32, ramp: Option<state::SpeedRamp>) -> f32 {
+    match ramp {
+        Some(r) => {
+            let a = r.start_pct / 100.0;
+            let b = r.end_pct / 100.0;
+            if (a - b).abs() < 1e-6 {
+                a
+            } else {
+                (b - a) / (b / a).ln()
+            }
+        }
+        None => speed,
+    }
+}
+
 fn freeze_extra_secs(freeze: Option<state::Freeze>) -> f32 {
     #[allow(clippy::cast_possible_truncation)]
     freeze.map_or(0.0, |f| f.hold_secs as f32)
@@ -359,6 +378,41 @@ pub fn show_inspector(state: &mut state::AppState, ui: &mut egui::Ui) {
                             );
                             f.at_secs = f.at_secs.max(0.0);
                             f.hold_secs = f.hold_secs.max(0.1);
+                        }
+                    });
+                    // Linear speed ramp (video only; audio muted; export-only). #177.
+                    ui.horizontal(|ui| {
+                        let mut ramp_on = clip.speed_ramp.is_some();
+                        if ui
+                            .checkbox(&mut ramp_on, "Speed ramp")
+                            .on_hover_text(
+                                "Linear video speed ramp; audio muted. Applies on export; \
+                                 the preview plays at the average speed.",
+                            )
+                            .changed()
+                        {
+                            clip.speed_ramp = ramp_on.then_some(state::SpeedRamp {
+                                start_pct: clip.speed * 100.0,
+                                end_pct: clip.speed * 100.0,
+                            });
+                        }
+                        if let Some(r) = clip.speed_ramp.as_mut() {
+                            ui.label("start");
+                            ui.add(
+                                egui::DragValue::new(&mut r.start_pct)
+                                    .speed(1.0)
+                                    .suffix(" %")
+                                    .fixed_decimals(0),
+                            );
+                            ui.label("end");
+                            ui.add(
+                                egui::DragValue::new(&mut r.end_pct)
+                                    .speed(1.0)
+                                    .suffix(" %")
+                                    .fixed_decimals(0),
+                            );
+                            r.start_pct = r.start_pct.clamp(10.0, 400.0);
+                            r.end_pct = r.end_pct.clamp(10.0, 400.0);
                         }
                     });
                     ui.horizontal(|ui| {
@@ -1282,6 +1336,16 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     let src = &clips[tc.source_index];
                     export::ExportClip {
                         path: src.path.clone(),
+                        src_dur_secs: {
+                            let full = src.info.duration();
+                            match (tc.in_point, tc.out_point) {
+                                (Some(i), Some(o)) if o > i => o - i,
+                                (None, Some(o)) => o,
+                                (Some(i), None) => full.saturating_sub(i),
+                                _ => full,
+                            }
+                            .as_secs_f64()
+                        },
                         start_on_track: tc.start_on_track,
                         in_point: tc.in_point,
                         out_point: tc.out_point,
@@ -1299,6 +1363,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         speed: tc.speed,
                         reverse: tc.reverse,
                         freeze: tc.freeze,
+                        speed_ramp: tc.speed_ramp,
                         opacity: tc.opacity,
                         blend_mode: tc.blend_mode,
                         position_x: tc.position_x,
@@ -1790,6 +1855,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 lut_path: tc.lut_path.clone(),
                 speed: tc.speed,
                 freeze: tc.freeze,
+                speed_ramp: tc.speed_ramp,
                 opacity: tc.opacity,
                 blend_mode: tc.blend_mode,
                 position_x: tc.position_x,
@@ -1889,6 +1955,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             lut_path: tc.lut_path.clone(),
                             speed: tc.speed,
                             freeze: tc.freeze,
+                            speed_ramp: tc.speed_ramp,
                             opacity: tc.opacity,
                             blend_mode: tc.blend_mode,
                             position_x: tc.position_x,
@@ -2014,7 +2081,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     _ => c.info.duration(),
                 };
                 tc.start_on_track.as_secs_f32()
-                    + src_dur.as_secs_f32() / tc.speed
+                    + src_dur.as_secs_f32() / effective_speed(tc.speed, tc.speed_ramp)
                     + freeze_extra_secs(tc.freeze)
             })
         })
@@ -2485,7 +2552,9 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                             let fps = source.info.frame_rate().unwrap_or(30.0) as f32;
                             let one_frame_sec = (1.0 / fps).max(0.001_f32);
                             let orig_x = lane_rect.left() + tc.start_on_track.as_secs_f32() * pps;
-                            let orig_w = eff_dur.as_secs_f32() / tc.speed * pps;
+                            let orig_w = eff_dur.as_secs_f32()
+                                / effective_speed(tc.speed, tc.speed_ramp)
+                                * pps;
                             let mut new_speed_pct = tc.speed * 100.0;
 
                             // Live-preview dimensions during an active trim drag
@@ -3389,7 +3458,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                                     }
                                     _ => s.info.duration().as_secs_f32(),
                                 };
-                                src_dur / tc.speed + freeze_extra_secs(tc.freeze)
+                                src_dur / effective_speed(tc.speed, tc.speed_ramp)
+                                    + freeze_extra_secs(tc.freeze)
                             })
                         })
                         .unwrap_or(1.0);
@@ -3818,6 +3888,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 lut_path: tc.lut_path.clone(),
                 speed: tc.speed,
                 freeze: tc.freeze,
+                speed_ramp: tc.speed_ramp,
                 opacity: tc.opacity,
                 blend_mode: tc.blend_mode,
                 position_x: tc.position_x,
@@ -3931,6 +4002,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             speed: 1.0,
             reverse: false,
             freeze: None,
+            speed_ramp: None,
             opacity: 1.0,
             blend_mode: avio::BlendMode::Normal,
             position_x: 0.0,
@@ -4083,6 +4155,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 speed: state.timeline.tracks[ti].clips[ci].speed,
                 reverse: state.timeline.tracks[ti].clips[ci].reverse,
                 freeze: None,
+                speed_ramp: None,
                 opacity: state.timeline.tracks[ti].clips[ci].opacity,
                 blend_mode: state.timeline.tracks[ti].clips[ci].blend_mode,
                 position_x: state.timeline.tracks[ti].clips[ci].position_x,


### PR DESCRIPTION
## Summary

Adds a per-clip **linear speed ramp** (start% → end%) for video, the MVP of #177. The clip's scalar speed is set to the **log-mean** of the two factors (so avio's duration math is correct), audio is muted on ramped clips, and on export the ramp is realised by avio's `FilterStep::SpeedRampVideo` (setpts + fps). The realtime preview plays the clip at the ramp's **average** speed (a documented limitation — true preview ramp is #180).

## Changes

- **`src/state.rs`**: `SpeedRamp { start_pct, end_pct }` + `TimelineClip.speed_ramp: Option<SpeedRamp>` (threaded like #143's `freeze`).
- **`src/export.rs`**: `log_mean()` + `apply_speed_ramp()` — sets `with_speed(log_mean)`, mutes audio, and (export only) attaches `SpeedRampVideo{start,end,clip_dur}`. Overrides the static speed slider. Wired into `clips_to_avio`. Tests: `speed_ramp_maps_to_setpts_and_mutes`, `clips_to_avio_preserves_speed_ramp`.
- **`src/player.rs`**: preview applies log-mean speed + mute (no `SpeedRampVideo` — constant average).
- **`src/ui/timeline.rs`**: `effective_speed()` so a ramped clip's timeline length uses the log-mean; a "Speed ramp" inspector control (start%/end%).
- **`src/project.rs` / `src/ui/clip_browser.rs`**: thread `speed_ramp` through the serde DTO and clip constructors.

## Notes / limitations

- **Export-only**: avio's export applies the ramp via `setpts`+`fps`; the preview runner times video by a scalar speed, so it plays the ramp's average (log-mean) speed. True preview ramp = **#180** (curve-aware runner).
- **Video-only**: audio is muted on ramped clips. Full A/V variable-speed = **docs/issue80**.
- **Depends on avio #1318** (`FilterStep::SpeedRampVideo`).

## Verification

avio renders the ramp correctly end-to-end — verified by decoding the exported video (accelerating ramp: output midpoint shows the source ~33% consumed vs ~50% for constant speed), and the demo's own `clips_to_avio` path produces the same result.

## Related Issues

Part of #177 / #143
Follow-ups: #180 (preview ramp), docs/issue80 (full A/V variable speed)

## Test Plan

- [x] `cargo test` passes (43)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes