### PR TITLE
chore(deps): adopt avio 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -239,7 +239,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -258,7 +258,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -484,8 +484,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "avio"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
+ "ff-analysis",
  "ff-common",
  "ff-decode",
  "ff-encode",
@@ -494,6 +495,9 @@ dependencies = [
  "ff-pipeline",
  "ff-preview",
  "ff-probe",
+ "ff-remux",
+ "log",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1242,7 +1246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1294,15 +1298,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff-analysis"
+version = "0.16.0"
+dependencies = [
+ "ff-decode",
+ "ff-format",
+ "ff-sys",
+ "log",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ff-common"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "ff-decode"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "ff-common",
  "ff-format",
@@ -1315,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "ff-encode"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "ff-format",
  "ff-sys",
@@ -1326,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "ff-filter"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "ff-common",
  "ff-format",
@@ -1338,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "ff-format"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "ff-common",
  "log",
@@ -1347,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "ff-pipeline"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "ff-common",
  "ff-decode",
@@ -1360,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "ff-preview"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "ff-decode",
  "ff-encode",
@@ -1376,7 +1391,17 @@ dependencies = [
 
 [[package]]
 name = "ff-probe"
-version = "0.15.1"
+version = "0.16.0"
+dependencies = [
+ "ff-format",
+ "ff-sys",
+ "log",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ff-remux"
+version = "0.16.0"
 dependencies = [
  "ff-format",
  "ff-sys",
@@ -1386,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "ff-sys"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "bindgen",
  "log",
@@ -3133,7 +3158,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3380,7 +3405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3442,7 +3467,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3656,7 +3681,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4138,7 +4163,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4371,15 +4396,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4411,28 +4427,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4457,12 +4456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4473,12 +4466,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4493,22 +4480,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4523,12 +4498,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4539,12 +4508,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4559,12 +4522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4575,12 +4532,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-avio = { version = "0.15", features = [
+avio = { version = "0.16", features = [
     "decode",
     "encode",
     "filter",


### PR DESCRIPTION
## Summary

Adopt `avio` 0.16.0. The 0.16 release splits avio into an editing **engine** (`avio`) and model-free **`ff-*`** primitive crates; because this demo consumes avio through the `avio::` facade, the split is transparent and the adaptation is a single dependency version bump. No demo source changes were required.

## Changes

- Bump the `avio` dependency from `0.15` to `0.16` in `Cargo.toml`. The local `[patch.crates-io]` path crates are at `0.16.0`; the `"0.15"` requirement no longer matched the patched version, so the bump is required for the patch to apply (otherwise Cargo silently falls back to published `0.15.x`).
- `Cargo.lock` regenerated for the 0.16.0 dependency graph (all `ff-*` crates now lockstep at `0.16.0`; the new `ff-analysis` / `ff-remux` crates are re-exported through `avio`).
- No `src/` changes: the demo's entire `avio::` usage surface resolves unchanged. The items removed in 0.16 (editorial `FilterStep::dissolve`/`join`, `VideoLayer`/`AudioTrack` timeline fields, moved `DecodeError`/`EncodeError` variants) are not used by the demo, and the newly `#[non_exhaustive]` enums have no exhaustive `match` in the demo.

## Related Issues

No linked issue — routine dependency adoption. A follow-up **Tracking Issue** will be filed for migrating the demo's editing layer to avio 0.16's `Editor` / `Command` model (and enumerating the demo-local features discarded in that migration).

## Test Plan

- [x] `cargo test` passes (41 passed)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes