### PR TITLE
feat: lossless TimelineClip <-> avio::Clip carrier (P2)

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 /// Send-safe snapshot of a single clip on any track.
-pub struct ExportClip {
+pub(crate) struct ExportClip {
     pub path: PathBuf,
     pub start_on_track: Duration,
     pub in_point: Option<Duration>,
@@ -89,6 +89,76 @@ pub struct ExportClip {
     pub mask: crate::state::Mask,
     /// Per-clip keyframe animation (opacity now; more properties in later phases).
     pub animation: crate::state::ClipAnimation,
+}
+
+/// Builds an [`ExportClip`] from a `TimelineClip` and its media-pool entry.
+///
+/// Returns `None` (logging a warning) when `tc.source_index` is out of range
+/// for `pool`, matching the original inline `make_clip` closure's behavior.
+pub(crate) fn timeline_clip_to_export_clip(
+    tc: &crate::state::TimelineClip,
+    pool: &[crate::state::ImportedClip],
+    use_proxy: bool,
+) -> Option<ExportClip> {
+    let Some(src) = pool.get(tc.source_index) else {
+        log::warn!(
+            "timeline_clip_to_export_clip: source_index {} out of range (pool len {})",
+            tc.source_index,
+            pool.len()
+        );
+        return None;
+    };
+    Some(ExportClip {
+        path: src.path.clone(),
+        start_on_track: tc.start_on_track,
+        in_point: tc.in_point,
+        out_point: tc.out_point,
+        transition: tc.transition,
+        transition_duration: tc.transition_duration,
+        source_duration: src.info.duration(),
+        fps: src.info.frame_rate().unwrap_or(30.0),
+        has_audio: src.info.primary_audio().is_some(),
+        gain_db: tc.gain_db,
+        fade_in: tc.fade_in,
+        fade_out: tc.fade_out,
+        brightness: tc.brightness,
+        contrast: tc.contrast,
+        saturation: tc.saturation,
+        speed: tc.speed,
+        reverse: tc.reverse,
+        freeze: tc.freeze,
+        opacity: tc.opacity,
+        blend_mode: tc.blend_mode,
+        position_x: tc.position_x,
+        position_y: tc.position_y,
+        scale_pct: tc.scale_pct,
+        proxy_path: if use_proxy {
+            src.proxy_path.clone()
+        } else {
+            None
+        },
+        lut_path: tc.lut_path.clone(),
+        wb_temperature: tc.wb_temperature,
+        wb_tint: tc.wb_tint,
+        hue_degrees: tc.hue_degrees,
+        gamma_r: tc.gamma_r,
+        gamma_g: tc.gamma_g,
+        gamma_b: tc.gamma_b,
+        vignette: tc.vignette,
+        vignette_x: tc.vignette_x,
+        vignette_y: tc.vignette_y,
+        width: src.info.primary_video().map(|v| v.width()).unwrap_or(0),
+        height: src.info.primary_video().map(|v| v.height()).unwrap_or(0),
+        curves: tc.curves.clone(),
+        wheels: tc.wheels,
+        video_effects: tc.video_effects,
+        transform: tc.transform,
+        overlay: tc.overlay.clone(),
+        subtitle: tc.subtitle.clone(),
+        keying: tc.keying,
+        mask: tc.mask.clone(),
+        animation: tc.animation.clone(),
+    })
 }
 
 /// Send-safe snapshot of all timeline tracks, constructed on the main thread
@@ -894,7 +964,7 @@ pub fn apply_freeze(clip: avio::Clip, freeze: Option<crate::state::Freeze>) -> a
     }
 }
 
-fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio::Clip> {
+pub(crate) fn clips_to_avio(clips: Vec<ExportClip>, canvas: Option<(u32, u32)>) -> Vec<avio::Clip> {
     clips
         .into_iter()
         .map(|c| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod proxy;
 mod sprite;
 mod state;
 mod thumbnail;
+mod timeline_bridge;
 mod trim;
 mod ui;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1276,7 +1276,7 @@ pub struct Freeze {
     pub hold_secs: f64,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TimelineClip {
     pub source_index: usize,
     pub start_on_track: Duration,
@@ -1557,5 +1557,64 @@ impl ImportedClip {
         let mins = total_secs / 60;
         let secs = total_secs % 60;
         format!("{mins}:{secs:02}.{millis:03}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeline_clip_serde_round_trips() {
+        let tc = TimelineClip {
+            source_index: 3,
+            start_on_track: Duration::from_secs(2),
+            in_point: Some(Duration::from_secs(1)),
+            out_point: Some(Duration::from_secs(5)),
+            transition: Some(avio::XfadeTransition::Dissolve),
+            transition_duration: Duration::from_millis(500),
+            gain_db: 0.0,
+            fade_in: Duration::ZERO,
+            fade_out: Duration::ZERO,
+            brightness: 0.0,
+            contrast: 1.0,
+            saturation: 1.0,
+            speed: 1.5,
+            reverse: false,
+            freeze: None,
+            opacity: 1.0,
+            blend_mode: avio::BlendMode::Multiply,
+            position_x: 0.0,
+            position_y: 0.0,
+            scale_pct: 100.0,
+            lut_path: None,
+            wb_temperature: 5000,
+            wb_tint: 0.0,
+            hue_degrees: 0.0,
+            gamma_r: 1.0,
+            gamma_g: 1.0,
+            gamma_b: 1.0,
+            vignette: 0.4,
+            vignette_x: 50.0,
+            vignette_y: 50.0,
+            curves: ToneCurves::default(),
+            wheels: ColorWheels::default(),
+            video_effects: VideoEffects::default(),
+            transform: Transform::default(),
+            overlay: Overlay::default(),
+            subtitle: Subtitle::default(),
+            keying: Keying::default(),
+            mask: Mask {
+                shape: MaskShape::Rectangle,
+                ..Mask::default()
+            },
+            animation: ClipAnimation::default(),
+        };
+        let json = serde_json::to_string(&tc).expect("serialize");
+        let back: TimelineClip = serde_json::from_str(&json).expect("deserialize");
+        // TimelineClip has no Debug impl, so assert_eq!'s failure-message
+        // formatting isn't available here; assert! still exercises the same
+        // PartialEq round-trip check.
+        assert!(tc == back);
     }
 }

--- a/src/timeline_bridge.rs
+++ b/src/timeline_bridge.rs
@@ -56,13 +56,17 @@ pub(crate) fn load_demo_clip(clip: &avio::Clip) -> Option<state::TimelineClip> {
 /// source `TimelineClip` as metadata JSON on the resulting `avio::Clip` and
 /// using avio-native `Track` mute/solo flags (so muted tracks keep their
 /// clips in the model; avio's `is_active()` excludes them from render).
+///
+/// Returns `Err` when `TimelineBuilder::build()` fails (e.g. `timeline.tracks`
+/// is empty, or a first-clip probe fails) — propagated rather than papered
+/// over with a fallback, since `build()` is genuinely fallible.
 #[allow(dead_code)]
 pub(crate) fn to_avio(
     timeline: &state::TimelineState,
     pool: &[state::ImportedClip],
     canvas: Option<(u32, u32)>,
     use_proxy: bool,
-) -> avio::Timeline {
+) -> Result<avio::Timeline, avio::TimelineError> {
     let mut builder = avio::Timeline::builder();
     if let Some((w, h)) = canvas {
         builder = builder.canvas(w, h);
@@ -91,23 +95,7 @@ pub(crate) fn to_avio(
             state::TrackKind::Audio => builder.audio_track_with(track),
         };
     }
-    // `build()` errors only when both track lists are empty (`timeline.tracks`
-    // itself was empty) or when probing a first clip's source file fails.
-    // Neither applies to the fallback below: an empty video track makes
-    // `video_tracks` non-empty (skipping the `NoInput` check) and has no clip
-    // to probe, so canvas/frame-rate resolution falls through to its default
-    // (1920x1080@30) — that `build()` call cannot fail. The retry loop is a
-    // non-panicking safety net in case that invariant ever changes upstream;
-    // it is expected to run its body exactly once.
-    builder.build().unwrap_or_else(|e| {
-        log::warn!("to_avio: build failed ({e}); returning empty timeline");
-        loop {
-            match avio::Timeline::builder().video_track(Vec::new()).build() {
-                Ok(t) => break t,
-                Err(e2) => log::error!("to_avio: fallback build failed ({e2}); retrying"),
-            }
-        }
-    })
+    builder.build()
 }
 
 #[cfg(test)]

--- a/src/timeline_bridge.rs
+++ b/src/timeline_bridge.rs
@@ -25,10 +25,14 @@ pub(crate) fn store_demo_clip(clip: &mut avio::Clip, tc: &state::TimelineClip) {
     );
 }
 
-/// Reconstructs the source `TimelineClip` from `clip.metadata`, overriding its
-/// structural fields (`start_on_track`/`in_point`/`out_point`) with the avio
-/// clip's own first-class `offset`/`in_point`/`out_point` — those are
-/// authoritative once the clip has been built into a timeline.
+/// Reconstructs the source `TimelineClip` from `clip.metadata`, overriding
+/// exactly these fields with the avio clip's own first-class fields —
+/// `start_on_track` (from `offset`), `in_point`, `out_point`, `transition`,
+/// `transition_duration`, `fade_in`, `fade_out` — since those are
+/// authoritative once the clip has been built into a timeline (e.g. `SplitClip`
+/// clears `transition`/`transition_duration`/`fade_in`/`fade_out` on the avio
+/// clip, and a stale JSON blob must not resurrect them). Every other field on
+/// the returned `TimelineClip` comes as-is from the JSON blob.
 ///
 /// Returns `None` when the metadata is missing, empty, or fails to parse
 /// (logging a warning in the parse-error case).
@@ -43,6 +47,10 @@ pub(crate) fn load_demo_clip(clip: &avio::Clip) -> Option<state::TimelineClip> {
             tc.start_on_track = clip.offset;
             tc.in_point = clip.in_point;
             tc.out_point = clip.out_point;
+            tc.transition = clip.transition;
+            tc.transition_duration = clip.transition_duration;
+            tc.fade_in = clip.fade_in;
+            tc.fade_out = clip.fade_out;
             Some(tc)
         }
         Err(e) => {
@@ -53,9 +61,18 @@ pub(crate) fn load_demo_clip(clip: &avio::Clip) -> Option<state::TimelineClip> {
 }
 
 /// Builds an `avio::Timeline` from the demo's `TimelineState`, carrying each
-/// source `TimelineClip` as metadata JSON on the resulting `avio::Clip` and
-/// using avio-native `Track` mute/solo flags (so muted tracks keep their
-/// clips in the model; avio's `is_active()` excludes them from render).
+/// source `TimelineClip` as metadata JSON on the resulting `avio::Clip`.
+///
+/// avio's native `Track::is_active()` scopes solo *per track list*
+/// (video/audio separately), but the demo's mute/solo (`track_is_active` in
+/// `ui/timeline.rs`) scopes solo *globally* across the whole flat
+/// video+audio `tracks` vec — soloing a video track also silences a
+/// non-soloed audio track. To render exactly the demo's semantics, each
+/// avio `Track`'s `enabled` flag is set to the demo's global active state
+/// (`any_solo` computed over all tracks), while `muted`/`soloed` still carry
+/// the raw demo flags unchanged (so `from_avio` round-trips them). This
+/// makes avio's own per-list `is_active()` collapse to that `enabled` value
+/// regardless of its per-list scoping — see the inline comment below.
 ///
 /// Returns `Err` when `TimelineBuilder::build()` fails (e.g. `timeline.tracks`
 /// is empty, or a first-clip probe fails) — propagated rather than papered
@@ -71,6 +88,9 @@ pub(crate) fn to_avio(
     if let Some((w, h)) = canvas {
         builder = builder.canvas(w, h);
     }
+    // Demo's global solo flag (matches ui/timeline.rs's track_is_active): solo
+    // scopes across the whole flat video+audio tracks vec, not per list.
+    let any_solo = timeline.tracks.iter().any(|t| t.soloed);
     for tr in &timeline.tracks {
         // Build avio::Clips for this track, carrying each source TimelineClip as JSON.
         let mut avio_clips: Vec<avio::Clip> = Vec::new();
@@ -85,11 +105,16 @@ pub(crate) fn to_avio(
                 avio_clips.push(c);
             }
         }
-        // Native avio Track with the demo's mute/solo — clips stay in the model,
-        // avio's is_active() excludes muted/non-soloed tracks from render.
+        // `active` mirrors the demo's global track_is_active exactly. Setting
+        // it as avio's `enabled` makes avio's per-list `is_active(any_solo_in_list)
+        // = enabled && !mute && (!any_solo_in_list || solo)` reduce to `active`
+        // in every case: when `active` is false, `enabled == false` forces it;
+        // when `active` is true, both `!mute` and the solo clause also hold.
+        let active = if any_solo { tr.soloed } else { !tr.muted };
         let track = avio::Track::new(avio_clips)
             .muted(tr.muted)
-            .soloed(tr.soloed);
+            .soloed(tr.soloed)
+            .enabled(active);
         builder = match tr.kind {
             state::TrackKind::Video => builder.video_track_with(track),
             state::TrackKind::Audio => builder.audio_track_with(track),
@@ -180,6 +205,10 @@ mod tests {
         clip.offset = Duration::from_secs(9);
         clip.in_point = Some(Duration::from_secs(1));
         clip.out_point = Some(Duration::from_secs(4));
+        clip.transition = tc.transition;
+        clip.transition_duration = tc.transition_duration;
+        clip.fade_in = tc.fade_in;
+        clip.fade_out = tc.fade_out;
         store_demo_clip(&mut clip, &tc);
         let back = load_demo_clip(&clip).expect("some");
         // Structural fields come from the avio clip, not the JSON's originals:
@@ -189,6 +218,40 @@ mod tests {
         // TimelineClip has no Debug impl, so assert_eq!'s failure-message
         // formatting isn't available here; assert! still exercises the same
         // PartialEq round-trip check.
+        assert!(back == tc);
+    }
+
+    #[test]
+    fn load_demo_clip_prefers_cleared_first_class_transition_and_fades_over_stale_json() {
+        // Simulate a split: the JSON blob still carries the pre-split
+        // transition/fades, but the avio clip's first-class fields were
+        // cleared by SplitClip — those cleared values must win.
+        let mut tc = state::TimelineClip {
+            transition: Some(avio::XfadeTransition::Dissolve),
+            transition_duration: Duration::from_millis(500),
+            fade_in: Duration::from_millis(300),
+            fade_out: Duration::from_millis(300),
+            ..neutral_clip(0, Duration::ZERO)
+        };
+        let mut clip = avio::Clip::new("x.mp4");
+        clip.transition = None;
+        clip.transition_duration = Duration::ZERO;
+        clip.fade_in = Duration::ZERO;
+        clip.fade_out = Duration::ZERO;
+        store_demo_clip(&mut clip, &tc);
+
+        let back = load_demo_clip(&clip).expect("some");
+        assert!(back.transition.is_none());
+        assert!(back.transition_duration == Duration::ZERO);
+        assert!(back.fade_in == Duration::ZERO);
+        assert!(back.fade_out == Duration::ZERO);
+
+        // sanity: not just because tc was already cleared — the JSON really
+        // did carry the non-cleared values before the override.
+        tc.transition = None;
+        tc.transition_duration = Duration::ZERO;
+        tc.fade_in = Duration::ZERO;
+        tc.fade_out = Duration::ZERO;
         assert!(back == tc);
     }
 
@@ -285,5 +348,43 @@ mod tests {
         assert!(tracks[2].kind == state::TrackKind::Audio);
         assert!(tracks[2].soloed);
         assert!(tracks[2].clips == vec![a0]);
+    }
+
+    #[test]
+    fn to_avio_maps_demo_global_solo_onto_avio_enabled() {
+        // A soloed video track and a non-soloed audio track: under the demo's
+        // GLOBAL solo semantics (track_is_active in ui/timeline.rs), soloing
+        // the video track must also silence the non-soloed audio track, even
+        // though avio's native is_active() scopes solo per track list.
+        let state = state::TimelineState {
+            tracks: vec![
+                state::Track {
+                    kind: state::TrackKind::Video,
+                    clips: Vec::new(),
+                    muted: false,
+                    soloed: true,
+                },
+                state::Track {
+                    kind: state::TrackKind::Audio,
+                    clips: Vec::new(),
+                    muted: false,
+                    soloed: false,
+                },
+            ],
+            pixels_per_second: 1.0,
+            title_clips: Vec::new(),
+        };
+
+        let timeline = to_avio(&state, &[], Some((1920, 1080)), false).expect("builds");
+
+        let video = &timeline.video_tracks()[0];
+        assert!(video.enabled); // soloed -> active under global solo
+        assert!(video.solo);
+        assert!(!video.mute);
+
+        let audio = &timeline.audio_tracks()[0];
+        assert!(!audio.enabled); // global solo elsewhere -> silenced
+        assert!(!audio.solo);
+        assert!(!audio.mute);
     }
 }

--- a/src/timeline_bridge.rs
+++ b/src/timeline_bridge.rs
@@ -1,0 +1,180 @@
+//! Bridges the demo's `TimelineState` to `avio::Timeline`.
+//!
+//! Each `avio::Clip` carries its source `TimelineClip` as a JSON blob in
+//! `clip.metadata` (see [`store_demo_clip`] / [`load_demo_clip`]), and tracks
+//! use avio-native `mute`/`solo` flags so muted-track clips stay in the model
+//! instead of being dropped before reaching avio.
+//!
+//! Not yet wired into any preview/export/edit path — that is a later phase.
+
+use crate::{export, state};
+
+#[allow(dead_code)]
+pub(crate) const DEMO_CLIP_KEY: &str = "avio_editor_demo_clip";
+
+/// Serializes `tc` into `clip.metadata` under [`DEMO_CLIP_KEY`].
+///
+/// Serialization of a plain data struct cannot fail in practice;
+/// `unwrap_or_default()` avoids a panic and yields an empty string, which
+/// `load_demo_clip` treats as absent.
+#[allow(dead_code)]
+pub(crate) fn store_demo_clip(clip: &mut avio::Clip, tc: &state::TimelineClip) {
+    clip.metadata.insert(
+        DEMO_CLIP_KEY.to_string(),
+        serde_json::to_string(tc).unwrap_or_default(),
+    );
+}
+
+/// Reconstructs the source `TimelineClip` from `clip.metadata`, overriding its
+/// structural fields (`start_on_track`/`in_point`/`out_point`) with the avio
+/// clip's own first-class `offset`/`in_point`/`out_point` — those are
+/// authoritative once the clip has been built into a timeline.
+///
+/// Returns `None` when the metadata is missing, empty, or fails to parse
+/// (logging a warning in the parse-error case).
+#[allow(dead_code)]
+pub(crate) fn load_demo_clip(clip: &avio::Clip) -> Option<state::TimelineClip> {
+    let raw = clip.metadata.get(DEMO_CLIP_KEY)?;
+    if raw.is_empty() {
+        return None;
+    }
+    match serde_json::from_str::<state::TimelineClip>(raw) {
+        Ok(mut tc) => {
+            tc.start_on_track = clip.offset;
+            tc.in_point = clip.in_point;
+            tc.out_point = clip.out_point;
+            Some(tc)
+        }
+        Err(e) => {
+            log::warn!("load_demo_clip: parse failed: {e}");
+            None
+        }
+    }
+}
+
+/// Builds an `avio::Timeline` from the demo's `TimelineState`, carrying each
+/// source `TimelineClip` as metadata JSON on the resulting `avio::Clip` and
+/// using avio-native `Track` mute/solo flags (so muted tracks keep their
+/// clips in the model; avio's `is_active()` excludes them from render).
+#[allow(dead_code)]
+pub(crate) fn to_avio(
+    timeline: &state::TimelineState,
+    pool: &[state::ImportedClip],
+    canvas: Option<(u32, u32)>,
+    use_proxy: bool,
+) -> avio::Timeline {
+    let mut builder = avio::Timeline::builder();
+    if let Some((w, h)) = canvas {
+        builder = builder.canvas(w, h);
+    }
+    for tr in &timeline.tracks {
+        // Build avio::Clips for this track, carrying each source TimelineClip as JSON.
+        let mut avio_clips: Vec<avio::Clip> = Vec::new();
+        for tc in &tr.clips {
+            let Some(ec) = export::timeline_clip_to_export_clip(tc, pool, use_proxy) else {
+                continue; // unresolved source — skipped, as the export path does
+            };
+            // Reuse the exact per-clip avio build (effect chain), then attach metadata.
+            let mut built = export::clips_to_avio(vec![ec], canvas);
+            if let Some(mut c) = built.pop() {
+                store_demo_clip(&mut c, tc);
+                avio_clips.push(c);
+            }
+        }
+        // Native avio Track with the demo's mute/solo — clips stay in the model,
+        // avio's is_active() excludes muted/non-soloed tracks from render.
+        let track = avio::Track::new(avio_clips)
+            .muted(tr.muted)
+            .soloed(tr.soloed);
+        builder = match tr.kind {
+            state::TrackKind::Video => builder.video_track_with(track),
+            state::TrackKind::Audio => builder.audio_track_with(track),
+        };
+    }
+    // `build()` errors only when both track lists are empty (`timeline.tracks`
+    // itself was empty) or when probing a first clip's source file fails.
+    // Neither applies to the fallback below: an empty video track makes
+    // `video_tracks` non-empty (skipping the `NoInput` check) and has no clip
+    // to probe, so canvas/frame-rate resolution falls through to its default
+    // (1920x1080@30) — that `build()` call cannot fail. The retry loop is a
+    // non-panicking safety net in case that invariant ever changes upstream;
+    // it is expected to run its body exactly once.
+    builder.build().unwrap_or_else(|e| {
+        log::warn!("to_avio: build failed ({e}); returning empty timeline");
+        loop {
+            match avio::Timeline::builder().video_track(Vec::new()).build() {
+                Ok(t) => break t,
+                Err(e2) => log::error!("to_avio: fallback build failed ({e2}); retrying"),
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn store_load_round_trips_and_overrides_structural_from_first_class() {
+        let mut tc = state::TimelineClip {
+            source_index: 3,
+            start_on_track: Duration::from_secs(2),
+            in_point: Some(Duration::from_secs(1)),
+            out_point: Some(Duration::from_secs(5)),
+            transition: Some(avio::XfadeTransition::Dissolve),
+            transition_duration: Duration::from_millis(500),
+            gain_db: 0.0,
+            fade_in: Duration::ZERO,
+            fade_out: Duration::ZERO,
+            brightness: 0.0,
+            contrast: 1.0,
+            saturation: 1.0,
+            speed: 1.5,
+            reverse: false,
+            freeze: None,
+            opacity: 1.0,
+            blend_mode: avio::BlendMode::Multiply,
+            position_x: 0.0,
+            position_y: 0.0,
+            scale_pct: 100.0,
+            lut_path: None,
+            wb_temperature: 5000,
+            wb_tint: 0.0,
+            hue_degrees: 0.0,
+            gamma_r: 1.0,
+            gamma_g: 1.0,
+            gamma_b: 1.0,
+            vignette: 0.4,
+            vignette_x: 50.0,
+            vignette_y: 50.0,
+            curves: state::ToneCurves::default(),
+            wheels: state::ColorWheels::default(),
+            video_effects: state::VideoEffects::default(),
+            transform: state::Transform::default(),
+            overlay: state::Overlay::default(),
+            subtitle: state::Subtitle::default(),
+            keying: state::Keying::default(),
+            mask: state::Mask {
+                shape: state::MaskShape::Rectangle,
+                ..state::Mask::default()
+            },
+            animation: state::ClipAnimation::default(),
+        };
+        let mut clip = avio::Clip::new("x.mp4");
+        // Simulate the built avio clip's authoritative structural fields:
+        clip.offset = Duration::from_secs(9);
+        clip.in_point = Some(Duration::from_secs(1));
+        clip.out_point = Some(Duration::from_secs(4));
+        store_demo_clip(&mut clip, &tc);
+        let back = load_demo_clip(&clip).expect("some");
+        // Structural fields come from the avio clip, not the JSON's originals:
+        tc.start_on_track = Duration::from_secs(9);
+        tc.in_point = Some(Duration::from_secs(1));
+        tc.out_point = Some(Duration::from_secs(4));
+        // TimelineClip has no Debug impl, so assert_eq!'s failure-message
+        // formatting isn't available here; assert! still exercises the same
+        // PartialEq round-trip check.
+        assert!(back == tc);
+    }
+}

--- a/src/timeline_bridge.rs
+++ b/src/timeline_bridge.rs
@@ -98,6 +98,32 @@ pub(crate) fn to_avio(
     builder.build()
 }
 
+/// Reconstructs `TimelineState.tracks` from an `avio::Timeline`: video tracks
+/// first, then audio (matching the demo's flat-vec convention), carrying each
+/// track's native `mute`/`solo` flags and reconstructing its clips via
+/// [`load_demo_clip`] (clips with missing/unparseable metadata are dropped).
+#[allow(dead_code)]
+pub(crate) fn from_avio(timeline: &avio::Timeline) -> Vec<state::Track> {
+    let mut tracks = Vec::new();
+    for t in timeline.video_tracks() {
+        tracks.push(state::Track {
+            kind: state::TrackKind::Video,
+            muted: t.mute,
+            soloed: t.solo,
+            clips: t.clips.iter().filter_map(load_demo_clip).collect(),
+        });
+    }
+    for t in timeline.audio_tracks() {
+        tracks.push(state::Track {
+            kind: state::TrackKind::Audio,
+            muted: t.mute,
+            soloed: t.solo,
+            clips: t.clips.iter().filter_map(load_demo_clip).collect(),
+        });
+    }
+    tracks
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,5 +190,100 @@ mod tests {
         // formatting isn't available here; assert! still exercises the same
         // PartialEq round-trip check.
         assert!(back == tc);
+    }
+
+    /// A neutral `TimelineClip` at `source_index`/`start`, used as a baseline
+    /// for the round-trip test below (individual fields are overridden per
+    /// clip to prove non-default values survive too).
+    fn neutral_clip(source_index: usize, start: Duration) -> state::TimelineClip {
+        state::TimelineClip {
+            source_index,
+            start_on_track: start,
+            in_point: None,
+            out_point: None,
+            transition: None,
+            transition_duration: Duration::ZERO,
+            gain_db: 0.0,
+            fade_in: Duration::ZERO,
+            fade_out: Duration::ZERO,
+            brightness: 0.0,
+            contrast: 1.0,
+            saturation: 1.0,
+            speed: 1.0,
+            reverse: false,
+            freeze: None,
+            opacity: 1.0,
+            blend_mode: avio::BlendMode::Normal,
+            position_x: 0.0,
+            position_y: 0.0,
+            scale_pct: 100.0,
+            lut_path: None,
+            wb_temperature: 0,
+            wb_tint: 0.0,
+            hue_degrees: 0.0,
+            gamma_r: 1.0,
+            gamma_g: 1.0,
+            gamma_b: 1.0,
+            vignette: 0.0,
+            vignette_x: 50.0,
+            vignette_y: 50.0,
+            curves: state::ToneCurves::default(),
+            wheels: state::ColorWheels::default(),
+            video_effects: state::VideoEffects::default(),
+            transform: state::Transform::default(),
+            overlay: state::Overlay::default(),
+            subtitle: state::Subtitle::default(),
+            keying: state::Keying::default(),
+            mask: state::Mask::default(),
+            animation: state::ClipAnimation::default(),
+        }
+    }
+
+    #[test]
+    fn from_avio_round_trips_tracks_clips_and_mute_solo() {
+        // helper: an avio clip carrying tc, with authoritative structural fields
+        fn carried(tc: &state::TimelineClip) -> avio::Clip {
+            let mut c = avio::Clip::new("x.mp4").offset(tc.start_on_track);
+            c.in_point = tc.in_point;
+            c.out_point = tc.out_point;
+            store_demo_clip(&mut c, tc);
+            c
+        }
+        let v0 = neutral_clip(0, Duration::ZERO);
+        let mut v1 = neutral_clip(1, Duration::from_secs(5));
+        v1.in_point = Some(Duration::from_secs(1));
+        v1.out_point = Some(Duration::from_secs(4));
+        v1.wb_temperature = 5000;
+        v1.transform = state::Transform {
+            rotation: 45.0,
+            ..state::Transform::default()
+        };
+        v1.mask = state::Mask {
+            shape: state::MaskShape::Rectangle,
+            ..state::Mask::default()
+        };
+        let a0 = neutral_clip(2, Duration::from_secs(1));
+
+        let timeline = avio::Timeline::builder()
+            // Explicit canvas/fps avoid probing "x.mp4" (which doesn't exist on disk).
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track_with(avio::Track::new(vec![carried(&v0)]))
+            .video_track_with(avio::Track::new(vec![carried(&v1)]).muted(true))
+            .audio_track_with(avio::Track::new(vec![carried(&a0)]).soloed(true))
+            .build()
+            .expect("builds");
+
+        let tracks = from_avio(&timeline);
+        assert!(tracks.len() == 3);
+        assert!(tracks[0].kind == state::TrackKind::Video);
+        assert!(!tracks[0].muted);
+        assert!(tracks[0].clips == vec![v0]);
+        assert!(tracks[1].kind == state::TrackKind::Video);
+        assert!(tracks[1].muted); // muted track's clip survived reconstruction
+        assert!(tracks[1].clips == vec![v1]);
+        assert!(tracks[2].kind == state::TrackKind::Audio);
+        assert!(tracks[2].soloed);
+        assert!(tracks[2].clips == vec![a0]);
     }
 }

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -1279,58 +1279,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                 let clips = &state.clips;
                 let use_proxies = state.export_use_proxies;
                 let make_clip = |tc: &state::TimelineClip| {
-                    let src = &clips[tc.source_index];
-                    export::ExportClip {
-                        path: src.path.clone(),
-                        start_on_track: tc.start_on_track,
-                        in_point: tc.in_point,
-                        out_point: tc.out_point,
-                        transition: tc.transition,
-                        transition_duration: tc.transition_duration,
-                        source_duration: src.info.duration(),
-                        fps: src.info.frame_rate().unwrap_or(30.0),
-                        has_audio: src.info.primary_audio().is_some(),
-                        gain_db: tc.gain_db,
-                        fade_in: tc.fade_in,
-                        fade_out: tc.fade_out,
-                        brightness: tc.brightness,
-                        contrast: tc.contrast,
-                        saturation: tc.saturation,
-                        speed: tc.speed,
-                        reverse: tc.reverse,
-                        freeze: tc.freeze,
-                        opacity: tc.opacity,
-                        blend_mode: tc.blend_mode,
-                        position_x: tc.position_x,
-                        position_y: tc.position_y,
-                        scale_pct: tc.scale_pct,
-                        proxy_path: if use_proxies {
-                            src.proxy_path.clone()
-                        } else {
-                            None
-                        },
-                        lut_path: tc.lut_path.clone(),
-                        wb_temperature: tc.wb_temperature,
-                        wb_tint: tc.wb_tint,
-                        hue_degrees: tc.hue_degrees,
-                        gamma_r: tc.gamma_r,
-                        gamma_g: tc.gamma_g,
-                        gamma_b: tc.gamma_b,
-                        vignette: tc.vignette,
-                        vignette_x: tc.vignette_x,
-                        vignette_y: tc.vignette_y,
-                        width: src.info.primary_video().map(|v| v.width()).unwrap_or(0),
-                        height: src.info.primary_video().map(|v| v.height()).unwrap_or(0),
-                        curves: tc.curves.clone(),
-                        wheels: tc.wheels,
-                        video_effects: tc.video_effects,
-                        transform: tc.transform,
-                        overlay: tc.overlay.clone(),
-                        subtitle: tc.subtitle.clone(),
-                        keying: tc.keying,
-                        mask: tc.mask.clone(),
-                        animation: tc.animation.clone(),
-                    }
+                    export::timeline_clip_to_export_clip(tc, clips, use_proxies)
                 };
                 let tracks = &state.timeline.tracks;
                 let audio_start = state.timeline.audio_track_start();
@@ -1338,7 +1287,7 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                     video_clips: (0..audio_start)
                         .map(|ti| {
                             if track_is_active(tracks, ti) {
-                                tracks[ti].clips.iter().map(make_clip).collect()
+                                tracks[ti].clips.iter().filter_map(make_clip).collect()
                             } else {
                                 vec![]
                             }
@@ -1346,7 +1295,11 @@ pub fn show(state: &mut state::AppState, ui: &mut egui::Ui) {
                         .collect(),
                     a1_clips: if audio_start < tracks.len() && track_is_active(tracks, audio_start)
                     {
-                        tracks[audio_start].clips.iter().map(make_clip).collect()
+                        tracks[audio_start]
+                            .clips
+                            .iter()
+                            .filter_map(make_clip)
+                            .collect()
                     } else {
                         vec![]
                     },


### PR DESCRIPTION
## Summary

P2 of adopting the avio 0.17 edit model: a **lossless** `TimelineState` ⇄ `avio::Timeline` bridge (dormant — not wired into preview/export/edit until P3). It fixes the two losses in the naive `avio::Timeline → TimelineState` inverse so a later phase can make `avio::Editor` the structural-edit truth and rebuild `TimelineState` from `editor.current()` without losing per-clip params or muted-track content. Behavior-identical — no preview/export/edit/undo change in this phase.

## Changes

- Extract `timeline_clip_to_export_clip` (behavior-identical refactor of the inline export mapping) + widen `clips_to_avio`/`ExportClip` to `pub(crate)`.
- Derive `serde` on `TimelineClip` (avio's `XfadeTransition`/`BlendMode` already serialize under avio's `serde` feature).
- New `src/timeline_bridge.rs` (dead-code until P3):
  - **Rich-param loss fixed** — each `avio::Clip` carries its source `TimelineClip` as a JSON blob in `clip.metadata`; reconstruction reads the structural/first-class fields (`offset`/`in`/`out` + `transition`/`transition_duration`/`fade_in`/`fade_out`, the ones avio's structural `Command`s mutate) from the avio clip and every other field from the JSON.
  - **Muted-track loss fixed** — tracks build as avio-native `Track` with mute/solo flags (`video_track_with`/`audio_track_with`), keeping every clip in the model; the demo's global-solo semantics are mapped onto `Track.enabled` so render matches the demo's `track_is_active`.
  - `to_avio` returns `Result`; `from_avio` reconstructs `Vec<Track>`. Round-trip property tests prove a muted track's clip survives and non-neutral rich params round-trip.

## Related Issues

Internal migration step (P2 of the avio 0.17 edit-model adoption); no tracking issue. Known residual deferred to P3: the `muted`+`soloed`-simultaneously corner (demo solo-overrides-mute vs avio mute-overrides-solo).

## Test Plan

- [x] `cargo test` passes (46/46)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes