### PR TITLE
refactor: Phase 4 flip groundwork (occupancy helper + preview projection)

### DIFF
--- a/src/clip_effects.rs
+++ b/src/clip_effects.rs
@@ -162,11 +162,9 @@ impl ClipParams {
         }
     }
 
-    /// Builds params from a [`TrackClipData`](crate::player::TrackClipData)
-    /// preview snapshot. `reverse` is `false` — reverse is export-only and the
-    /// preview projection passes `is_export = false` to [`regenerate`], which
-    /// gates it out regardless.
-    pub fn from_track_clip_data(c: &crate::player::TrackClipData) -> Self {
+    /// Builds params from a [`TimelineClip`](crate::state::TimelineClip) — the
+    /// demo's live authoring model — for projection into the avio document.
+    pub fn from_timeline_clip(c: &crate::state::TimelineClip) -> Self {
         Self {
             speed: c.speed,
             gain_db: c.gain_db,
@@ -179,7 +177,7 @@ impl ClipParams {
             position_x: c.position_x,
             position_y: c.position_y,
             scale_pct: c.scale_pct,
-            reverse: false,
+            reverse: c.reverse,
             freeze: c.freeze,
             lut_path: c.lut_path.clone(),
             brightness: c.brightness,

--- a/src/player.rs
+++ b/src/player.rs
@@ -5,79 +5,84 @@ use std::time::{Duration, Instant};
 
 use avio::{PlayerHandle, RgbaFrame};
 
-// ── TrackClipData ─────────────────────────────────────────────────────────────
+use crate::state;
 
-/// Minimal clip description for `spawn_timeline_player`.
-pub struct TrackClipData {
-    pub path: PathBuf,
-    pub start_on_track: Duration,
-    pub in_point: Option<Duration>,
-    pub out_point: Option<Duration>,
-    pub transition: Option<avio::XfadeTransition>,
-    pub transition_duration: Duration,
-    /// Per-clip audio gain in dB (`0.0` = unity). Forwarded to `Clip::volume_db`.
-    pub gain_db: f32,
-    /// Audio fade-in duration (`Duration::ZERO` = no fade).
-    pub fade_in: Duration,
-    /// Audio fade-out duration (`Duration::ZERO` = no fade).
-    pub fade_out: Duration,
-    /// Per-clip brightness. `0.0` = no change.
-    pub brightness: f32,
-    /// Per-clip contrast. `1.0` = no change.
-    pub contrast: f32,
-    /// Per-clip saturation. `1.0` = no change.
-    pub saturation: f32,
-    /// White-balance colour temperature (Kelvin). `WB_NEUTRAL_TEMP` + tint 0 = off.
-    pub wb_temperature: u32,
-    /// White-balance tint (added to the green multiplier).
-    pub wb_tint: f32,
-    /// Hue rotation in degrees (`0.0` = off).
-    pub hue_degrees: f32,
-    /// Per-channel gamma (`1.0` = off).
-    pub gamma_r: f32,
-    pub gamma_g: f32,
-    pub gamma_b: f32,
-    /// Optional 3D LUT (.cube) path.
-    pub lut_path: Option<PathBuf>,
-    /// Per-clip playback speed multiplier. `1.0` = normal speed.
-    pub speed: f32,
-    /// Freeze-frame spec, applied in preview + export so clip lengths match. #143.
-    pub freeze: Option<crate::state::Freeze>,
-    /// Per-clip opacity (`1.0` = fully opaque). Forwarded to `Clip::with_opacity`.
-    pub opacity: f32,
-    /// Per-clip blend mode. Forwarded to `Clip::with_blend_mode`.
-    pub blend_mode: avio::BlendMode,
-    /// Static overlay position (canvas px) for a PiP (V2+) clip. `Clip::with_position`.
-    pub position_x: f32,
-    pub position_y: f32,
-    /// Static uniform scale (% of source) for a PiP (V2+) clip. `FilterStep::ScaleAnimated`.
-    pub scale_pct: f32,
-    /// Vignette strength percentage (`0.0` = off) and normalized centre X/Y (%).
-    pub vignette: f32,
-    pub vignette_x: f32,
-    pub vignette_y: f32,
-    /// Source video dimensions — used to convert the normalized vignette centre
-    /// to pixel `x0`/`y0`. `0` when the source has no video stream.
-    pub width: u32,
-    pub height: u32,
-    /// Per-clip tone curves (Luma + R/G/B).
-    pub curves: crate::state::ToneCurves,
-    /// Per-clip 3-way colour corrector (lift / gamma / gain).
-    pub wheels: crate::state::ColorWheels,
-    /// Per-clip stackable video effects.
-    pub video_effects: crate::state::VideoEffects,
-    /// Per-clip geometric transform (crop / rotate / flip).
-    pub transform: crate::state::Transform,
-    /// Per-clip image overlay (watermark / logo).
-    pub overlay: crate::state::Overlay,
-    /// Per-clip burned-in subtitle (SRT / ASS).
-    pub subtitle: crate::state::Subtitle,
-    /// Per-clip chroma key (green/blue screen).
-    pub keying: crate::state::Keying,
-    /// Per-clip region-composite mask.
-    pub mask: crate::state::Mask,
-    /// Per-clip keyframe animation (opacity now; more properties in later phases).
-    pub animation: crate::state::ClipAnimation,
+// ── build_preview_timeline ────────────────────────────────────────────────────
+
+/// Projects the demo's live document (video/audio tracks + media pool) into the
+/// `avio::Timeline` the realtime preview plays.
+///
+/// Mute/solo is applied host-side (inactive tracks contribute no clips);
+/// `aspect_canvas` reframes each clip (fit/fill) and `is_export = false` gates out
+/// the export-only reverse (the preview plays forward). The per-clip effect chain
+/// is built by [`clip_effects::regenerate`](crate::clip_effects::regenerate) — the
+/// same projection the export path uses. Returns `None` when there is no V1 clip
+/// to play (nothing to preview).
+pub fn build_preview_timeline(
+    tracks: &[state::Track],
+    pool: &[state::ImportedClip],
+    aspect_canvas: Option<(u32, u32)>,
+) -> Option<avio::Timeline> {
+    use crate::ui::timeline::track_is_active;
+
+    let audio_start = tracks
+        .iter()
+        .take_while(|t| t.kind == state::TrackKind::Video)
+        .count();
+
+    let project = |tc: &state::TimelineClip| -> Option<avio::Clip> {
+        let src = pool.get(tc.source_index)?;
+        let dims = src
+            .info
+            .primary_video()
+            .map(|v| (v.width(), v.height()))
+            .unwrap_or((0, 0));
+        let mut base = avio::Clip::new(&src.path).offset(tc.start_on_track);
+        base.in_point = tc.in_point;
+        base.out_point = tc.out_point;
+        let params = crate::clip_effects::ClipParams::from_timeline_clip(tc);
+        Some(crate::clip_effects::regenerate(
+            base,
+            &params,
+            dims,
+            aspect_canvas,
+            false,
+        ))
+    };
+
+    let video_tracks: Vec<Vec<avio::Clip>> = (0..audio_start)
+        .map(|ti| {
+            if track_is_active(tracks, ti) {
+                tracks[ti].clips.iter().filter_map(&project).collect()
+            } else {
+                Vec::new()
+            }
+        })
+        .collect();
+    let a1: Vec<avio::Clip> = if audio_start < tracks.len() && track_is_active(tracks, audio_start)
+    {
+        tracks[audio_start]
+            .clips
+            .iter()
+            .filter_map(&project)
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    if video_tracks.first().is_none_or(Vec::is_empty) {
+        return None;
+    }
+    let mut builder = avio::Timeline::builder().video_track(video_tracks[0].clone());
+    for vn in video_tracks.iter().skip(1) {
+        if !vn.is_empty() {
+            builder = builder.video_track(vn.clone());
+        }
+    }
+    if !a1.is_empty() {
+        builder = builder.audio_track(a1);
+    }
+    builder.build().ok()
 }
 
 // ── EguiFrameSink ─────────────────────────────────────────────────────────────
@@ -424,63 +429,15 @@ pub fn spawn_player(
 /// Returns `(thread, handle_rx)`. `handle_rx` delivers the `PlayerHandle` once
 /// the runner is ready (one-shot).
 pub fn spawn_timeline_player(
-    video_tracks: Vec<Vec<TrackClipData>>,
-    a1: Vec<TrackClipData>,
+    timeline: avio::Timeline,
     frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
     ctx: egui::Context,
     start_pos: Duration,
     cpal_rate: Arc<AtomicU64>,
-    canvas: Option<(u32, u32)>,
 ) -> (std::thread::JoinHandle<()>, mpsc::Receiver<PlayerHandle>) {
     let (handle_tx, handle_rx) = mpsc::sync_channel::<PlayerHandle>(1);
 
     let thread = std::thread::spawn(move || {
-        // One shared projection: build the clip's structural fields, then let
-        // `clip_effects::regenerate` bake the identical effect chain + native
-        // creative fields the export path builds (golden-tested against
-        // `clips_to_avio`). `is_export = false` gates out the export-only reverse
-        // so the preview plays forward. #143.
-        let make_clip = |tc: TrackClipData| -> avio::Clip {
-            let mut base = avio::Clip::new(&tc.path).offset(tc.start_on_track);
-            base.in_point = tc.in_point;
-            base.out_point = tc.out_point;
-            let params = crate::clip_effects::ClipParams::from_track_clip_data(&tc);
-            crate::clip_effects::regenerate(base, &params, (tc.width, tc.height), canvas, false)
-        };
-
-        let avio_video_tracks: Vec<Vec<avio::Clip>> = video_tracks
-            .into_iter()
-            .map(|track| track.into_iter().map(make_clip).collect())
-            .collect();
-        let a1_clips: Vec<avio::Clip> = a1.into_iter().map(make_clip).collect();
-
-        let Some(v1_clips) = avio_video_tracks.first() else {
-            log::warn!("spawn_timeline_player: no V1 clips");
-            return;
-        };
-        if v1_clips.is_empty() {
-            log::warn!("spawn_timeline_player: no V1 clips");
-            return;
-        }
-
-        let mut builder = avio::Timeline::builder().video_track(avio_video_tracks[0].clone());
-        for vn in avio_video_tracks.into_iter().skip(1) {
-            if !vn.is_empty() {
-                builder = builder.video_track(vn);
-            }
-        }
-        if !a1_clips.is_empty() {
-            builder = builder.audio_track(a1_clips);
-        }
-
-        let timeline = match builder.build() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Timeline::builder().build() failed: {e}");
-                return;
-            }
-        };
-
         let (mut runner, handle) = match avio::TimelinePlayer::open(&timeline) {
             Ok(pair) => pair,
             Err(e) => {

--- a/src/state.rs
+++ b/src/state.rs
@@ -7,6 +7,22 @@ use std::time::Duration;
 /// white-balance filter is treated as "off" and skipped, so output is unchanged.
 pub const WB_NEUTRAL_TEMP: u32 = 6500;
 
+/// Effective source duration a clip consumes, from its in/out trim points and the
+/// full source length. The shared basis for the timeline occupancy math (clip
+/// width = `eff_source_dur / speed [+ freeze hold]`).
+pub fn eff_source_dur(
+    source_dur: Duration,
+    in_point: Option<Duration>,
+    out_point: Option<Duration>,
+) -> Duration {
+    match (in_point, out_point) {
+        (Some(i), Some(o)) if o > i => o - i,
+        (None, Some(o)) => o,
+        (Some(i), None) => source_dur.saturating_sub(i),
+        _ => source_dur,
+    }
+}
+
 /// Which edge of a clip is being trimmed.
 #[derive(Clone, Debug, PartialEq)]
 pub enum TrimEdge {

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -18,7 +18,7 @@ fn blend_mode_label(mode: avio::BlendMode) -> &'static str {
 ///
 /// Solo takes priority: if any track is soloed, only soloed tracks are active.
 /// Otherwise, a track is active unless it is muted.
-fn track_is_active(tracks: &[state::Track], idx: usize) -> bool {
+pub(crate) fn track_is_active(tracks: &[state::Track], idx: usize) -> bool {
     let any_solo = tracks.iter().any(|t| t.soloed);
     if any_solo {
         tracks[idx].soloed
@@ -1760,90 +1760,26 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             state.stop_timeline_player();
             state.monitor_clip_index = None;
 
-            let clips = &state.clips;
-            let make_tcd = |tc: &state::TimelineClip| player::TrackClipData {
-                path: clips[tc.source_index].path.clone(),
-                start_on_track: tc.start_on_track,
-                in_point: tc.in_point,
-                out_point: tc.out_point,
-                transition: tc.transition,
-                transition_duration: tc.transition_duration,
-                gain_db: tc.gain_db,
-                fade_in: tc.fade_in,
-                fade_out: tc.fade_out,
-                brightness: tc.brightness,
-                contrast: tc.contrast,
-                saturation: tc.saturation,
-                wb_temperature: tc.wb_temperature,
-                wb_tint: tc.wb_tint,
-                hue_degrees: tc.hue_degrees,
-                gamma_r: tc.gamma_r,
-                gamma_g: tc.gamma_g,
-                gamma_b: tc.gamma_b,
-                lut_path: tc.lut_path.clone(),
-                speed: tc.speed,
-                freeze: tc.freeze,
-                opacity: tc.opacity,
-                blend_mode: tc.blend_mode,
-                position_x: tc.position_x,
-                position_y: tc.position_y,
-                scale_pct: tc.scale_pct,
-                vignette: tc.vignette,
-                vignette_x: tc.vignette_x,
-                vignette_y: tc.vignette_y,
-                width: clips[tc.source_index]
-                    .info
-                    .primary_video()
-                    .map(|v| v.width())
-                    .unwrap_or(0),
-                height: clips[tc.source_index]
-                    .info
-                    .primary_video()
-                    .map(|v| v.height())
-                    .unwrap_or(0),
-                curves: tc.curves.clone(),
-                wheels: tc.wheels,
-                video_effects: tc.video_effects,
-                transform: tc.transform,
-                overlay: tc.overlay.clone(),
-                subtitle: tc.subtitle.clone(),
-                keying: tc.keying,
-                mask: tc.mask.clone(),
-                animation: tc.animation.clone(),
-            };
-            let tracks = &state.timeline.tracks;
-            let audio_start = state.timeline.audio_track_start();
-            let video_tracks: Vec<Vec<_>> = (0..audio_start)
-                .map(|ti| {
-                    if track_is_active(tracks, ti) {
-                        tracks[ti].clips.iter().map(make_tcd).collect()
-                    } else {
-                        vec![]
-                    }
-                })
-                .collect();
-            let a1: Vec<_> = if audio_start < tracks.len() && track_is_active(tracks, audio_start) {
-                tracks[audio_start].clips.iter().map(make_tcd).collect()
-            } else {
-                vec![]
-            };
-
             let start = Duration::from_secs_f64(state.timeline_playhead_secs.max(0.0));
             // Timeline always plays at 1×; reset cpal_rate to 1.0
             state
                 .cpal_rate
                 .store(1.0f64.to_bits(), std::sync::atomic::Ordering::Relaxed);
-            let (thread, handle_rx) = player::spawn_timeline_player(
-                video_tracks,
-                a1,
-                Arc::clone(&state.frame_handle),
-                ui.ctx().clone(),
-                start,
-                Arc::clone(&state.cpal_rate),
+            if let Some(timeline) = player::build_preview_timeline(
+                &state.timeline.tracks,
+                &state.clips,
                 state.project_aspect.dims(),
-            );
-            state.timeline_player_thread = Some(thread);
-            state.timeline_pending_handle_rx = Some(handle_rx);
+            ) {
+                let (thread, handle_rx) = player::spawn_timeline_player(
+                    timeline,
+                    Arc::clone(&state.frame_handle),
+                    ui.ctx().clone(),
+                    start,
+                    Arc::clone(&state.cpal_rate),
+                );
+                state.timeline_player_thread = Some(thread);
+                state.timeline_pending_handle_rx = Some(handle_rx);
+            }
             state.timeline_is_paused = false;
         }
 
@@ -1859,88 +1795,24 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         let resume_pos =
                             Duration::from_secs_f64(state.timeline_playhead_secs.max(0.0));
                         state.stop_timeline_player();
-                        let clips = &state.clips;
-                        let make_tcd = |tc: &state::TimelineClip| player::TrackClipData {
-                            path: clips[tc.source_index].path.clone(),
-                            start_on_track: tc.start_on_track,
-                            in_point: tc.in_point,
-                            out_point: tc.out_point,
-                            transition: tc.transition,
-                            transition_duration: tc.transition_duration,
-                            gain_db: tc.gain_db,
-                            fade_in: tc.fade_in,
-                            fade_out: tc.fade_out,
-                            brightness: tc.brightness,
-                            contrast: tc.contrast,
-                            saturation: tc.saturation,
-                            wb_temperature: tc.wb_temperature,
-                            wb_tint: tc.wb_tint,
-                            hue_degrees: tc.hue_degrees,
-                            gamma_r: tc.gamma_r,
-                            gamma_g: tc.gamma_g,
-                            gamma_b: tc.gamma_b,
-                            lut_path: tc.lut_path.clone(),
-                            speed: tc.speed,
-                            freeze: tc.freeze,
-                            opacity: tc.opacity,
-                            blend_mode: tc.blend_mode,
-                            position_x: tc.position_x,
-                            position_y: tc.position_y,
-                            scale_pct: tc.scale_pct,
-                            vignette: tc.vignette,
-                            vignette_x: tc.vignette_x,
-                            vignette_y: tc.vignette_y,
-                            width: clips[tc.source_index]
-                                .info
-                                .primary_video()
-                                .map(|v| v.width())
-                                .unwrap_or(0),
-                            height: clips[tc.source_index]
-                                .info
-                                .primary_video()
-                                .map(|v| v.height())
-                                .unwrap_or(0),
-                            curves: tc.curves.clone(),
-                            wheels: tc.wheels,
-                            video_effects: tc.video_effects,
-                            transform: tc.transform,
-                            overlay: tc.overlay.clone(),
-                            subtitle: tc.subtitle.clone(),
-                            keying: tc.keying,
-                            mask: tc.mask.clone(),
-                            animation: tc.animation.clone(),
-                        };
-                        let tracks = &state.timeline.tracks;
-                        let audio_start = state.timeline.audio_track_start();
-                        let video_tracks: Vec<Vec<_>> = (0..audio_start)
-                            .map(|ti| {
-                                if track_is_active(tracks, ti) {
-                                    tracks[ti].clips.iter().map(make_tcd).collect()
-                                } else {
-                                    vec![]
-                                }
-                            })
-                            .collect();
-                        let a1: Vec<_> =
-                            if audio_start < tracks.len() && track_is_active(tracks, audio_start) {
-                                tracks[audio_start].clips.iter().map(make_tcd).collect()
-                            } else {
-                                vec![]
-                            };
                         state
                             .cpal_rate
                             .store(1.0f64.to_bits(), std::sync::atomic::Ordering::Relaxed);
-                        let (thread, handle_rx) = player::spawn_timeline_player(
-                            video_tracks,
-                            a1,
-                            Arc::clone(&state.frame_handle),
-                            ui.ctx().clone(),
-                            resume_pos,
-                            Arc::clone(&state.cpal_rate),
+                        if let Some(timeline) = player::build_preview_timeline(
+                            &state.timeline.tracks,
+                            &state.clips,
                             state.project_aspect.dims(),
-                        );
-                        state.timeline_player_thread = Some(thread);
-                        state.timeline_pending_handle_rx = Some(handle_rx);
+                        ) {
+                            let (thread, handle_rx) = player::spawn_timeline_player(
+                                timeline,
+                                Arc::clone(&state.frame_handle),
+                                ui.ctx().clone(),
+                                resume_pos,
+                                Arc::clone(&state.cpal_rate),
+                            );
+                            state.timeline_player_thread = Some(thread);
+                            state.timeline_pending_handle_rx = Some(handle_rx);
+                        }
                         state.clips_moved_while_paused = false;
                         state.timeline_is_paused = false;
                     } else {
@@ -3770,87 +3642,22 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             let resume_pos = Duration::from_secs_f64(state.timeline_playhead_secs.max(0.0));
             let aspect_canvas = state.project_aspect.dims();
             state.stop_timeline_player();
-            let clips = &state.clips;
-            let make_tcd = |tc: &state::TimelineClip| player::TrackClipData {
-                path: clips[tc.source_index].path.clone(),
-                start_on_track: tc.start_on_track,
-                in_point: tc.in_point,
-                out_point: tc.out_point,
-                transition: tc.transition,
-                transition_duration: tc.transition_duration,
-                gain_db: tc.gain_db,
-                fade_in: tc.fade_in,
-                fade_out: tc.fade_out,
-                brightness: tc.brightness,
-                contrast: tc.contrast,
-                saturation: tc.saturation,
-                wb_temperature: tc.wb_temperature,
-                wb_tint: tc.wb_tint,
-                hue_degrees: tc.hue_degrees,
-                gamma_r: tc.gamma_r,
-                gamma_g: tc.gamma_g,
-                gamma_b: tc.gamma_b,
-                lut_path: tc.lut_path.clone(),
-                speed: tc.speed,
-                freeze: tc.freeze,
-                opacity: tc.opacity,
-                blend_mode: tc.blend_mode,
-                position_x: tc.position_x,
-                position_y: tc.position_y,
-                scale_pct: tc.scale_pct,
-                vignette: tc.vignette,
-                vignette_x: tc.vignette_x,
-                vignette_y: tc.vignette_y,
-                width: clips[tc.source_index]
-                    .info
-                    .primary_video()
-                    .map(|v| v.width())
-                    .unwrap_or(0),
-                height: clips[tc.source_index]
-                    .info
-                    .primary_video()
-                    .map(|v| v.height())
-                    .unwrap_or(0),
-                curves: tc.curves.clone(),
-                wheels: tc.wheels,
-                video_effects: tc.video_effects,
-                transform: tc.transform,
-                overlay: tc.overlay.clone(),
-                subtitle: tc.subtitle.clone(),
-                keying: tc.keying,
-                mask: tc.mask.clone(),
-                animation: tc.animation.clone(),
-            };
-            let tracks = &state.timeline.tracks;
-            let audio_start = state.timeline.audio_track_start();
-            let video_tracks: Vec<Vec<_>> = (0..audio_start)
-                .map(|ti| {
-                    if track_is_active(tracks, ti) {
-                        tracks[ti].clips.iter().map(make_tcd).collect()
-                    } else {
-                        vec![]
-                    }
-                })
-                .collect();
-            let a1: Vec<_> = if audio_start < tracks.len() && track_is_active(tracks, audio_start) {
-                tracks[audio_start].clips.iter().map(make_tcd).collect()
-            } else {
-                vec![]
-            };
             state
                 .cpal_rate
                 .store(1.0f64.to_bits(), std::sync::atomic::Ordering::Relaxed);
-            let (thread, handle_rx) = player::spawn_timeline_player(
-                video_tracks,
-                a1,
-                Arc::clone(&state.frame_handle),
-                ctx,
-                resume_pos,
-                Arc::clone(&state.cpal_rate),
-                aspect_canvas,
-            );
-            state.timeline_player_thread = Some(thread);
-            state.timeline_pending_handle_rx = Some(handle_rx);
+            if let Some(timeline) =
+                player::build_preview_timeline(&state.timeline.tracks, &state.clips, aspect_canvas)
+            {
+                let (thread, handle_rx) = player::spawn_timeline_player(
+                    timeline,
+                    Arc::clone(&state.frame_handle),
+                    ctx.clone(),
+                    resume_pos,
+                    Arc::clone(&state.cpal_rate),
+                );
+                state.timeline_player_thread = Some(thread);
+                state.timeline_pending_handle_rx = Some(handle_rx);
+            }
         } else {
             // Paused or stopped: mark as dirty so Resume rebuilds with correct state.
             state.clips_moved_while_paused = true;

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -63,12 +63,8 @@ fn snap_trim_edge(
             let Some(src) = clips_info.get(clip.source_index) else {
                 continue;
             };
-            let src_dur = match (clip.in_point, clip.out_point) {
-                (Some(i), Some(o)) if o > i => (o - i).as_secs_f32(),
-                (None, Some(o)) => o.as_secs_f32(),
-                (Some(i), None) => src.info.duration().saturating_sub(i).as_secs_f32(),
-                _ => src.info.duration().as_secs_f32(),
-            };
+            let src_dur = state::eff_source_dur(src.info.duration(), clip.in_point, clip.out_point)
+                .as_secs_f32();
             let dur = src_dur / clip.speed + freeze_extra_secs(clip.freeze);
             let c_left = lane_left + clip.start_on_track.as_secs_f32() * pps;
             let c_right = c_left + dur * pps;
@@ -111,12 +107,9 @@ fn snap_clip_start(
                 .filter(|(ci, _)| !(dst_track == src_track && *ci == src_clip))
                 .filter_map(|(_, c)| {
                     clips_info.get(c.source_index).map(|s| {
-                        let src_dur = match (c.in_point, c.out_point) {
-                            (Some(i), Some(o)) if o > i => (o - i).as_secs_f32(),
-                            (None, Some(o)) => o.as_secs_f32(),
-                            (Some(i), None) => s.info.duration().saturating_sub(i).as_secs_f32(),
-                            _ => s.info.duration().as_secs_f32(),
-                        };
+                        let src_dur =
+                            state::eff_source_dur(s.info.duration(), c.in_point, c.out_point)
+                                .as_secs_f32();
                         let dur = src_dur / c.speed + freeze_extra_secs(c.freeze);
                         let cs = c.start_on_track.as_secs_f32();
                         (cs, cs + dur)
@@ -2007,12 +2000,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
         .flat_map(|t| t.clips.iter())
         .filter_map(|tc| {
             state.clips.get(tc.source_index).map(|c| {
-                let src_dur = match (tc.in_point, tc.out_point) {
-                    (Some(i), Some(o)) if o > i => o - i,
-                    (None, Some(o)) => o,
-                    (Some(i), None) => c.info.duration().saturating_sub(i),
-                    _ => c.info.duration(),
-                };
+                let src_dur = state::eff_source_dur(c.info.duration(), tc.in_point, tc.out_point);
                 tc.start_on_track.as_secs_f32()
                     + src_dur.as_secs_f32() / tc.speed
                     + freeze_extra_secs(tc.freeze)
@@ -2476,12 +2464,11 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     for (clip_i, tc) in track.clips.iter().enumerate() {
                         if let Some(source) = state.clips.get(tc.source_index) {
                             let eff_in = tc.in_point.unwrap_or(Duration::ZERO);
-                            let eff_dur = match (tc.in_point, tc.out_point) {
-                                (Some(i), Some(o)) if o > i => o - i,
-                                (None, Some(o)) => o,
-                                (Some(i), None) => source.info.duration().saturating_sub(i),
-                                _ => source.info.duration(),
-                            };
+                            let eff_dur = state::eff_source_dur(
+                                source.info.duration(),
+                                tc.in_point,
+                                tc.out_point,
+                            );
                             let fps = source.info.frame_rate().unwrap_or(30.0) as f32;
                             let one_frame_sec = (1.0 / fps).max(0.001_f32);
                             let orig_x = lane_rect.left() + tc.start_on_track.as_secs_f32() * pps;
@@ -3381,14 +3368,12 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         .and_then(|t| t.clips.get(drag.src_clip))
                         .and_then(|tc| {
                             state.clips.get(tc.source_index).map(|s| {
-                                let src_dur = match (tc.in_point, tc.out_point) {
-                                    (Some(i), Some(o)) if o > i => (o - i).as_secs_f32(),
-                                    (None, Some(o)) => o.as_secs_f32(),
-                                    (Some(i), None) => {
-                                        s.info.duration().saturating_sub(i).as_secs_f32()
-                                    }
-                                    _ => s.info.duration().as_secs_f32(),
-                                };
+                                let src_dur = state::eff_source_dur(
+                                    s.info.duration(),
+                                    tc.in_point,
+                                    tc.out_point,
+                                )
+                                .as_secs_f32();
                                 src_dur / tc.speed + freeze_extra_secs(tc.freeze)
                             })
                         })
@@ -3662,12 +3647,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             .get(clip.source_index)
             .map(|s| s.info.duration())
             .unwrap_or(Duration::ZERO);
-        let eff_src_dur = match (clip.in_point, clip.out_point) {
-            (Some(i), Some(o)) if o > i => o - i,
-            (None, Some(o)) => o,
-            (Some(i), None) => src_dur.saturating_sub(i),
-            _ => src_dur,
-        };
+        let eff_src_dur = state::eff_source_dur(src_dur, clip.in_point, clip.out_point);
         let eff_dur = eff_src_dur.div_f32(clip.speed);
         let paste_start = clip.start_on_track + eff_dur;
         let mut new_clip = clip;
@@ -3688,12 +3668,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             .get(clip.source_index)
             .map(|s| s.info.duration())
             .unwrap_or(Duration::ZERO);
-        let eff_src_dur = match (clip.in_point, clip.out_point) {
-            (Some(i), Some(o)) if o > i => o - i,
-            (None, Some(o)) => o,
-            (Some(i), None) => src_dur.saturating_sub(i),
-            _ => src_dur,
-        };
+        let eff_src_dur = state::eff_source_dur(src_dur, clip.in_point, clip.out_point);
         let eff_dur = eff_src_dur.div_f32(clip.speed);
         let dup_start = clip.start_on_track + eff_dur;
         let mut new_clip = clip;
@@ -3987,12 +3962,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     .get(deleted.source_index)
                     .map(|s| s.info.duration())
                     .unwrap_or(Duration::ZERO);
-                let eff_src_dur = match (deleted.in_point, deleted.out_point) {
-                    (Some(i), Some(o)) if o > i => o - i,
-                    (None, Some(o)) => o,
-                    (Some(i), None) => src_dur.saturating_sub(i),
-                    _ => src_dur,
-                };
+                let eff_src_dur =
+                    state::eff_source_dur(src_dur, deleted.in_point, deleted.out_point);
                 let eff_dur = eff_src_dur.div_f32(deleted.speed);
                 let gap_start = deleted.start_on_track + eff_dur;
                 for clip in &mut state.timeline.tracks[ti].clips {
@@ -4038,12 +4009,8 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             for (ci, tc) in track.clips.iter().enumerate() {
                 if let Some(source) = state.clips.get(tc.source_index) {
                     let eff_in = tc.in_point.unwrap_or(Duration::ZERO);
-                    let eff_dur = match (tc.in_point, tc.out_point) {
-                        (Some(i), Some(o)) if o > i => o - i,
-                        (None, Some(o)) => o,
-                        (Some(i), None) => source.info.duration().saturating_sub(i),
-                        _ => source.info.duration(),
-                    };
+                    let eff_dur =
+                        state::eff_source_dur(source.info.duration(), tc.in_point, tc.out_point);
                     let clip_end = tc.start_on_track + eff_dur;
                     if playhead > tc.start_on_track && playhead < clip_end {
                         let offset = playhead.saturating_sub(tc.start_on_track);


### PR DESCRIPTION
## Summary

Behavior-identical groundwork for "the flip" (making `avio::Timeline` the single editing document — migration Phase 4). Two prep steps that shrink and de-risk the upcoming flip; nothing user-visible changes. Builds on the merged edit-model scaffolding (`clip_effects` / `edit_history`, PR #183).

## Changes

- **P0 — `eff_source_dur` occupancy helper (`state.rs`).** Extracted the effective-source-duration match (`in/out` trim → source length), which was duplicated verbatim at 9 timeline sites, into one shared function; the per-site `/speed` and `+ freeze` steps are left in place (they legitimately differ), so the change is exactly behavior-preserving. `clip_browser.rs` and `main.rs` use subtly different formulas and were intentionally left untouched.
- **4a-i — one preview projection (`player.rs`).** Added `build_preview_timeline(tracks, pool, aspect)` and changed `spawn_timeline_player` to take a prebuilt `avio::Timeline` (built on the main thread, moved into the worker). This replaces the three byte-identical ~85-line `make_tcd` closures (Play / Resume / mute-solo-restart) and deletes `player::TrackClipData`. The preview now flows through `clip_effects::regenerate` — the same projection the export path is golden-tested against — so the composited output is unchanged (reverse stays export-only via `is_export = false`). Confirms `avio::Timeline: Send`.
- Net **+164 / −419** lines (a ~255-line reduction); `track_is_active` made `pub(crate)`; `ClipParams::from_track_clip_data` replaced by `from_timeline_clip`.

## Related Issues

No linked issue — migration groundwork. Follow-up: Phase 4b (the document flip, including export projection consolidation) is the next PR.

## Test Plan

- [x] `cargo test` passes (58 passed)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes