### PR TITLE
refactor: route preview and export through avio::Editor timeline (P1)

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -117,22 +117,33 @@ pub struct ExportSnapshot {
 
 /// A single entry in the export queue.
 ///
-/// The snapshot is stored as `Option` and consumed (via `.take()`) when
-/// rendering begins so it cannot be accidentally re-used.
+/// The timeline/config are stored as `Option` and consumed (via `.take()`)
+/// when rendering begins so they cannot be accidentally re-used.
 pub struct QueueJob {
     pub output_path: PathBuf,
-    /// Snapshot captured at "Add to Queue" time. `None` after rendering starts.
-    pub snapshot: Option<ExportSnapshot>,
+    /// Timeline assembled (on the main thread) at "Add to Queue" time.
+    /// `None` after rendering starts.
+    pub timeline: Option<avio::Timeline>,
+    /// Encoder config captured at "Add to Queue" time. `None` after rendering starts.
+    pub config: Option<avio::EncoderConfig>,
+    pub total_frames_estimate: Option<u64>,
     pub status: Arc<Mutex<crate::state::QueueJobStatus>>,
     pub progress: Arc<AtomicU32>,
     pub cancel: Arc<AtomicBool>,
 }
 
 impl QueueJob {
-    pub fn new(snapshot: ExportSnapshot, output_path: PathBuf) -> Self {
+    pub fn new(
+        timeline: avio::Timeline,
+        config: avio::EncoderConfig,
+        total_frames_estimate: Option<u64>,
+        output_path: PathBuf,
+    ) -> Self {
         Self {
             output_path,
-            snapshot: Some(snapshot),
+            timeline: Some(timeline),
+            config: Some(config),
+            total_frames_estimate,
             status: Arc::new(Mutex::new(crate::state::QueueJobStatus::Pending)),
             progress: Arc::new(AtomicU32::new(0)),
             cancel: Arc::new(AtomicBool::new(false)),
@@ -142,14 +153,19 @@ impl QueueJob {
 
 /// Starts rendering `job` in the background.
 ///
-/// Takes the snapshot from `job.snapshot`, sets status to `Running`, and
+/// Takes the timeline/config from `job`, sets status to `Running`, and
 /// spawns a `tokio::task::spawn_blocking` call. Returns `false` if the job is
-/// not `Pending` or the snapshot was already consumed.
+/// not `Pending` or the timeline/config were already consumed.
 pub fn spawn_queue_job(job: &mut QueueJob) -> bool {
-    let snapshot = match job.snapshot.take() {
-        Some(s) => s,
+    let timeline = match job.timeline.take() {
+        Some(t) => t,
         None => return false,
     };
+    let config = match job.config.take() {
+        Some(c) => c,
+        None => return false,
+    };
+    let total_frames_estimate = job.total_frames_estimate;
     {
         let mut s = job.status.lock().unwrap_or_else(|e| e.into_inner());
         if *s != crate::state::QueueJobStatus::Pending {
@@ -163,7 +179,14 @@ pub fn spawn_queue_job(job: &mut QueueJob) -> bool {
     let output = job.output_path.clone();
 
     tokio::task::spawn_blocking(move || {
-        let result = build_and_render(snapshot, &output, &progress, &cancel);
+        let result = build_and_render(
+            timeline,
+            config,
+            total_frames_estimate,
+            &output,
+            &progress,
+            &cancel,
+        );
         let mut guard = status.lock().unwrap_or_else(|e| e.into_inner());
         *guard = match result {
             Ok(()) => crate::state::QueueJobStatus::Done(output),
@@ -1256,13 +1279,13 @@ pub(crate) fn assemble_export_timeline(
 }
 
 fn build_and_render(
-    snapshot: ExportSnapshot,
+    timeline: avio::Timeline,
+    config: avio::EncoderConfig,
+    total_frames_estimate: Option<u64>,
     output: &std::path::Path,
     progress: &Arc<AtomicU32>,
     cancel: &Arc<AtomicBool>,
 ) -> Result<(), String> {
-    let config = snapshot.encoder_config.to_encoder_config();
-    let (timeline, total_frames_estimate) = assemble_export_timeline(snapshot)?;
     let progress_ref = Arc::clone(progress);
     let cancel_ref = Arc::clone(cancel);
     let render_result = timeline.render_with_progress(output, config, move |p| {

--- a/src/export.rs
+++ b/src/export.rs
@@ -1091,12 +1091,12 @@ fn build_lavfi_overlay_filter(
     Some(chain)
 }
 
-fn build_and_render(
+/// Composes the export `avio::Timeline` from a snapshot on the calling thread.
+/// Applies the export-range filter, computes the total-frames estimate, and runs
+/// the same track/canvas/audio/lavfi builder as before. Pure: no I/O, no probe.
+pub(crate) fn assemble_export_timeline(
     mut snapshot: ExportSnapshot,
-    output: &std::path::Path,
-    progress: &Arc<AtomicU32>,
-    cancel: &Arc<AtomicBool>,
-) -> Result<(), String> {
+) -> Result<(avio::Timeline, Option<u64>), String> {
     // Apply export range filter. Mutates the snapshot so all downstream logic
     // (total_frames_estimate, timeline_dur_secs, lavfi overlay) uses trimmed clips.
     if let (Some(range_in), Some(range_out)) = (snapshot.export_in, snapshot.export_out)
@@ -1219,8 +1219,6 @@ fn build_and_render(
         return Err("V1 track has no clips to export".to_string());
     }
 
-    let config = snapshot.encoder_config.to_encoder_config();
-
     let mut builder = avio::Timeline::builder().video_track(avio_video[0].clone());
 
     if let Some((cw, ch)) = builder_canvas {
@@ -1254,6 +1252,17 @@ fn build_and_render(
 
     let timeline = builder.build().map_err(|e| e.to_string())?;
 
+    Ok((timeline, total_frames_estimate))
+}
+
+fn build_and_render(
+    snapshot: ExportSnapshot,
+    output: &std::path::Path,
+    progress: &Arc<AtomicU32>,
+    cancel: &Arc<AtomicBool>,
+) -> Result<(), String> {
+    let config = snapshot.encoder_config.to_encoder_config();
+    let (timeline, total_frames_estimate) = assemble_export_timeline(snapshot)?;
     let progress_ref = Arc::clone(progress);
     let cancel_ref = Arc::clone(cancel);
     let render_result = timeline.render_with_progress(output, config, move |p| {

--- a/src/player.rs
+++ b/src/player.rs
@@ -418,6 +418,127 @@ pub fn spawn_player(
     (thread, handle_rx, proxy_rx)
 }
 
+// ── assemble_preview_timeline ───────────────────────────────────────────────────
+
+/// Composes the preview `avio::Timeline` from track snapshots on the calling
+/// thread. Same per-clip mapping and builder as the playback worker used inline;
+/// returns `Err` when there is no V1 clip or the builder fails.
+pub fn assemble_preview_timeline(
+    video_tracks: Vec<Vec<TrackClipData>>,
+    a1: Vec<TrackClipData>,
+    canvas: Option<(u32, u32)>,
+) -> Result<avio::Timeline, String> {
+    let make_clip = |tc: TrackClipData| -> avio::Clip {
+        let mut c = avio::Clip::new(&tc.path).offset(tc.start_on_track);
+        c.in_point = tc.in_point;
+        c.out_point = tc.out_point;
+        #[allow(clippy::float_cmp)]
+        if tc.speed != 1.0 {
+            c = c.with_speed(tc.speed as f64);
+        }
+        // A volume envelope (animation.volume) overrides the static gain.
+        if tc.gain_db != 0.0 && !tc.animation.volume.is_active() {
+            c = c.volume(tc.gain_db as f64);
+        }
+        if tc.fade_in > Duration::ZERO {
+            c = c.with_fade_in(tc.fade_in);
+        }
+        if tc.fade_out > Duration::ZERO {
+            c = c.with_fade_out(tc.fade_out);
+        }
+        if let Some(kind) = tc.transition {
+            c = c.with_transition(kind, tc.transition_duration);
+        }
+        // Freeze frame — applied in preview too so the clip length matches export.
+        // (Reverse is export-only; the preview plays forward.) #143.
+        c = crate::export::apply_freeze(c, tc.freeze);
+        // Chroma key first — key original colours before transform/grade,
+        // producing alpha the composer reveals through. Matches export.
+        c = crate::export::apply_keying(c, &tc.keying);
+        // Geometric transform (crop → flip → rotate) applied before the grade,
+        // matching export so the monitor reflects the rendered geometry.
+        c = crate::export::apply_transform(c, &tc.transform, tc.width, tc.height);
+        // Full colour grade (Eq → WB → Hue → Gamma → ThreeWayCC → Curves → LUT → Vignette), shared with export.
+        // The preview player applies these via avio's RealtimeComposer, so the
+        // monitor matches the rendered output without any host-side re-grading.
+        c = crate::export::apply_color_grade(
+            c,
+            tc.brightness,
+            tc.contrast,
+            tc.saturation,
+            tc.wb_temperature,
+            tc.wb_tint,
+            tc.hue_degrees,
+            tc.gamma_r,
+            tc.gamma_g,
+            tc.gamma_b,
+            &tc.wheels,
+            &tc.curves,
+            tc.lut_path.as_deref(),
+            tc.vignette,
+            tc.vignette_x,
+            tc.vignette_y,
+            tc.width,
+            tc.height,
+        );
+        // Stackable video effects, on top of the grade (matches export).
+        c = crate::export::apply_video_effects(c, &tc.video_effects);
+        // Re-frame into the project canvas (fit/fill) — final video step, matches
+        // export. No-op when no aspect preset is active.
+        if let Some((cw, ch)) = canvas {
+            c = crate::export::apply_aspect(c, tc.transform.fit_mode, tc.width, tc.height, cw, ch);
+        }
+        // Image overlay (watermark / logo) — matches export.
+        c = crate::export::apply_overlay(c, &tc.overlay);
+        // Burned-in subtitle — on top of the overlay, matches export.
+        c = crate::export::apply_subtitle(c, &tc.subtitle);
+        // Region-composite mask — shapes the final alpha, matches export.
+        c = crate::export::apply_mask(c, &tc.mask, tc.width, tc.height);
+        // Per-clip static transform + keyframe animation (opacity, position, scale)
+        // — matches export so the monitor reflects the rendered output.
+        c = crate::export::apply_animation(
+            c,
+            &tc.animation,
+            tc.start_on_track,
+            (tc.position_x, tc.position_y),
+            tc.scale_pct,
+            (tc.width, tc.height),
+        );
+        #[allow(clippy::float_cmp)]
+        if tc.opacity != 1.0 {
+            c = c.with_opacity(tc.opacity);
+        }
+        if tc.blend_mode != avio::BlendMode::Normal {
+            c = c.with_blend_mode(tc.blend_mode);
+        }
+        c
+    };
+
+    let avio_video_tracks: Vec<Vec<avio::Clip>> = video_tracks
+        .into_iter()
+        .map(|track| track.into_iter().map(make_clip).collect())
+        .collect();
+    let a1_clips: Vec<avio::Clip> = a1.into_iter().map(make_clip).collect();
+
+    let Some(v1_clips) = avio_video_tracks.first() else {
+        return Err("no V1 clips".to_string());
+    };
+    if v1_clips.is_empty() {
+        return Err("no V1 clips".to_string());
+    }
+
+    let mut builder = avio::Timeline::builder().video_track(avio_video_tracks[0].clone());
+    for vn in avio_video_tracks.into_iter().skip(1) {
+        if !vn.is_empty() {
+            builder = builder.video_track(vn);
+        }
+    }
+    if !a1_clips.is_empty() {
+        builder = builder.audio_track(a1_clips);
+    }
+    builder.build().map_err(|e| e.to_string())
+}
+
 // ── spawn_timeline_player ──────────────────────────────────────────────────────
 
 /// Spawns a background thread running `TimelineRunner::run()` for multi-track playback.
@@ -436,128 +557,10 @@ pub fn spawn_timeline_player(
     let (handle_tx, handle_rx) = mpsc::sync_channel::<PlayerHandle>(1);
 
     let thread = std::thread::spawn(move || {
-        let make_clip = |tc: TrackClipData| -> avio::Clip {
-            let mut c = avio::Clip::new(&tc.path).offset(tc.start_on_track);
-            c.in_point = tc.in_point;
-            c.out_point = tc.out_point;
-            #[allow(clippy::float_cmp)]
-            if tc.speed != 1.0 {
-                c = c.with_speed(tc.speed as f64);
-            }
-            // A volume envelope (animation.volume) overrides the static gain.
-            if tc.gain_db != 0.0 && !tc.animation.volume.is_active() {
-                c = c.volume(tc.gain_db as f64);
-            }
-            if tc.fade_in > Duration::ZERO {
-                c = c.with_fade_in(tc.fade_in);
-            }
-            if tc.fade_out > Duration::ZERO {
-                c = c.with_fade_out(tc.fade_out);
-            }
-            if let Some(kind) = tc.transition {
-                c = c.with_transition(kind, tc.transition_duration);
-            }
-            // Freeze frame — applied in preview too so the clip length matches export.
-            // (Reverse is export-only; the preview plays forward.) #143.
-            c = crate::export::apply_freeze(c, tc.freeze);
-            // Chroma key first — key original colours before transform/grade,
-            // producing alpha the composer reveals through. Matches export.
-            c = crate::export::apply_keying(c, &tc.keying);
-            // Geometric transform (crop → flip → rotate) applied before the grade,
-            // matching export so the monitor reflects the rendered geometry.
-            c = crate::export::apply_transform(c, &tc.transform, tc.width, tc.height);
-            // Full colour grade (Eq → WB → Hue → Gamma → ThreeWayCC → Curves → LUT → Vignette), shared with export.
-            // The preview player applies these via avio's RealtimeComposer, so the
-            // monitor matches the rendered output without any host-side re-grading.
-            c = crate::export::apply_color_grade(
-                c,
-                tc.brightness,
-                tc.contrast,
-                tc.saturation,
-                tc.wb_temperature,
-                tc.wb_tint,
-                tc.hue_degrees,
-                tc.gamma_r,
-                tc.gamma_g,
-                tc.gamma_b,
-                &tc.wheels,
-                &tc.curves,
-                tc.lut_path.as_deref(),
-                tc.vignette,
-                tc.vignette_x,
-                tc.vignette_y,
-                tc.width,
-                tc.height,
-            );
-            // Stackable video effects, on top of the grade (matches export).
-            c = crate::export::apply_video_effects(c, &tc.video_effects);
-            // Re-frame into the project canvas (fit/fill) — final video step, matches
-            // export. No-op when no aspect preset is active.
-            if let Some((cw, ch)) = canvas {
-                c = crate::export::apply_aspect(
-                    c,
-                    tc.transform.fit_mode,
-                    tc.width,
-                    tc.height,
-                    cw,
-                    ch,
-                );
-            }
-            // Image overlay (watermark / logo) — matches export.
-            c = crate::export::apply_overlay(c, &tc.overlay);
-            // Burned-in subtitle — on top of the overlay, matches export.
-            c = crate::export::apply_subtitle(c, &tc.subtitle);
-            // Region-composite mask — shapes the final alpha, matches export.
-            c = crate::export::apply_mask(c, &tc.mask, tc.width, tc.height);
-            // Per-clip static transform + keyframe animation (opacity, position, scale)
-            // — matches export so the monitor reflects the rendered output.
-            c = crate::export::apply_animation(
-                c,
-                &tc.animation,
-                tc.start_on_track,
-                (tc.position_x, tc.position_y),
-                tc.scale_pct,
-                (tc.width, tc.height),
-            );
-            #[allow(clippy::float_cmp)]
-            if tc.opacity != 1.0 {
-                c = c.with_opacity(tc.opacity);
-            }
-            if tc.blend_mode != avio::BlendMode::Normal {
-                c = c.with_blend_mode(tc.blend_mode);
-            }
-            c
-        };
-
-        let avio_video_tracks: Vec<Vec<avio::Clip>> = video_tracks
-            .into_iter()
-            .map(|track| track.into_iter().map(make_clip).collect())
-            .collect();
-        let a1_clips: Vec<avio::Clip> = a1.into_iter().map(make_clip).collect();
-
-        let Some(v1_clips) = avio_video_tracks.first() else {
-            log::warn!("spawn_timeline_player: no V1 clips");
-            return;
-        };
-        if v1_clips.is_empty() {
-            log::warn!("spawn_timeline_player: no V1 clips");
-            return;
-        }
-
-        let mut builder = avio::Timeline::builder().video_track(avio_video_tracks[0].clone());
-        for vn in avio_video_tracks.into_iter().skip(1) {
-            if !vn.is_empty() {
-                builder = builder.video_track(vn);
-            }
-        }
-        if !a1_clips.is_empty() {
-            builder = builder.audio_track(a1_clips);
-        }
-
-        let timeline = match builder.build() {
+        let timeline = match assemble_preview_timeline(video_tracks, a1, canvas) {
             Ok(t) => t,
             Err(e) => {
-                log::warn!("Timeline::builder().build() failed: {e}");
+                log::warn!("assemble_preview_timeline: {e}");
                 return;
             }
         };

--- a/src/player.rs
+++ b/src/player.rs
@@ -546,25 +546,15 @@ pub fn assemble_preview_timeline(
 /// Returns `(thread, handle_rx)`. `handle_rx` delivers the `PlayerHandle` once
 /// the runner is ready (one-shot).
 pub fn spawn_timeline_player(
-    video_tracks: Vec<Vec<TrackClipData>>,
-    a1: Vec<TrackClipData>,
+    timeline: avio::Timeline,
     frame_handle: Arc<Mutex<Option<RgbaFrame>>>,
     ctx: egui::Context,
     start_pos: Duration,
     cpal_rate: Arc<AtomicU64>,
-    canvas: Option<(u32, u32)>,
 ) -> (std::thread::JoinHandle<()>, mpsc::Receiver<PlayerHandle>) {
     let (handle_tx, handle_rx) = mpsc::sync_channel::<PlayerHandle>(1);
 
     let thread = std::thread::spawn(move || {
-        let timeline = match assemble_preview_timeline(video_tracks, a1, canvas) {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("assemble_preview_timeline: {e}");
-                return;
-            }
-        };
-
         let (mut runner, handle) = match avio::TimelinePlayer::open(&timeline) {
             Ok(pair) => pair,
             Err(e) => {

--- a/src/state.rs
+++ b/src/state.rs
@@ -90,7 +90,6 @@ pub struct AppState {
     /// avio edit engine holding the composed timeline. In P1 it is a write-only
     /// derived mirror, reseated from the current timeline right before each
     /// preview/export (`None` until first reseat). P2+ makes it the edit truth.
-    #[allow(dead_code)]
     pub editor: Option<avio::Editor>,
     pub trim_jobs: Vec<TrimJobHandle>,
     pub gif_jobs: Vec<GifJobHandle>,
@@ -1468,7 +1467,6 @@ impl AppState {
 
     /// Replaces the editor's timeline (P1: write-only derived mirror, reseated
     /// before each preview/export).
-    #[allow(dead_code)]
     pub fn reseat_editor(&mut self, timeline: avio::Timeline) {
         self.editor = Some(avio::Editor::new(timeline));
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -87,6 +87,11 @@ pub struct AppState {
     pub sprite_tx: mpsc::SyncSender<(usize, u32, u32, Vec<u8>)>,
     pub sprite_rx: mpsc::Receiver<(usize, u32, u32, Vec<u8>)>,
     pub timeline: TimelineState,
+    /// avio edit engine holding the composed timeline. In P1 it is a write-only
+    /// derived mirror, reseated from the current timeline right before each
+    /// preview/export (`None` until first reseat). P2+ makes it the edit truth.
+    #[allow(dead_code)]
+    pub editor: Option<avio::Editor>,
     pub trim_jobs: Vec<TrimJobHandle>,
     pub gif_jobs: Vec<GifJobHandle>,
     pub proxy_jobs: Vec<ProxyJobHandle>,
@@ -199,6 +204,7 @@ impl Default for AppState {
             sprite_tx,
             sprite_rx,
             timeline: TimelineState::default(),
+            editor: None,
             trim_jobs: Vec::new(),
             gif_jobs: Vec::new(),
             proxy_jobs: Vec::new(),
@@ -1458,6 +1464,13 @@ impl AppState {
         if self.undo_stack.len() > 50 {
             self.undo_stack.remove(0);
         }
+    }
+
+    /// Replaces the editor's timeline (P1: write-only derived mirror, reseated
+    /// before each preview/export).
+    #[allow(dead_code)]
+    pub fn reseat_editor(&mut self, timeline: avio::Timeline) {
+        self.editor = Some(avio::Editor::new(timeline));
     }
 
     fn pause_timeline_if_playing(&mut self) {

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -1367,9 +1367,25 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     },
                     canvas: state.project_aspect.dims(),
                 };
-                state
-                    .export_queue
-                    .push(export::QueueJob::new(snapshot, output_path));
+                let config = snapshot.encoder_config.to_encoder_config();
+                match export::assemble_export_timeline(snapshot) {
+                    Ok((timeline, total_frames_estimate)) => {
+                        state.reseat_editor(timeline);
+                        match state.editor.as_ref() {
+                            Some(ed) => {
+                                let render_timeline = ed.current().clone();
+                                state.export_queue.push(export::QueueJob::new(
+                                    render_timeline,
+                                    config,
+                                    total_frames_estimate,
+                                    output_path,
+                                ));
+                            }
+                            None => log::warn!("editor empty after reseat"),
+                        }
+                    }
+                    Err(e) => log::warn!("export assemble: {e}"),
+                }
             }
             ui.toggle_value(&mut state.show_export_settings, "⚙")
                 .on_hover_text("Export settings");

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -1856,18 +1856,28 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             state
                 .cpal_rate
                 .store(1.0f64.to_bits(), std::sync::atomic::Ordering::Relaxed);
-            let (thread, handle_rx) = player::spawn_timeline_player(
-                video_tracks,
-                a1,
-                Arc::clone(&state.frame_handle),
-                ui.ctx().clone(),
-                start,
-                Arc::clone(&state.cpal_rate),
-                state.project_aspect.dims(),
-            );
-            state.timeline_player_thread = Some(thread);
-            state.timeline_pending_handle_rx = Some(handle_rx);
-            state.timeline_is_paused = false;
+            match player::assemble_preview_timeline(video_tracks, a1, state.project_aspect.dims()) {
+                Ok(timeline) => {
+                    state.reseat_editor(timeline);
+                    match state.editor.as_ref() {
+                        Some(ed) => {
+                            let render_timeline = ed.current().clone();
+                            let (thread, handle_rx) = player::spawn_timeline_player(
+                                render_timeline,
+                                Arc::clone(&state.frame_handle),
+                                ui.ctx().clone(),
+                                start,
+                                Arc::clone(&state.cpal_rate),
+                            );
+                            state.timeline_player_thread = Some(thread);
+                            state.timeline_pending_handle_rx = Some(handle_rx);
+                            state.timeline_is_paused = false;
+                        }
+                        None => log::warn!("editor empty after reseat"),
+                    }
+                }
+                Err(e) => log::warn!("preview assemble: {e}"),
+            }
         }
 
         if is_playing {
@@ -1953,19 +1963,33 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         state
                             .cpal_rate
                             .store(1.0f64.to_bits(), std::sync::atomic::Ordering::Relaxed);
-                        let (thread, handle_rx) = player::spawn_timeline_player(
+                        match player::assemble_preview_timeline(
                             video_tracks,
                             a1,
-                            Arc::clone(&state.frame_handle),
-                            ui.ctx().clone(),
-                            resume_pos,
-                            Arc::clone(&state.cpal_rate),
                             state.project_aspect.dims(),
-                        );
-                        state.timeline_player_thread = Some(thread);
-                        state.timeline_pending_handle_rx = Some(handle_rx);
-                        state.clips_moved_while_paused = false;
-                        state.timeline_is_paused = false;
+                        ) {
+                            Ok(timeline) => {
+                                state.reseat_editor(timeline);
+                                match state.editor.as_ref() {
+                                    Some(ed) => {
+                                        let render_timeline = ed.current().clone();
+                                        let (thread, handle_rx) = player::spawn_timeline_player(
+                                            render_timeline,
+                                            Arc::clone(&state.frame_handle),
+                                            ui.ctx().clone(),
+                                            resume_pos,
+                                            Arc::clone(&state.cpal_rate),
+                                        );
+                                        state.timeline_player_thread = Some(thread);
+                                        state.timeline_pending_handle_rx = Some(handle_rx);
+                                        state.clips_moved_while_paused = false;
+                                        state.timeline_is_paused = false;
+                                    }
+                                    None => log::warn!("editor empty after reseat"),
+                                }
+                            }
+                            Err(e) => log::warn!("preview assemble: {e}"),
+                        }
                     } else {
                         if let Some(h) = &state.timeline_player_handle {
                             h.play();
@@ -3881,17 +3905,27 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
             state
                 .cpal_rate
                 .store(1.0f64.to_bits(), std::sync::atomic::Ordering::Relaxed);
-            let (thread, handle_rx) = player::spawn_timeline_player(
-                video_tracks,
-                a1,
-                Arc::clone(&state.frame_handle),
-                ctx,
-                resume_pos,
-                Arc::clone(&state.cpal_rate),
-                aspect_canvas,
-            );
-            state.timeline_player_thread = Some(thread);
-            state.timeline_pending_handle_rx = Some(handle_rx);
+            match player::assemble_preview_timeline(video_tracks, a1, aspect_canvas) {
+                Ok(timeline) => {
+                    state.reseat_editor(timeline);
+                    match state.editor.as_ref() {
+                        Some(ed) => {
+                            let render_timeline = ed.current().clone();
+                            let (thread, handle_rx) = player::spawn_timeline_player(
+                                render_timeline,
+                                Arc::clone(&state.frame_handle),
+                                ctx,
+                                resume_pos,
+                                Arc::clone(&state.cpal_rate),
+                            );
+                            state.timeline_player_thread = Some(thread);
+                            state.timeline_pending_handle_rx = Some(handle_rx);
+                        }
+                        None => log::warn!("editor empty after reseat"),
+                    }
+                }
+                Err(e) => log::warn!("preview assemble: {e}"),
+            }
         } else {
             // Paused or stopped: mark as dirty so Resume rebuilds with correct state.
             state.clips_moved_while_paused = true;


### PR DESCRIPTION
## Summary

P1 of adopting the avio 0.17 edit model. Introduces `avio::Editor` holding the composed `avio::Timeline`, built on the main thread, so both preview and export consume `editor.current()`. This is a behavior-identical refactor — no preview or export output changes — that establishes the single seam the later phases (P2–P5) flip the edit/undo/serde model onto.

## Changes

- `assemble_export_timeline` extracted (pure, main-thread) from `build_and_render`.
- `assemble_preview_timeline` extracted (pure, main-thread) from `spawn_timeline_player`.
- `AppState.editor: Option<avio::Editor>` + `reseat_editor` added (write-only derived mirror in P1).
- Export renders `editor.current()`: the queue job now carries a prebuilt `avio::Timeline` + `EncoderConfig` + frame estimate; assembly moved off the worker thread.
- Preview plays `editor.current()`: `spawn_timeline_player` takes a prebuilt `avio::Timeline`; the three call sites reseat the editor and hand it the composed timeline.

Routing through `editor.current().clone()` is provably identical to the pre-refactor timeline (`Editor::new(t).current() == &t`). `TimelineState` / `TimelineClip` / `EditCommand` are untouched.

## Related Issues

Internal migration step (P1 of the avio 0.17 edit-model adoption); no tracking issue.

## Test Plan

- [x] `cargo test` passes (41/41)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes