### PR TITLE
feat: avio 0.16 edit-model migration groundwork (phases 1-3)

### DIFF
--- a/src/clip_effects.rs
+++ b/src/clip_effects.rs
@@ -1,0 +1,569 @@
+//! Regeneration seam: demo per-clip authoring params ⇄ an `avio::Clip`'s effect
+//! chain + native creative fields.
+//!
+//! Phase 1 of migrating the demo onto avio 0.16's edit model (`avio::Timeline` /
+//! `Clip` as the single document — see the migration plan). avio's `Command` /
+//! `ClipProperty` can only edit five scalar properties, so the demo's ~35 creative
+//! per-clip params live in [`Clip.metadata`](avio::Clip) as one JSON blob
+//! ([`ClipParams`]) and the `video_effects` chain + native creative fields are
+//! **regenerated** from them on every edit via [`regenerate`], which reuses the
+//! existing `export.rs` `apply_*` builders in the exact order `clips_to_avio`
+//! uses. This keeps the structured inspector re-editable while the `avio::Clip`
+//! stays the single source of truth (the params ride `Timeline` snapshots).
+//!
+//! This module is unwired in Phase 1 (`#![allow(dead_code)]`); it is validated by
+//! a golden test asserting [`regenerate`] reproduces the exact chain
+//! `clips_to_avio` builds today.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::state::{
+    ClipAnimation, ColorWheels, Freeze, ImportedClip, Keying, Mask, Overlay, Subtitle, ToneCurves,
+    Transform, VideoEffects, WB_NEUTRAL_TEMP,
+};
+
+/// `Clip.metadata` key holding the demo's stable per-clip id.
+pub const DEMO_ID_KEY: &str = "demo_id";
+/// `Clip.metadata` key holding the [`ClipParams`] JSON blob.
+pub const PARAMS_KEY: &str = "demo.params";
+
+/// All per-clip *rich* authoring params — everything the demo edits that avio's
+/// `Command`/`ClipProperty` cannot express, plus the few native scalars, in a
+/// serde-friendly form (transition/blend-mode as strings, durations as seconds)
+/// so it round-trips through `Clip.metadata` and the project file.
+///
+/// Structural fields (source, offset, in/out, proxy) are NOT here — they live on
+/// the `avio::Clip` directly and are set by structural commands.
+#[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ClipParams {
+    pub speed: f32,
+    pub gain_db: f32,
+    pub fade_in_secs: f64,
+    pub fade_out_secs: f64,
+    pub transition: Option<String>,
+    pub transition_duration_secs: f64,
+    pub opacity: f32,
+    pub blend_mode: String,
+    pub position_x: f32,
+    pub position_y: f32,
+    pub scale_pct: f32,
+    pub reverse: bool,
+    pub freeze: Option<Freeze>,
+    pub lut_path: Option<PathBuf>,
+    pub brightness: f32,
+    pub contrast: f32,
+    pub saturation: f32,
+    pub wb_temperature: u32,
+    pub wb_tint: f32,
+    pub hue_degrees: f32,
+    pub gamma_r: f32,
+    pub gamma_g: f32,
+    pub gamma_b: f32,
+    pub vignette: f32,
+    pub vignette_x: f32,
+    pub vignette_y: f32,
+    pub curves: ToneCurves,
+    pub wheels: ColorWheels,
+    pub video_effects: VideoEffects,
+    pub transform: Transform,
+    pub overlay: Overlay,
+    pub subtitle: Subtitle,
+    pub keying: Keying,
+    pub mask: Mask,
+    pub animation: ClipAnimation,
+}
+
+impl Default for ClipParams {
+    fn default() -> Self {
+        Self {
+            speed: 1.0,
+            gain_db: 0.0,
+            fade_in_secs: 0.0,
+            fade_out_secs: 0.0,
+            transition: None,
+            transition_duration_secs: 0.5,
+            opacity: 1.0,
+            blend_mode: "Normal".to_string(),
+            position_x: 0.0,
+            position_y: 0.0,
+            scale_pct: 100.0,
+            reverse: false,
+            freeze: None,
+            lut_path: None,
+            brightness: 0.0,
+            contrast: 1.0,
+            saturation: 1.0,
+            wb_temperature: WB_NEUTRAL_TEMP,
+            wb_tint: 0.0,
+            hue_degrees: 0.0,
+            gamma_r: 1.0,
+            gamma_g: 1.0,
+            gamma_b: 1.0,
+            vignette: 0.0,
+            vignette_x: 50.0,
+            vignette_y: 50.0,
+            curves: ToneCurves::default(),
+            wheels: ColorWheels::default(),
+            video_effects: VideoEffects::default(),
+            transform: Transform::default(),
+            overlay: Overlay::default(),
+            subtitle: Subtitle::default(),
+            keying: Keying::default(),
+            mask: Mask::default(),
+            animation: ClipAnimation::default(),
+        }
+    }
+}
+
+impl ClipParams {
+    /// Builds params from an [`ExportClip`](crate::export::ExportClip) snapshot —
+    /// the current authoring source. Used by the Phase-1 golden test and (later)
+    /// wherever the demo's typed state is projected into the avio document.
+    pub fn from_export_clip(c: &crate::export::ExportClip) -> Self {
+        Self {
+            speed: c.speed,
+            gain_db: c.gain_db,
+            fade_in_secs: c.fade_in.as_secs_f64(),
+            fade_out_secs: c.fade_out.as_secs_f64(),
+            transition: c.transition.map(|t| t.as_str().to_string()),
+            transition_duration_secs: c.transition_duration.as_secs_f64(),
+            opacity: c.opacity,
+            blend_mode: crate::project::blend_mode_to_str(c.blend_mode).to_string(),
+            position_x: c.position_x,
+            position_y: c.position_y,
+            scale_pct: c.scale_pct,
+            reverse: c.reverse,
+            freeze: c.freeze,
+            lut_path: c.lut_path.clone(),
+            brightness: c.brightness,
+            contrast: c.contrast,
+            saturation: c.saturation,
+            wb_temperature: c.wb_temperature,
+            wb_tint: c.wb_tint,
+            hue_degrees: c.hue_degrees,
+            gamma_r: c.gamma_r,
+            gamma_g: c.gamma_g,
+            gamma_b: c.gamma_b,
+            vignette: c.vignette,
+            vignette_x: c.vignette_x,
+            vignette_y: c.vignette_y,
+            curves: c.curves.clone(),
+            wheels: c.wheels,
+            video_effects: c.video_effects,
+            transform: c.transform,
+            overlay: c.overlay.clone(),
+            subtitle: c.subtitle.clone(),
+            keying: c.keying,
+            mask: c.mask.clone(),
+            animation: c.animation.clone(),
+        }
+    }
+
+    /// Serializes to `{PARAMS_KEY: <json>}`. The caller merges this into the
+    /// clip's existing metadata (preserving [`DEMO_ID_KEY`]).
+    pub fn to_metadata(&self) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        if let Ok(json) = serde_json::to_string(self) {
+            m.insert(PARAMS_KEY.to_string(), json);
+        }
+        m
+    }
+
+    /// Parses params from a clip's metadata, or `None` when absent/invalid.
+    pub fn from_metadata(meta: &HashMap<String, String>) -> Option<Self> {
+        let json = meta.get(PARAMS_KEY)?;
+        serde_json::from_str(json).ok()
+    }
+}
+
+/// Rebuilds `clip`'s effect chain + native creative fields from `params`,
+/// **preserving** the structural fields (source, offset, in/out, proxy, metadata).
+///
+/// This reuses the `export.rs` `apply_*` builders in the exact order
+/// `clips_to_avio` applies them, so the resulting `video_effects` chain and native
+/// fields are identical to today's export projection (verified by the golden
+/// test). `src` is the source video `(w, h)`; `canvas` the project canvas (for
+/// fit/fill), `None` = original framing.
+///
+/// `is_export` gates the export-only reverse effect: `Reverse`/`AReverse` are
+/// baked only for export (the streaming preview plays forward — see
+/// `apply_reverse`). Pass `false` for the live/preview document.
+pub fn regenerate(
+    clip: avio::Clip,
+    params: &ClipParams,
+    src: (u32, u32),
+    canvas: Option<(u32, u32)>,
+    is_export: bool,
+) -> avio::Clip {
+    use crate::export::{
+        apply_animation, apply_color_grade, apply_freeze, apply_keying, apply_mask, apply_overlay,
+        apply_reverse, apply_subtitle, apply_transform, apply_video_effects,
+    };
+
+    let start = clip.offset;
+    let (w, h) = src;
+
+    // Reset the regenerated surface to neutral; keep source/offset/in/out/proxy/metadata.
+    let mut clip = clip;
+    clip.video_effects.clear();
+    clip.audio_effects.clear();
+    clip.speed = 1.0;
+    clip.volume_db = 0.0;
+    clip.volume_track = None;
+    clip.fade_in = Duration::ZERO;
+    clip.fade_out = Duration::ZERO;
+    clip.transition = None;
+    clip.brightness = 0.0;
+    clip.contrast = 1.0;
+    clip.saturation = 1.0;
+    clip.opacity = 1.0;
+    clip.opacity_track = None;
+    clip.x = 0.0;
+    clip.y = 0.0;
+    clip.x_track = None;
+    clip.y_track = None;
+    clip.blend_mode = avio::BlendMode::Normal;
+    clip.composite_op = avio::CompositeOp::Over;
+
+    // Same order as export::clips_to_avio.
+    #[allow(clippy::float_cmp)]
+    let clip = if params.speed != 1.0 {
+        clip.with_speed(f64::from(params.speed))
+    } else {
+        clip
+    };
+    #[allow(clippy::float_cmp)]
+    let clip = if params.gain_db != 0.0 && !params.animation.volume.is_active() {
+        clip.volume(f64::from(params.gain_db))
+    } else {
+        clip
+    };
+    let clip = if params.fade_in_secs > 0.0 {
+        clip.with_fade_in(Duration::from_secs_f64(params.fade_in_secs))
+    } else {
+        clip
+    };
+    let clip = if params.fade_out_secs > 0.0 {
+        clip.with_fade_out(Duration::from_secs_f64(params.fade_out_secs))
+    } else {
+        clip
+    };
+    let clip = match params
+        .transition
+        .as_deref()
+        .and_then(crate::project::xfade_from_str)
+    {
+        Some(kind) => clip.with_transition(
+            kind,
+            Duration::from_secs_f64(params.transition_duration_secs),
+        ),
+        None => clip,
+    };
+    let clip = if is_export {
+        apply_reverse(clip, params.reverse)
+    } else {
+        clip
+    };
+    let clip = apply_freeze(clip, params.freeze);
+    let clip = apply_keying(clip, &params.keying);
+    let clip = apply_transform(clip, &params.transform, w, h);
+    let clip = apply_color_grade(
+        clip,
+        params.brightness,
+        params.contrast,
+        params.saturation,
+        params.wb_temperature,
+        params.wb_tint,
+        params.hue_degrees,
+        params.gamma_r,
+        params.gamma_g,
+        params.gamma_b,
+        &params.wheels,
+        &params.curves,
+        params.lut_path.as_deref(),
+        params.vignette,
+        params.vignette_x,
+        params.vignette_y,
+        w,
+        h,
+    );
+    let clip = apply_video_effects(clip, &params.video_effects);
+    let clip = match canvas {
+        Some((cw, ch)) => apply_aspect_ref(clip, &params.transform, w, h, cw, ch),
+        None => clip,
+    };
+    let clip = apply_overlay(clip, &params.overlay);
+    let clip = apply_subtitle(clip, &params.subtitle);
+    let clip = apply_mask(clip, &params.mask, w, h);
+    let clip = apply_animation(
+        clip,
+        &params.animation,
+        start,
+        (params.position_x, params.position_y),
+        params.scale_pct,
+        (w, h),
+    );
+    #[allow(clippy::float_cmp)]
+    let clip = if params.opacity != 1.0 {
+        clip.with_opacity(params.opacity)
+    } else {
+        clip
+    };
+    let bm = crate::project::blend_mode_from_str(&params.blend_mode);
+    if bm != avio::BlendMode::Normal {
+        clip.with_blend_mode(bm)
+    } else {
+        clip
+    }
+}
+
+/// Thin wrapper so `regenerate` reads the `fit_mode` off the transform exactly as
+/// `clips_to_avio` does (`apply_aspect(clip, t.fit_mode, ...)`).
+fn apply_aspect_ref(
+    clip: avio::Clip,
+    t: &Transform,
+    src_w: u32,
+    src_h: u32,
+    canvas_w: u32,
+    canvas_h: u32,
+) -> avio::Clip {
+    crate::export::apply_aspect(clip, t.fit_mode, src_w, src_h, canvas_w, canvas_h)
+}
+
+/// Source video `(w, h)` for a clip's source path, from the media pool. `(0, 0)`
+/// when the source is absent or has no video stream. `regenerate`, crop, and
+/// aspect all need pixel dimensions; this is the path→dims lookup used at the
+/// regenerate call sites once the document flips (`avio::Clip.source` is a path,
+/// not an index).
+pub fn source_dims(pool: &[ImportedClip], source: &std::path::Path) -> (u32, u32) {
+    pool.iter()
+        .find(|c| c.path == source)
+        .and_then(|c| c.info.primary_video().map(|v| (v.width(), v.height())))
+        .unwrap_or((0, 0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::export::{ExportClip, clips_to_avio};
+
+    fn loaded_export_clip() -> ExportClip {
+        ExportClip {
+            path: PathBuf::from("clip.mp4"),
+            start_on_track: Duration::from_secs(3),
+            in_point: None,
+            out_point: None,
+            transition: Some(avio::XfadeTransition::Fade),
+            transition_duration: Duration::from_millis(500),
+            source_duration: Duration::from_secs(10),
+            fps: 30.0,
+            has_audio: true,
+            gain_db: -6.0,
+            fade_in: Duration::from_millis(250),
+            fade_out: Duration::from_millis(250),
+            brightness: 0.1,
+            contrast: 1.2,
+            saturation: 0.9,
+            speed: 2.0,
+            reverse: true,
+            freeze: Some(Freeze {
+                at_secs: 1.0,
+                hold_secs: 2.0,
+            }),
+            opacity: 0.5,
+            blend_mode: avio::BlendMode::Multiply,
+            position_x: 100.0,
+            position_y: 50.0,
+            scale_pct: 80.0,
+            proxy_path: None,
+            lut_path: Some(PathBuf::from("look.cube")),
+            wb_temperature: 5000,
+            wb_tint: 0.1,
+            hue_degrees: 30.0,
+            gamma_r: 1.1,
+            gamma_g: 1.0,
+            gamma_b: 0.9,
+            vignette: 40.0,
+            vignette_x: 50.0,
+            vignette_y: 50.0,
+            width: 1280,
+            height: 720,
+            curves: ToneCurves {
+                master: vec![(0.0, 0.0), (0.5, 0.6), (1.0, 1.0)],
+                ..Default::default()
+            },
+            wheels: ColorWheels {
+                lift: crate::state::ColorWheel {
+                    x: 0.1,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            video_effects: VideoEffects {
+                blur: 3.0,
+                glow: 0.4,
+                ..Default::default()
+            },
+            transform: Transform {
+                crop_left: 5.0,
+                crop_right: 5.0,
+                rotation: 10.0,
+                flip_h: true,
+                ..Default::default()
+            },
+            overlay: crate::state::Overlay {
+                path: Some(PathBuf::from("logo.png")),
+                ..Default::default()
+            },
+            subtitle: crate::state::Subtitle {
+                path: Some(PathBuf::from("subs.srt")),
+                ..Default::default()
+            },
+            keying: crate::state::Keying {
+                enabled: true,
+                spill: 0.3,
+                ..Default::default()
+            },
+            mask: crate::state::Mask {
+                shape: crate::state::MaskShape::Rectangle,
+                feather: 4,
+                ..Default::default()
+            },
+            animation: {
+                use crate::state::KeyEasing::Linear;
+                let mut opacity = crate::state::KeyTrack::default();
+                opacity.insert(0.0, 0.0, Linear);
+                opacity.insert(1.0, 1.0, Linear);
+                let mut scale = crate::state::KeyTrack::default();
+                scale.insert(0.0, 100.0, Linear);
+                scale.insert(2.0, 150.0, Linear);
+                ClipAnimation {
+                    opacity,
+                    scale,
+                    ..Default::default()
+                }
+            },
+        }
+    }
+
+    fn neutral_export_clip() -> ExportClip {
+        let mut c = loaded_export_clip();
+        // Reset every creative field to neutral.
+        c.transition = None;
+        c.gain_db = 0.0;
+        c.fade_in = Duration::ZERO;
+        c.fade_out = Duration::ZERO;
+        c.brightness = 0.0;
+        c.contrast = 1.0;
+        c.saturation = 1.0;
+        c.speed = 1.0;
+        c.reverse = false;
+        c.freeze = None;
+        c.opacity = 1.0;
+        c.blend_mode = avio::BlendMode::Normal;
+        c.position_x = 0.0;
+        c.position_y = 0.0;
+        c.scale_pct = 100.0;
+        c.lut_path = None;
+        c.wb_temperature = WB_NEUTRAL_TEMP;
+        c.wb_tint = 0.0;
+        c.hue_degrees = 0.0;
+        c.gamma_r = 1.0;
+        c.gamma_g = 1.0;
+        c.gamma_b = 1.0;
+        c.vignette = 0.0;
+        c.curves = ToneCurves::default();
+        c.wheels = ColorWheels::default();
+        c.video_effects = VideoEffects::default();
+        c.transform = Transform::default();
+        c.overlay = Overlay::default();
+        c.subtitle = Subtitle::default();
+        c.keying = Keying::default();
+        c.mask = Mask::default();
+        c.animation = ClipAnimation::default();
+        c
+    }
+
+    /// Builds the `avio::Clip` `clips_to_avio` produces (structural fields set the
+    /// same way regenerate's caller would), then asserts `regenerate` reproduces
+    /// the identical effect chain + native creative fields.
+    fn assert_regenerate_matches(ec: ExportClip, canvas: Option<(u32, u32)>) {
+        let params = ClipParams::from_export_clip(&ec);
+        let src = (ec.width, ec.height);
+        let path = ec.path.clone();
+        let start = ec.start_on_track;
+
+        let want = clips_to_avio(vec![ec], canvas).remove(0);
+        let base = avio::Clip::new(&path).offset(start);
+        let got = regenerate(base, &params, src, canvas, true);
+
+        assert_eq!(
+            format!("{:?}", want.video_effects),
+            format!("{:?}", got.video_effects),
+            "video_effects chain differs"
+        );
+        assert_eq!(
+            format!("{:?}", want.audio_effects),
+            format!("{:?}", got.audio_effects),
+            "audio_effects chain differs"
+        );
+        assert_eq!(want.blend_mode, got.blend_mode);
+        assert!((want.opacity - got.opacity).abs() < f32::EPSILON);
+        assert!((want.speed - got.speed).abs() < f64::EPSILON);
+        assert!((want.volume_db - got.volume_db).abs() < f64::EPSILON);
+        assert_eq!(want.fade_in, got.fade_in);
+        assert_eq!(want.fade_out, got.fade_out);
+        assert_eq!(want.transition, got.transition);
+        assert!((want.brightness - got.brightness).abs() < f32::EPSILON);
+        assert!((want.contrast - got.contrast).abs() < f32::EPSILON);
+        assert!((want.saturation - got.saturation).abs() < f32::EPSILON);
+        assert!((want.x - got.x).abs() < f64::EPSILON);
+        assert!((want.y - got.y).abs() < f64::EPSILON);
+        assert_eq!(want.opacity_track.is_some(), got.opacity_track.is_some());
+        assert_eq!(want.volume_track.is_some(), got.volume_track.is_some());
+    }
+
+    #[test]
+    fn regenerate_matches_clips_to_avio_loaded_with_canvas() {
+        assert_regenerate_matches(loaded_export_clip(), Some((1920, 1080)));
+    }
+
+    #[test]
+    fn regenerate_matches_clips_to_avio_loaded_no_canvas() {
+        assert_regenerate_matches(loaded_export_clip(), None);
+    }
+
+    #[test]
+    fn regenerate_matches_clips_to_avio_neutral() {
+        assert_regenerate_matches(neutral_export_clip(), None);
+    }
+
+    #[test]
+    fn regenerate_gates_reverse_to_export_only() {
+        let ec = loaded_export_clip();
+        let params = ClipParams::from_export_clip(&ec);
+        let src = (ec.width, ec.height);
+        let base = avio::Clip::new(&ec.path).offset(ec.start_on_track);
+        let preview = regenerate(base, &params, src, None, false);
+        // No AReverse in the audio chain for the preview (reverse is export-only).
+        assert!(
+            !format!("{:?}", preview.audio_effects).contains("AReverse"),
+            "reverse must not leak into the preview chain"
+        );
+    }
+
+    #[test]
+    fn clip_params_round_trips_through_metadata() {
+        let ec = loaded_export_clip();
+        let params = ClipParams::from_export_clip(&ec);
+        let meta = params.to_metadata();
+        let back = ClipParams::from_metadata(&meta).expect("params present in metadata");
+        assert!(
+            params == back,
+            "ClipParams did not round-trip through metadata"
+        );
+    }
+}

--- a/src/clip_effects.rs
+++ b/src/clip_effects.rs
@@ -162,6 +162,50 @@ impl ClipParams {
         }
     }
 
+    /// Builds params from a [`TrackClipData`](crate::player::TrackClipData)
+    /// preview snapshot. `reverse` is `false` — reverse is export-only and the
+    /// preview projection passes `is_export = false` to [`regenerate`], which
+    /// gates it out regardless.
+    pub fn from_track_clip_data(c: &crate::player::TrackClipData) -> Self {
+        Self {
+            speed: c.speed,
+            gain_db: c.gain_db,
+            fade_in_secs: c.fade_in.as_secs_f64(),
+            fade_out_secs: c.fade_out.as_secs_f64(),
+            transition: c.transition.map(|t| t.as_str().to_string()),
+            transition_duration_secs: c.transition_duration.as_secs_f64(),
+            opacity: c.opacity,
+            blend_mode: crate::project::blend_mode_to_str(c.blend_mode).to_string(),
+            position_x: c.position_x,
+            position_y: c.position_y,
+            scale_pct: c.scale_pct,
+            reverse: false,
+            freeze: c.freeze,
+            lut_path: c.lut_path.clone(),
+            brightness: c.brightness,
+            contrast: c.contrast,
+            saturation: c.saturation,
+            wb_temperature: c.wb_temperature,
+            wb_tint: c.wb_tint,
+            hue_degrees: c.hue_degrees,
+            gamma_r: c.gamma_r,
+            gamma_g: c.gamma_g,
+            gamma_b: c.gamma_b,
+            vignette: c.vignette,
+            vignette_x: c.vignette_x,
+            vignette_y: c.vignette_y,
+            curves: c.curves.clone(),
+            wheels: c.wheels,
+            video_effects: c.video_effects,
+            transform: c.transform,
+            overlay: c.overlay.clone(),
+            subtitle: c.subtitle.clone(),
+            keying: c.keying,
+            mask: c.mask.clone(),
+            animation: c.animation.clone(),
+        }
+    }
+
     /// Serializes to `{PARAMS_KEY: <json>}`. The caller merges this into the
     /// clip's existing metadata (preserving [`DEMO_ID_KEY`]).
     pub fn to_metadata(&self) -> HashMap<String, String> {

--- a/src/edit_history.rs
+++ b/src/edit_history.rs
@@ -1,0 +1,311 @@
+//! `EditHistory` — a host-owned Do/Undo/Redo history over the demo's editing
+//! document (`avio::Timeline`).
+//!
+//! Phase 2 of migrating the demo onto avio 0.16's edit model. avio ships an
+//! `Editor`, but it is not usable by a host with in-place rich edits + drag
+//! gestures: it exposes only `current(&self)` and `apply(&Command)`, keeps
+//! `history`/`cursor` private, pushes one undo step per command, and offers no
+//! amend-in-place, no coalescing, and no way to seat an externally-rebuilt
+//! `Timeline` (catalogued as gap **B6**). The public **pure**
+//! `avio::apply(&Timeline, &Command)` IS usable, so this owns the history over it
+//! and adds the two missing pieces: [`amend`](EditHistory::amend) (replace the
+//! current version without a new step — for non-undoable rich edits) and gesture
+//! coalescing ([`begin_gesture`](EditHistory::begin_gesture) /
+//! [`commit_gesture`](EditHistory::commit_gesture)).
+//!
+//! `avio::Timeline` is opaque (clips are exposed only as `&[Vec<Clip>]`, fields
+//! are private), so every edit yields a **new** `Timeline`: structural edits via
+//! `avio::apply`, rich edits by rebuilding and handing the result to `amend`.
+//!
+//! Unwired in Phase 2 (`#![allow(dead_code)]`); validated by unit tests.
+#![allow(dead_code)]
+
+use avio::{Command, EditError, Timeline};
+
+/// Maximum retained undo versions (matches the demo's previous 50-entry cap).
+const MAX_HISTORY: usize = 50;
+
+/// A linear snapshot history of [`Timeline`] versions with a cursor.
+///
+/// The version at `cursor` is current. Structural edits push a new version;
+/// [`amend`](Self::amend) replaces the current one in place; a gesture coalesces
+/// several live amends into a single undo step.
+pub struct EditHistory {
+    history: Vec<Timeline>,
+    cursor: usize,
+    /// Pre-gesture snapshot; `Some` while a coalescing gesture is open.
+    gesture_pre: Option<Timeline>,
+}
+
+impl EditHistory {
+    /// Starts a history at `initial` (not undoable).
+    pub fn new(initial: Timeline) -> Self {
+        Self {
+            history: vec![initial],
+            cursor: 0,
+            gesture_pre: None,
+        }
+    }
+
+    /// The current document version.
+    pub fn current(&self) -> &Timeline {
+        &self.history[self.cursor]
+    }
+
+    /// Pushes `next` as a new undo step: discards the redo tail and caps history.
+    fn record(&mut self, next: Timeline) {
+        self.history.truncate(self.cursor + 1);
+        self.history.push(next);
+        self.cursor += 1;
+        if self.history.len() > MAX_HISTORY {
+            self.history.remove(0);
+            self.cursor -= 1;
+        }
+    }
+
+    /// Applies one structural `command` via `avio::apply` as a single undo step.
+    ///
+    /// # Errors
+    /// Returns the [`EditError`] from `avio::apply` when the command is invalid;
+    /// the history is left unchanged.
+    pub fn apply(&mut self, command: &Command) -> Result<&Timeline, EditError> {
+        let next = avio::apply(&self.history[self.cursor], command)?;
+        self.record(next);
+        Ok(&self.history[self.cursor])
+    }
+
+    /// Applies several commands as **one** undo step (for host-composed ops avio
+    /// has no single command for — split, ripple, cross-track move). Empty input
+    /// is a no-op. Aborts atomically: on the first error nothing is recorded.
+    ///
+    /// # Errors
+    /// Returns the [`EditError`] from the first failing command.
+    pub fn apply_batch(&mut self, commands: &[Command]) -> Result<&Timeline, EditError> {
+        if commands.is_empty() {
+            return Ok(&self.history[self.cursor]);
+        }
+        let mut next = self.history[self.cursor].clone();
+        for command in commands {
+            next = avio::apply(&next, command)?;
+        }
+        self.record(next);
+        Ok(&self.history[self.cursor])
+    }
+
+    /// Replaces the current version with `next` **without** adding an undo step,
+    /// discarding the redo tail. Used for rich, non-undoable edits (colour,
+    /// effects, keyframes — rebuilt into a new `Timeline`) and for live drag
+    /// feedback. Undoing after an amend returns to the previous committed version;
+    /// a later [`apply`](Self::apply) builds on the amended state, so amended rich
+    /// edits are preserved across a subsequent structural undo.
+    pub fn amend(&mut self, next: Timeline) {
+        self.history.truncate(self.cursor + 1);
+        self.history[self.cursor] = next;
+    }
+
+    /// Opens a coalescing gesture: snapshots the current version so a run of live
+    /// [`amend`](Self::amend)s can be committed as a single undo step. Idempotent
+    /// while a gesture is already open.
+    pub fn begin_gesture(&mut self) {
+        if self.gesture_pre.is_none() {
+            self.gesture_pre = Some(self.history[self.cursor].clone());
+        }
+    }
+
+    /// Commits an open gesture: the amended current version becomes one undo step
+    /// over the pre-gesture snapshot. No-op if no gesture is open. (The caller
+    /// should only commit when the gesture actually changed the document.)
+    pub fn commit_gesture(&mut self) {
+        if let Some(pre) = self.gesture_pre.take() {
+            let post = self.history[self.cursor].clone();
+            self.history[self.cursor] = pre;
+            self.record(post);
+        }
+    }
+
+    /// Cancels an open gesture, restoring the pre-gesture version. No-op if none.
+    pub fn cancel_gesture(&mut self) {
+        if let Some(pre) = self.gesture_pre.take() {
+            self.history.truncate(self.cursor + 1);
+            self.history[self.cursor] = pre;
+        }
+    }
+
+    /// Moves back one version, or `None` at the start of history.
+    pub fn undo(&mut self) -> Option<&Timeline> {
+        if self.cursor == 0 {
+            return None;
+        }
+        self.cursor -= 1;
+        Some(&self.history[self.cursor])
+    }
+
+    /// Moves forward one version, or `None` at the end of history.
+    pub fn redo(&mut self) -> Option<&Timeline> {
+        if self.cursor + 1 >= self.history.len() {
+            return None;
+        }
+        self.cursor += 1;
+        Some(&self.history[self.cursor])
+    }
+
+    pub fn can_undo(&self) -> bool {
+        self.cursor > 0
+    }
+
+    pub fn can_redo(&self) -> bool {
+        self.cursor + 1 < self.history.len()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    fn timeline(fps: f64) -> Timeline {
+        Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(fps)
+            .video_track(vec![avio::Clip::new("a.mp4")])
+            .build()
+            .expect("timeline builds with explicit canvas + fps")
+    }
+
+    fn set_fps(fps: f64) -> Command {
+        Command::SetFrameRate { fps }
+    }
+
+    fn fps(h: &EditHistory) -> f64 {
+        h.current().frame_rate()
+    }
+
+    #[test]
+    fn new_has_no_undo_or_redo() {
+        let h = EditHistory::new(timeline(30.0));
+        assert!(!h.can_undo());
+        assert!(!h.can_redo());
+        assert_eq!(fps(&h), 30.0);
+    }
+
+    #[test]
+    fn apply_advances_and_enables_undo() {
+        let mut h = EditHistory::new(timeline(30.0));
+        h.apply(&set_fps(24.0)).expect("valid");
+        assert_eq!(fps(&h), 24.0);
+        assert!(h.can_undo());
+        assert!(!h.can_redo());
+    }
+
+    #[test]
+    fn undo_then_redo() {
+        let mut h = EditHistory::new(timeline(30.0));
+        h.apply(&set_fps(24.0)).expect("valid");
+        assert_eq!(h.undo().map(Timeline::frame_rate), Some(30.0));
+        assert!(h.can_redo());
+        assert_eq!(h.redo().map(Timeline::frame_rate), Some(24.0));
+    }
+
+    #[test]
+    fn apply_after_undo_truncates_redo() {
+        let mut h = EditHistory::new(timeline(30.0));
+        h.apply(&set_fps(24.0)).expect("valid");
+        h.apply(&set_fps(48.0)).expect("valid");
+        h.undo(); // back to 24.0; 48.0 is now the redo tail
+        h.apply(&set_fps(60.0)).expect("valid"); // discards the 48.0 redo
+        assert!(!h.can_redo());
+        assert_eq!(fps(&h), 60.0);
+    }
+
+    #[test]
+    fn apply_batch_is_one_undo_step() {
+        let mut h = EditHistory::new(timeline(30.0));
+        h.apply_batch(&[
+            set_fps(24.0),
+            Command::SetCanvas {
+                width: 1280,
+                height: 720,
+            },
+        ])
+        .expect("valid");
+        assert_eq!(fps(&h), 24.0);
+        assert_eq!(h.current().explicit_canvas(), Some((1280, 720)));
+        // Undo reverts BOTH in one step.
+        h.undo();
+        assert_eq!(fps(&h), 30.0);
+        assert_eq!(h.current().explicit_canvas(), Some((1920, 1080)));
+        assert!(!h.can_undo());
+    }
+
+    #[test]
+    fn apply_batch_empty_is_noop() {
+        let mut h = EditHistory::new(timeline(30.0));
+        h.apply_batch(&[]).expect("valid");
+        assert!(!h.can_undo());
+    }
+
+    #[test]
+    fn apply_batch_aborts_atomically_on_error() {
+        let mut h = EditHistory::new(timeline(30.0));
+        let err = h.apply_batch(&[set_fps(24.0), set_fps(0.0)]); // 0 fps is invalid
+        assert!(err.is_err());
+        // Nothing recorded; still at the initial version.
+        assert_eq!(fps(&h), 30.0);
+        assert!(!h.can_undo());
+    }
+
+    #[test]
+    fn amend_replaces_without_a_new_step() {
+        let mut h = EditHistory::new(timeline(30.0));
+        h.apply(&set_fps(24.0)).expect("valid"); // one step: [30, 24]
+        h.amend(timeline(48.0)); // replace current 24 → 48, no new step
+        assert_eq!(fps(&h), 48.0);
+        assert!(h.can_undo());
+        assert!(!h.can_redo());
+        // Undo goes to the version BEFORE the amended one.
+        assert_eq!(h.undo().map(Timeline::frame_rate), Some(30.0));
+    }
+
+    #[test]
+    fn amend_truncates_redo() {
+        let mut h = EditHistory::new(timeline(30.0));
+        h.apply(&set_fps(24.0)).expect("valid");
+        h.apply(&set_fps(48.0)).expect("valid");
+        h.undo(); // current 24, redo tail = 48
+        h.amend(timeline(60.0));
+        assert!(!h.can_redo());
+        assert_eq!(fps(&h), 60.0);
+    }
+
+    #[test]
+    fn history_is_capped_and_keeps_newest() {
+        let mut h = EditHistory::new(timeline(1.0));
+        for i in 2..=(MAX_HISTORY + 5) {
+            h.apply(&set_fps(i as f64)).expect("valid");
+        }
+        assert!(h.can_undo());
+        assert_eq!(fps(&h), (MAX_HISTORY + 5) as f64);
+    }
+
+    #[test]
+    fn gesture_coalesces_amends_into_one_step() {
+        let mut h = EditHistory::new(timeline(30.0));
+        h.begin_gesture();
+        h.amend(timeline(24.0)); // live
+        h.amend(timeline(48.0)); // live
+        h.commit_gesture(); // one step: 30 -> 48
+        assert_eq!(fps(&h), 48.0);
+        assert_eq!(h.undo().map(Timeline::frame_rate), Some(30.0));
+        assert!(!h.can_undo());
+    }
+
+    #[test]
+    fn gesture_cancel_restores_pre() {
+        let mut h = EditHistory::new(timeline(30.0));
+        h.begin_gesture();
+        h.amend(timeline(24.0));
+        h.cancel_gesture();
+        assert_eq!(fps(&h), 30.0);
+        assert!(!h.can_undo());
+    }
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -871,7 +871,7 @@ pub fn apply_freeze(clip: avio::Clip, freeze: Option<crate::state::Freeze>) -> a
     }
 }
 
-fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio::Clip> {
+pub(crate) fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio::Clip> {
     clips
         .into_iter()
         .map(|c| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod analysis;
 mod clip_effects;
+mod edit_history;
 mod export;
 mod gif;
 mod player;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod analysis;
+mod clip_effects;
 mod export;
 mod gif;
 mod player;

--- a/src/player.rs
+++ b/src/player.rs
@@ -435,97 +435,17 @@ pub fn spawn_timeline_player(
     let (handle_tx, handle_rx) = mpsc::sync_channel::<PlayerHandle>(1);
 
     let thread = std::thread::spawn(move || {
+        // One shared projection: build the clip's structural fields, then let
+        // `clip_effects::regenerate` bake the identical effect chain + native
+        // creative fields the export path builds (golden-tested against
+        // `clips_to_avio`). `is_export = false` gates out the export-only reverse
+        // so the preview plays forward. #143.
         let make_clip = |tc: TrackClipData| -> avio::Clip {
-            let mut c = avio::Clip::new(&tc.path).offset(tc.start_on_track);
-            c.in_point = tc.in_point;
-            c.out_point = tc.out_point;
-            #[allow(clippy::float_cmp)]
-            if tc.speed != 1.0 {
-                c = c.with_speed(tc.speed as f64);
-            }
-            // A volume envelope (animation.volume) overrides the static gain.
-            if tc.gain_db != 0.0 && !tc.animation.volume.is_active() {
-                c = c.volume(tc.gain_db as f64);
-            }
-            if tc.fade_in > Duration::ZERO {
-                c = c.with_fade_in(tc.fade_in);
-            }
-            if tc.fade_out > Duration::ZERO {
-                c = c.with_fade_out(tc.fade_out);
-            }
-            if let Some(kind) = tc.transition {
-                c = c.with_transition(kind, tc.transition_duration);
-            }
-            // Freeze frame — applied in preview too so the clip length matches export.
-            // (Reverse is export-only; the preview plays forward.) #143.
-            c = crate::export::apply_freeze(c, tc.freeze);
-            // Chroma key first — key original colours before transform/grade,
-            // producing alpha the composer reveals through. Matches export.
-            c = crate::export::apply_keying(c, &tc.keying);
-            // Geometric transform (crop → flip → rotate) applied before the grade,
-            // matching export so the monitor reflects the rendered geometry.
-            c = crate::export::apply_transform(c, &tc.transform, tc.width, tc.height);
-            // Full colour grade (Eq → WB → Hue → Gamma → ThreeWayCC → Curves → LUT → Vignette), shared with export.
-            // The preview player applies these via avio's RealtimeComposer, so the
-            // monitor matches the rendered output without any host-side re-grading.
-            c = crate::export::apply_color_grade(
-                c,
-                tc.brightness,
-                tc.contrast,
-                tc.saturation,
-                tc.wb_temperature,
-                tc.wb_tint,
-                tc.hue_degrees,
-                tc.gamma_r,
-                tc.gamma_g,
-                tc.gamma_b,
-                &tc.wheels,
-                &tc.curves,
-                tc.lut_path.as_deref(),
-                tc.vignette,
-                tc.vignette_x,
-                tc.vignette_y,
-                tc.width,
-                tc.height,
-            );
-            // Stackable video effects, on top of the grade (matches export).
-            c = crate::export::apply_video_effects(c, &tc.video_effects);
-            // Re-frame into the project canvas (fit/fill) — final video step, matches
-            // export. No-op when no aspect preset is active.
-            if let Some((cw, ch)) = canvas {
-                c = crate::export::apply_aspect(
-                    c,
-                    tc.transform.fit_mode,
-                    tc.width,
-                    tc.height,
-                    cw,
-                    ch,
-                );
-            }
-            // Image overlay (watermark / logo) — matches export.
-            c = crate::export::apply_overlay(c, &tc.overlay);
-            // Burned-in subtitle — on top of the overlay, matches export.
-            c = crate::export::apply_subtitle(c, &tc.subtitle);
-            // Region-composite mask — shapes the final alpha, matches export.
-            c = crate::export::apply_mask(c, &tc.mask, tc.width, tc.height);
-            // Per-clip static transform + keyframe animation (opacity, position, scale)
-            // — matches export so the monitor reflects the rendered output.
-            c = crate::export::apply_animation(
-                c,
-                &tc.animation,
-                tc.start_on_track,
-                (tc.position_x, tc.position_y),
-                tc.scale_pct,
-                (tc.width, tc.height),
-            );
-            #[allow(clippy::float_cmp)]
-            if tc.opacity != 1.0 {
-                c = c.with_opacity(tc.opacity);
-            }
-            if tc.blend_mode != avio::BlendMode::Normal {
-                c = c.with_blend_mode(tc.blend_mode);
-            }
-            c
+            let mut base = avio::Clip::new(&tc.path).offset(tc.start_on_track);
+            base.in_point = tc.in_point;
+            base.out_point = tc.out_point;
+            let params = crate::clip_effects::ClipParams::from_track_clip_data(&tc);
+            crate::clip_effects::regenerate(base, &params, (tc.width, tc.height), canvas, false)
         };
 
         let avio_video_tracks: Vec<Vec<avio::Clip>> = video_tracks

--- a/src/project.rs
+++ b/src/project.rs
@@ -143,7 +143,7 @@ pub struct ProjectExportFilters {
 
 // ── Enum conversion helpers ───────────────────────────────────────────────────
 
-fn blend_mode_to_str(m: avio::BlendMode) -> &'static str {
+pub(crate) fn blend_mode_to_str(m: avio::BlendMode) -> &'static str {
     match m {
         avio::BlendMode::Normal => "Normal",
         avio::BlendMode::Multiply => "Multiply",
@@ -161,7 +161,7 @@ fn blend_mode_to_str(m: avio::BlendMode) -> &'static str {
     }
 }
 
-fn blend_mode_from_str(s: &str) -> avio::BlendMode {
+pub(crate) fn blend_mode_from_str(s: &str) -> avio::BlendMode {
     match s {
         "Multiply" => avio::BlendMode::Multiply,
         "Screen" => avio::BlendMode::Screen,
@@ -178,7 +178,7 @@ fn blend_mode_from_str(s: &str) -> avio::BlendMode {
     }
 }
 
-fn xfade_from_str(s: &str) -> Option<avio::XfadeTransition> {
+pub(crate) fn xfade_from_str(s: &str) -> Option<avio::XfadeTransition> {
     match s {
         "dissolve" => Some(avio::XfadeTransition::Dissolve),
         "fade" => Some(avio::XfadeTransition::Fade),


### PR DESCRIPTION
## Summary

Groundwork for migrating the demo's editing onto avio 0.16's edit model (`avio::Timeline` / `Clip` / `apply` as the single editing document). Three phases, all **unwired or behavior-identical** — the app still runs on the existing `TimelineClip` / `EditCommand` path, so nothing user-visible changes yet. This lands and de-risks the foundational pieces before the Phase-4 "flip".

## Changes

- **Phase 1 — `src/clip_effects.rs`** (new, unwired): `ClipParams` — a serde bundle of the ~35 rich per-clip authoring params — with `to_metadata` / `from_metadata` (one JSON blob under `demo.params`), and `regenerate()`, which rebuilds a clip's `video_effects` chain + native creative fields from the params by reusing the existing `export.rs` `apply_*` builders in `clips_to_avio`'s exact order. Golden-tested to reproduce `clips_to_avio`'s output exactly (loaded / neutral, ± canvas), plus reverse export-gating and metadata round-trip.
- **Phase 2 — `src/edit_history.rs`** (new, unwired): `EditHistory` — a host Do/Undo/Redo over the public pure `avio::apply`. avio's `Editor` is not usable by a host (no amend-in-place, no gesture coalescing, private history), so this owns the history and adds `apply` / `apply_batch` / `amend` / gesture coalescing / undo / redo with a 50-entry cap. Unit-tested.
- **Phase 3 — `src/player.rs`**: the timeline preview projection now delegates to `clip_effects::regenerate` (`is_export = false`), deleting ~90 lines of `make_clip` that duplicated the export projection. Behavior-identical (the golden test proves `regenerate` == `clips_to_avio`).

Supporting: `clips_to_avio`, `blend_mode_to_str` / `blend_mode_from_str`, and `xfade_from_str` made `pub(crate)`; `mod clip_effects;` / `mod edit_history;` declared.

## Related Issues

No linked issue — migration groundwork. The avio-side feature list surfaced by this work is tracked separately (`docs/issue81.md`). Follow-up: Phase 4 (the document flip) is the next PR.

## Test Plan

- [x] `cargo test` passes (58 passed)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes